### PR TITLE
[concatenate] fix bad state sync on edition

### DIFF
--- a/src/components/stepforms/ColumnPicker.vue
+++ b/src/components/stepforms/ColumnPicker.vue
@@ -31,14 +31,14 @@ export default class ColumnPicker extends Vue {
   @Prop({ type: String, default: 'Enter a column' })
   placeholder!: string;
 
-  @Prop({ type: String, default: null })
-  initialColumn!: string | null;
-
   @Prop({ type: Array, default: () => [] })
   errors!: ErrorObject[];
 
   @Prop({ default: null })
   dataPath!: string;
+
+  @Prop({ default: null })
+  value!: string;
 
   // Whether the column data of ColumnPicker should react to a change of
   // selected column
@@ -53,14 +53,13 @@ export default class ColumnPicker extends Vue {
   @VQBModule.Getter columnNames!: string[];
 
   created() {
-    if (this.initialColumn === null) {
+    if (this.value) {
+      this.column = this.value;
+    } else {
       const selected = this.selectedColumns;
       if (selected.length) {
         this.column = selected[0];
       }
-    } else {
-      this.column = this.initialColumn;
-      this.setSelectedColumns({ column: this.initialColumn });
     }
   }
 

--- a/tests/unit/column-picker.spec.ts
+++ b/tests/unit/column-picker.spec.ts
@@ -35,7 +35,7 @@ describe('Column Picker', () => {
     expect(selectWrapper.attributes('options')).toEqual('columnA,columnB,columnC');
   });
 
-  it('should set column when initialColumn is set', () => {
+  it('should set column when initial column value is set', () => {
     const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
@@ -46,7 +46,7 @@ describe('Column Picker', () => {
       store,
       localVue,
       propsData: {
-        initialColumn: 'columnA',
+        value: 'columnA',
       },
     });
     expect(wrapper.vm.$data.column).toEqual('columnA');

--- a/tests/unit/concatenate-step-form.spec.ts
+++ b/tests/unit/concatenate-step-form.spec.ts
@@ -3,6 +3,7 @@ import ConcatenateStepForm from '@/components/stepforms/ConcatenateStepForm.vue'
 import Vuex, { Store } from 'vuex';
 import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
+import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -131,4 +132,34 @@ describe('Concatenate Step Form', () => {
     wrapper.find('.widget-form-action__button--cancel').trigger('click');
     expect(store.state.vqb.selectedStepIndex).toEqual(3);
   });
+
+  it('should not sync selected columns on edition', async () => {
+    const store = setupMockStore({
+      selectedStepIndex: 1,
+      selectedColumns: ['spam'],
+    });
+    const wrapper = mount(ConcatenateStepForm, {
+      store,
+      localVue,
+      propsData: {
+        initialStepValue: {
+          name: 'concatenate',
+          columns: ['foo', 'bar'],
+          separator: '-',
+          new_column_name: 'baz',
+        },
+        isStepCreation: false,
+      },
+    });
+    await localVue.nextTick();
+    expect(store.state.vqb.selectedStepIndex).toEqual(1);
+    const columnPickers = wrapper.findAll(ColumnPicker);
+    expect(columnPickers.length).toEqual(2);
+    const [picker1, picker2] = columnPickers.wrappers;
+    expect(picker1.props('value')).toEqual('foo');
+    expect(picker1.vm.$data.column).toEqual('foo');
+    expect(picker2.props('value')).toEqual('bar');
+    expect(picker2.vm.$data.column).toEqual('bar');
+  });
+
 });


### PR DESCRIPTION
Before this commit, when a concatenate step was edited, its "column"
fields were reset with the current selected column in the dataset
viewer.

This was because the `value` property sent by the `List` component to
the `ColumnPicker` which contains the edited step's column names was not
taken into account by the `ColumnPicker`. Instead, it was introspecting
an `initialColumn` property that was never passed in this case and
actually never used elsewhere…

This commit gets rid of the `initialColumn` property and uses `value`
instead.

Closes #366