### PR TITLE
Fix :: step forms validator built too soon with obsolete column names

### DIFF
--- a/src/components/stepforms/StepForm.vue
+++ b/src/components/stepforms/StepForm.vue
@@ -21,7 +21,7 @@ type VqbError = Partial<ErrorObject>;
 type ValidatorProxy = {
   (step: PipelineStep): boolean | PromiseLike<any>;
   errors?: ErrorObject[] | null;
-}
+};
 
 /**
  * build a proxy on a Vue component instance that will automatically
@@ -115,20 +115,6 @@ export default class BaseStepForm<StepType> extends Vue {
     if (column) {
       this.setSelectedColumns({ column });
     }
-    this.editedStepModel = schemaFactory(this.stepname, this);
-    const ajv = Ajv({ schemaId: 'auto', allErrors: true });
-    addAjvKeywords(ajv);
-    const ajvValidator = ajv.compile(this.editedStepModel);
-    const interpolator = new PipelineInterpolator(
-      this.interpolateFunc,
-      this.variables);
-
-    const interpolateAndValidate: ValidatorProxy = function(step: PipelineStep) {
-      const ret = ajvValidator(interpolator.interpolateStep(step));
-      interpolateAndValidate.errors = ajvValidator.errors;
-      return ret;
-    }
-    this.validator = interpolateAndValidate;
   }
 
   mounted() {
@@ -221,6 +207,17 @@ export default class BaseStepForm<StepType> extends Vue {
    * with the edited step.
    */
   submit() {
+    this.editedStepModel = schemaFactory(this.stepname, this);
+    const ajv = Ajv({ schemaId: 'auto', allErrors: true });
+    addAjvKeywords(ajv);
+    const ajvValidator = ajv.compile(this.editedStepModel);
+    const interpolator = new PipelineInterpolator(this.interpolateFunc, this.variables);
+    const interpolateAndValidate: ValidatorProxy = function(step: PipelineStep) {
+      const ret = ajvValidator(interpolator.interpolateStep(step));
+      interpolateAndValidate.errors = ajvValidator.errors;
+      return ret;
+    };
+    this.validator = interpolateAndValidate;
     const errors = this.validate();
     this.errors = errors;
     if (errors === null) {


### PR DESCRIPTION
Step form validator used to get built at component initialization. When editing a step, the _updateDataset runs to get the dataset resulting from executing the pipeline until the step just before the one being edited. But as this function is asynchronous, sometimes (quite frequently) the validator got built before the column names were updated, then yielding an unexpected "columnNameAlreadyUsed" error when trying to save a step again.

Example: use a duplicate step, name the new column "new", then edit the step, and just save it again. The quoted error would randomly occur.

This PR proposes to build the validator at submit to solve this issue.