### PR TITLE
[eslint] allow empty arrow functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "core-js": "3",
     "csvtojson": "^2.0.8",
     "eslint": "^5.8.0",
+    "eslint-import-resolver-alias": "^1.1.2",
+    "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^22.13.0",
     "eslint-plugin-vue": "^5.0.0",
     "express": "^4.16.4",
@@ -112,14 +114,38 @@
     },
     "extends": [
       "plugin:@typescript-eslint/recommended",
+      "plugin:import/errors",
+      "plugin:import/warnings",
+      "plugin:import/typescript",
       "plugin:vue/essential",
       "eslint:recommended",
       "@vue/typescript"
     ],
+    "plugins": [
+      "import"
+    ],
+    "settings": {
+      "import/internal-regex": "^@/",
+      "import/resolver": {
+        "alias": {
+          "map": [
+            ["@", "./src"]
+          ],
+          "extensions": [".ts", ".js", ".vue", ".d.ts"]
+        }
+      }
+    },
     "rules": {
       "@typescript-eslint/explicit-function-return-type": "allow",
       "@typescript-eslint/no-explicit-any": "allow",
-      "@typescript-eslint/no-empty-function": ["error", { "allow": ["arrowFunctions"] }],
+      "@typescript-eslint/no-empty-function": [
+        "error",
+        {
+          "allow": [
+            "arrowFunctions"
+          ]
+        }
+      ],
       "@typescript-eslint/explicit-member-accessibility": "no-public",
       "@typescript-eslint/indent": [
         "error",

--- a/package.json
+++ b/package.json
@@ -129,9 +129,17 @@
       "import/resolver": {
         "alias": {
           "map": [
-            ["@", "./src"]
+            [
+              "@",
+              "./src"
+            ]
           ],
-          "extensions": [".ts", ".js", ".vue", ".d.ts"]
+          "extensions": [
+            ".ts",
+            ".js",
+            ".vue",
+            ".d.ts"
+          ]
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.5.1",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
-    "url" : "https://github.com/ToucanToco/weaverbird/issues",
-    "email" : "dev+vqb@toucantoco.com"
+    "url": "https://github.com/ToucanToco/weaverbird/issues",
+    "email": "dev+vqb@toucantoco.com"
   },
   "keywords": [
     "typescript",
@@ -42,8 +42,8 @@
     "@types/mocha": "^5.2.7",
     "@types/mongodb": "^3.1.25",
     "@types/tmp": "^0.1.0",
-    "@typescript-eslint/eslint-plugin": "^2.6.1",
-    "@typescript-eslint/parser": "^2.6.1",
+    "@typescript-eslint/eslint-plugin": "^2.10.0",
+    "@typescript-eslint/parser": "^2.10.0",
     "@vue/eslint-config-typescript": "^3.2.0",
     "@vue/test-utils": "^1.0.0-beta.29",
     "babel-core": "^7.0.0-bridge.0",
@@ -119,6 +119,7 @@
     "rules": {
       "@typescript-eslint/explicit-function-return-type": "allow",
       "@typescript-eslint/no-explicit-any": "allow",
+      "@typescript-eslint/no-empty-function": ["error", { "allow": ["arrowFunctions"] }],
       "@typescript-eslint/explicit-member-accessibility": "no-public",
       "@typescript-eslint/indent": [
         "error",

--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -14,12 +14,14 @@
   </popover>
 </template>
 <script lang="ts">
-import { VQBModule } from '@/store';
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+
+import { VQBModule } from '@/store';
 import { POPOVER_ALIGN } from '@/components/constants';
-import Popover from './Popover.vue';
 import { Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
 import { MutationCallbacks } from '@/store/mutations';
+
+import Popover from './Popover.vue';
 
 @Component({
   name: 'action-menu',

--- a/src/components/ActionToolbar.vue
+++ b/src/components/ActionToolbar.vue
@@ -19,11 +19,13 @@
 </template>
 <script lang="ts">
 import Vue from 'vue';
-import { VQBModule } from '@/store';
 import { Component, Prop } from 'vue-property-decorator';
+
+import { VQBModule } from '@/store';
+import { PipelineStepName } from '@/lib/steps';
+
 import ActionToolbarButton from './ActionToolbarButton.vue';
 import { ButtonDef } from './constants';
-import { PipelineStepName } from '@/lib/steps';
 import SearchBar from './SearchBar.vue';
 
 @Component({

--- a/src/components/ActionToolbarButton.vue
+++ b/src/components/ActionToolbarButton.vue
@@ -19,11 +19,13 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import { Component, Prop, Watch } from 'vue-property-decorator';
+
 import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
-import { Component, Prop, Watch } from 'vue-property-decorator';
 import * as S from '@/lib/steps';
 import { ACTION_CATEGORIES, POPOVER_ALIGN } from '@/components/constants';
+
 import Popover from './Popover.vue';
 
 /**

--- a/src/components/DataTypesMenu.vue
+++ b/src/components/DataTypesMenu.vue
@@ -31,12 +31,14 @@
   </popover>
 </template>
 <script lang="ts">
-import { VQBModule } from '@/store';
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+
+import { VQBModule } from '@/store';
 import { POPOVER_ALIGN } from '@/components/constants';
-import Popover from './Popover.vue';
 import { Pipeline, ConvertStep } from '@/lib/steps';
 import { MutationCallbacks } from '@/store/mutations';
+
+import Popover from './Popover.vue';
 
 type dataType = 'boolean' | 'date' | 'float' | 'integer' | 'text';
 

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -51,16 +51,18 @@
 </template>
 <script lang="ts">
 import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+
 import { VQBModule } from '@/store';
 import { DataSet, DataSetColumn, DataSetColumnType } from '@/lib/dataset';
 import { PipelineStepName } from '@/lib/steps';
 import { getTranslator } from '@/lib/translators';
-import { Component } from 'vue-property-decorator';
+import Pagination from '@/components/Pagination.vue';
+
 import ActionMenu from './ActionMenu.vue';
 import ActionToolbar from './ActionToolbar.vue';
 import DataTypesMenu from './DataTypesMenu.vue';
 import DataViewerCell from './DataViewerCell.vue';
-import Pagination from '@/components/Pagination.vue';
 import { CATEGORY_BUTTONS } from './constants';
 
 /**

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -16,9 +16,10 @@
 </template>
 
 <script lang="ts">
-import { VQBModule } from '@/store';
 import Paginate from 'vuejs-paginate';
 import { Vue, Component } from 'vue-property-decorator';
+
+import { VQBModule } from '@/store';
 import { DataSet } from '@/lib/dataset';
 import { numberOfPages, pageMinMax } from '@/lib/dataset/pagination';
 import { MutationCallbacks } from '@/store/mutations';

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -25,10 +25,12 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { VQBModule } from '@/store';
 import { Component } from 'vue-property-decorator';
+
+import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
 import { DomainStep, Pipeline, PipelineStep } from '@/lib/steps';
+
 import Step from './Step.vue';
 
 @Component({

--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -7,6 +7,7 @@
 import _ from 'lodash';
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
+
 import { Alignment } from '@/components/constants';
 import * as DOMUtil from '@/components/domutil';
 

--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -18,10 +18,12 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
+
 import { VQBModule } from '@/store';
 import { VQBState } from '@/store/state';
 import { Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
 import PipelineComponent from '@/components/Pipeline.vue';
+
 import '@/components/stepforms'; // required to load all step forms
 import { STEPFORM_REGISTRY } from './formlib';
 

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -15,11 +15,14 @@
 </template>
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { SEARCH_ACTION } from './constants';
 import Multiselect from 'vue-multiselect';
-import { VQBModule } from '../store';
+
 import { getTranslator } from '@/lib/translators';
+
+import { VQBModule } from '../store';
 import { PipelineStepName } from '../lib/steps';
+
+import { SEARCH_ACTION } from './constants';
 
 @Component({
   name: 'search-bar',

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -32,11 +32,13 @@
 </template>
 <script lang="ts">
 import Vue from 'vue';
-import { VQBModule } from '@/store';
 import { Component, Prop } from 'vue-property-decorator';
+
+import { VQBModule } from '@/store';
 import { PipelineStep } from '@/lib/steps';
 import { MutationCallbacks } from '@/store/mutations';
 import { humanReadableLabel } from '@/lib/labeller';
+
 import DeleteConfirmationModal from './DeleteConfirmationModal.vue';
 
 @Component({

--- a/src/components/Vqb.vue
+++ b/src/components/Vqb.vue
@@ -10,6 +10,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
+
 import DataViewer from '@/components/DataViewer.vue';
 import QueryBuilder from '@/components/QueryBuilder.vue';
 import ResizablePanels from '@/components/ResizablePanels.vue';

--- a/src/components/formlib.ts
+++ b/src/components/formlib.ts
@@ -4,6 +4,7 @@
 import _ from 'lodash';
 import Vue, { VueConstructor } from 'vue';
 import { Component } from 'vue-property-decorator';
+
 import { PipelineStepName } from '@/lib/steps';
 
 export type StepMapper = { [K in PipelineStepName]?: VueConstructor<Vue> };

--- a/src/components/stepforms/AddTextColumnStepForm.vue
+++ b/src/components/stepforms/AddTextColumnStepForm.vue
@@ -24,10 +24,12 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
-import BaseStepForm from './StepForm.vue';
 import { AddTextColumnStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'text',

--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -28,12 +28,14 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { AggFunctionStep, AggregationStep } from '@/lib/steps';
+import { StepFormComponent } from '@/components/formlib';
+
 import AggregationWidget from './widgets/Aggregation.vue';
 import MultiselectWidget from './widgets/Multiselect.vue';
 import ListWidget from './widgets/List.vue';
 import BaseStepForm from './StepForm.vue';
-import { StepFormComponent } from '@/components/formlib';
 
 @StepFormComponent({
   vqbstep: 'aggregate',

--- a/src/components/stepforms/AppendStepForm.vue
+++ b/src/components/stepforms/AppendStepForm.vue
@@ -16,11 +16,13 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { AppendStep , Pipeline } from '@/lib/steps';
-import MultiselectWidget from './widgets/Multiselect.vue';
-import BaseStepForm from './StepForm.vue';
 import { StepFormComponent } from '@/components/formlib';
 import { VQBModule } from '@/store';
+
+import MultiselectWidget from './widgets/Multiselect.vue';
+import BaseStepForm from './StepForm.vue';
 
 
 @StepFormComponent({

--- a/src/components/stepforms/AppendStepForm.vue
+++ b/src/components/stepforms/AppendStepForm.vue
@@ -16,12 +16,12 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
-import { AppendStep } from '@/lib/steps';
+import { AppendStep , Pipeline } from '@/lib/steps';
 import MultiselectWidget from './widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
 import { StepFormComponent } from '@/components/formlib';
 import { VQBModule } from '@/store';
-import { Pipeline } from '@/lib/steps';
+
 
 @StepFormComponent({
   vqbstep: 'append',

--- a/src/components/stepforms/ArgmaxStepForm.vue
+++ b/src/components/stepforms/ArgmaxStepForm.vue
@@ -24,11 +24,13 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { ArgmaxStep } from '@/lib/steps';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
+import { StepFormComponent } from '@/components/formlib';
+
 import MultiselectWidget from './widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
-import { StepFormComponent } from '@/components/formlib';
 
 @StepFormComponent({
   vqbstep: 'argmax',

--- a/src/components/stepforms/ArgminStepForm.vue
+++ b/src/components/stepforms/ArgminStepForm.vue
@@ -24,11 +24,13 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { ArgminStep } from '@/lib/steps';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
+import { StepFormComponent } from '@/components/formlib';
+
 import MultiselectWidget from './widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
-import { StepFormComponent } from '@/components/formlib';
 
 @StepFormComponent({
   vqbstep: 'argmin',

--- a/src/components/stepforms/ColumnPicker.vue
+++ b/src/components/stepforms/ColumnPicker.vue
@@ -13,12 +13,14 @@
 
 <script lang="ts">
 import _ from 'lodash';
-import { VQBModule } from '@/store';
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
+import { ErrorObject } from 'ajv';
+
+import { VQBModule } from '@/store';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import { MutationCallbacks } from '@/store/mutations';
-import { ErrorObject } from 'ajv';
+
 
 @Component({ components: { AutocompleteWidget } })
 export default class ColumnPicker extends Vue {

--- a/src/components/stepforms/ConcatenateStepForm.vue
+++ b/src/components/stepforms/ConcatenateStepForm.vue
@@ -35,12 +35,14 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import ListWidget from '@/components/stepforms/widgets/List.vue';
-import BaseStepForm from './StepForm.vue';
 import { ConcatenateStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'concatenate',

--- a/src/components/stepforms/ConvertStepForm.vue
+++ b/src/components/stepforms/ConvertStepForm.vue
@@ -26,11 +26,13 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
-import BaseStepForm from './StepForm.vue';
 import { ConvertStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'convert',

--- a/src/components/stepforms/DeleteColumnStepForm.vue
+++ b/src/components/stepforms/DeleteColumnStepForm.vue
@@ -17,10 +17,12 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
-import BaseStepForm from './StepForm.vue';
 import { DeleteStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'delete',

--- a/src/components/stepforms/DomainStepForm.vue
+++ b/src/components/stepforms/DomainStepForm.vue
@@ -13,12 +13,14 @@
 </template>
 
 <script lang="ts">
-import { VQBModule } from '@/store';
 import { Prop } from 'vue-property-decorator';
+
+import { VQBModule } from '@/store';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import { StepFormComponent } from '@/components/formlib';
-import BaseStepForm from './StepForm.vue';
 import { DomainStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'domain',

--- a/src/components/stepforms/DuplicateColumnStepForm.vue
+++ b/src/components/stepforms/DuplicateColumnStepForm.vue
@@ -23,11 +23,13 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
-import BaseStepForm from './StepForm.vue';
 import { DuplicateColumnStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'duplicate',

--- a/src/components/stepforms/FillnaStepForm.vue
+++ b/src/components/stepforms/FillnaStepForm.vue
@@ -22,15 +22,17 @@
 </template>
 
 <script lang="ts">
-import { VQBModule } from '@/store';
 import { Prop } from 'vue-property-decorator';
+
+import { VQBModule } from '@/store';
 import { StepFormComponent } from '@/components/formlib';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import BaseStepForm from './StepForm.vue';
 import { FillnaStep } from '@/lib/steps';
 import { ColumnTypeMapping } from '@/lib/dataset';
 import { castFromString } from '@/lib/helpers';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'fillna',

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -21,16 +21,17 @@
 </template>
 
 <script lang="ts">
-import { VQBModule } from '@/store';
 import { Prop } from 'vue-property-decorator';
+
+import { VQBModule } from '@/store';
 import { StepFormComponent } from '@/components/formlib';
 import FilterSimpleConditionWidget from '@/components/stepforms/widgets/FilterSimpleCondition.vue';
-import ListWidget from './widgets/List.vue';
-import BaseStepForm from './StepForm.vue';
 import { FilterStep, FilterComboAnd, isFilterComboAnd , FilterSimpleCondition } from '@/lib/steps';
-
 import { ColumnTypeMapping } from '@/lib/dataset';
 import { castFromString } from '@/lib/helpers';
+
+import BaseStepForm from './StepForm.vue';
+import ListWidget from './widgets/List.vue';
 
 @StepFormComponent({
   vqbstep: 'filter',

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -27,8 +27,8 @@ import { StepFormComponent } from '@/components/formlib';
 import FilterSimpleConditionWidget from '@/components/stepforms/widgets/FilterSimpleCondition.vue';
 import ListWidget from './widgets/List.vue';
 import BaseStepForm from './StepForm.vue';
-import { FilterStep, FilterComboAnd, isFilterComboAnd } from '@/lib/steps';
-import { FilterSimpleCondition } from '@/lib/steps';
+import { FilterStep, FilterComboAnd, isFilterComboAnd , FilterSimpleCondition } from '@/lib/steps';
+
 import { ColumnTypeMapping } from '@/lib/dataset';
 import { castFromString } from '@/lib/helpers';
 

--- a/src/components/stepforms/FormulaStepForm.vue
+++ b/src/components/stepforms/FormulaStepForm.vue
@@ -24,12 +24,14 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
-import { StepFormComponent } from '@/components/formlib';
-import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
-import BaseStepForm from './StepForm.vue';
-import { FormulaStep } from '@/lib/steps';
 import { parse } from 'mathjs';
 import { ErrorObject } from 'ajv';
+
+import { StepFormComponent } from '@/components/formlib';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
+import { FormulaStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 type VqbError = Partial<ErrorObject>;
 

--- a/src/components/stepforms/FromDateStepForm.vue
+++ b/src/components/stepforms/FromDateStepForm.vue
@@ -24,11 +24,13 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
-import BaseStepForm from './StepForm.vue';
 import { FromDateStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'fromdate',

--- a/src/components/stepforms/JoinStepForm.vue
+++ b/src/components/stepforms/JoinStepForm.vue
@@ -37,7 +37,7 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
-import { JoinStep } from '@/lib/steps';
+import { JoinStep , Pipeline } from '@/lib/steps';
 import BaseStepForm from './StepForm.vue';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import ListWidget from '@/components/stepforms/widgets/List.vue';
@@ -45,7 +45,7 @@ import JoinColumns from '@/components/stepforms/widgets/JoinColumns.vue';
 import Multiselect from './widgets/Multiselect.vue';
 import { StepFormComponent } from '@/components/formlib';
 import { VQBModule } from '@/store';
-import { Pipeline } from '@/lib/steps';
+
 
 @StepFormComponent({
   vqbstep: 'join',

--- a/src/components/stepforms/PercentageStepForm.vue
+++ b/src/components/stepforms/PercentageStepForm.vue
@@ -24,11 +24,13 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { PercentageStep } from '@/lib/steps';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
+import { StepFormComponent } from '@/components/formlib';
+
 import MultiselectWidget from './widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
-import { StepFormComponent } from '@/components/formlib';
 
 @StepFormComponent({
   vqbstep: 'percentage',

--- a/src/components/stepforms/PivotStepForm.vue
+++ b/src/components/stepforms/PivotStepForm.vue
@@ -41,12 +41,14 @@
 </template>
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
-import BaseStepForm from './StepForm.vue';
 import { PivotStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'pivot',

--- a/src/components/stepforms/RenameStepForm.vue
+++ b/src/components/stepforms/RenameStepForm.vue
@@ -23,11 +23,13 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
-import BaseStepForm from './StepForm.vue';
 import { RenameStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'rename',

--- a/src/components/stepforms/ReplaceStepForm.vue
+++ b/src/components/stepforms/ReplaceStepForm.vue
@@ -25,16 +25,18 @@
 </template>
 
 <script lang="ts">
-import { VQBModule } from '@/store';
 import { Prop } from 'vue-property-decorator';
+
+import { VQBModule } from '@/store';
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import ListWidget from '@/components/stepforms/widgets/List.vue';
 import ReplaceWidget from '@/components/stepforms/widgets/Replace.vue';
-import BaseStepForm from './StepForm.vue';
 import { ReplaceStep } from '@/lib/steps';
 import { ColumnTypeMapping } from '@/lib/dataset';
 import { castFromString } from '@/lib/helpers';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'replace',

--- a/src/components/stepforms/SelectColumnStepForm.vue
+++ b/src/components/stepforms/SelectColumnStepForm.vue
@@ -17,10 +17,12 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
-import BaseStepForm from './StepForm.vue';
 import { SelectStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'select',

--- a/src/components/stepforms/SortStepForm.vue
+++ b/src/components/stepforms/SortStepForm.vue
@@ -19,11 +19,11 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
-import { SortStep } from '@/lib/steps';
+import { SortStep , SortColumnType } from '@/lib/steps';
 import BaseStepForm from './StepForm.vue';
 import { StepFormComponent } from '@/components/formlib';
 import ListWidget from './widgets/List.vue';
-import { SortColumnType } from '@/lib/steps';
+
 import SortColumnWidget from './widgets/SortColumn.vue';
 
 @StepFormComponent({

--- a/src/components/stepforms/SortStepForm.vue
+++ b/src/components/stepforms/SortStepForm.vue
@@ -19,11 +19,12 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
-import { SortStep , SortColumnType } from '@/lib/steps';
-import BaseStepForm from './StepForm.vue';
-import { StepFormComponent } from '@/components/formlib';
-import ListWidget from './widgets/List.vue';
 
+import { SortStep , SortColumnType } from '@/lib/steps';
+import { StepFormComponent } from '@/components/formlib';
+
+import BaseStepForm from './StepForm.vue';
+import ListWidget from './widgets/List.vue';
 import SortColumnWidget from './widgets/SortColumn.vue';
 
 @StepFormComponent({

--- a/src/components/stepforms/SplitStepForm.vue
+++ b/src/components/stepforms/SplitStepForm.vue
@@ -32,11 +32,13 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { SplitStep } from '@/lib/steps';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
-import BaseStepForm from './StepForm.vue';
 import { StepFormComponent } from '@/components/formlib';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'split',

--- a/src/components/stepforms/StepForm.vue
+++ b/src/components/stepforms/StepForm.vue
@@ -1,9 +1,10 @@
 <script lang="ts">
 import _ from 'lodash';
 import Vue from 'vue';
-import { VQBModule } from '@/store';
 import { Prop, Component, Watch } from 'vue-property-decorator';
 import Ajv, { ValidateFunction, ErrorObject } from 'ajv';
+
+import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
 import StepFormButtonbar from '@/components/stepforms/StepFormButtonbar.vue';
 import StepFormTitle from '@/components/stepforms/StepFormTitle.vue';

--- a/src/components/stepforms/SubstringStepForm.vue
+++ b/src/components/stepforms/SubstringStepForm.vue
@@ -33,11 +33,13 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { SubstringStep } from '@/lib/steps';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
-import BaseStepForm from './StepForm.vue';
 import { StepFormComponent } from '@/components/formlib';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'substring',

--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -16,10 +16,12 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import BaseStepForm from './StepForm.vue';
 import { ToDateStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'todate',

--- a/src/components/stepforms/ToLowerStepForm.vue
+++ b/src/components/stepforms/ToLowerStepForm.vue
@@ -15,10 +15,12 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import BaseStepForm from './StepForm.vue';
 import { ToLowerStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'lowercase',

--- a/src/components/stepforms/ToUpperStepForm.vue
+++ b/src/components/stepforms/ToUpperStepForm.vue
@@ -15,10 +15,12 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import BaseStepForm from './StepForm.vue';
 import { ToUpperStep } from '@/lib/steps';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'uppercase',

--- a/src/components/stepforms/TopStepForm.vue
+++ b/src/components/stepforms/TopStepForm.vue
@@ -44,13 +44,15 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { TopStep } from '@/lib/steps';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
+import { StepFormComponent } from '@/components/formlib';
+
 import MultiselectWidget from './widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
-import { StepFormComponent } from '@/components/formlib';
 
 @StepFormComponent({
   vqbstep: 'top',

--- a/src/components/stepforms/UnpivotStepForm.vue
+++ b/src/components/stepforms/UnpivotStepForm.vue
@@ -28,12 +28,14 @@
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
+
 import { StepFormComponent } from '@/components/formlib';
 import CheckboxWidget from '@/components/stepforms/widgets/Checkbox.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
-import BaseStepForm from './StepForm.vue';
 import { UnpivotStep } from '@/lib/steps';
 import { generateNewColumnName } from '@/lib/helpers';
+
+import BaseStepForm from './StepForm.vue';
 
 @StepFormComponent({
   vqbstep: 'unpivot',

--- a/src/components/stepforms/widgets/Aggregation.vue
+++ b/src/components/stepforms/widgets/Aggregation.vue
@@ -22,11 +22,14 @@
 </template>
 <script lang="ts">
 import _ from 'lodash';
-import { VQBModule } from '@/store';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
-import { AggFunctionStep } from '@/lib/steps';
-import AutocompleteWidget from './Autocomplete.vue';
 import { ErrorObject } from 'ajv';
+
+import { VQBModule } from '@/store';
+import { AggFunctionStep } from '@/lib/steps';
+
+import AutocompleteWidget from './Autocomplete.vue';
+
 
 @Component({
   name: 'aggregation-widget',

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -19,6 +19,7 @@
 <script lang="ts">
 import { Component, Prop, Watch, Mixins } from 'vue-property-decorator';
 import Multiselect from 'vue-multiselect';
+
 import FormWidget from './FormWidget.vue';
 
 @Component({

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -33,15 +33,17 @@
 </template>
 
 <script lang="ts">
-import { VQBModule } from '@/store';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { VueConstructor } from 'vue';
+import { ErrorObject } from 'ajv';
+
+import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
-import MultiInputTextWidget from './MultiInputText.vue';
 import { FilterSimpleCondition } from '@/lib/steps';
-import { VueConstructor } from 'vue';
-import { ErrorObject } from 'ajv';
+
+import MultiInputTextWidget from './MultiInputText.vue';
 
 type LiteralOperator =
   | 'equal'

--- a/src/components/stepforms/widgets/InputText.vue
+++ b/src/components/stepforms/widgets/InputText.vue
@@ -22,6 +22,7 @@
 
 <script lang="ts">
 import { Component, Prop, Mixins } from 'vue-property-decorator';
+
 import FormWidget from './FormWidget.vue';
 
 @Component({

--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -36,9 +36,11 @@
 import _ from 'lodash';
 import { Component, Prop, Vue, Mixins } from 'vue-property-decorator';
 import { VueConstructor } from 'vue';
-import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
-import FormWidget from './FormWidget.vue';
 import { ErrorObject } from 'ajv';
+
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
+
+import FormWidget from './FormWidget.vue';
 
 type Field = {
   name: string;

--- a/src/components/stepforms/widgets/Multiselect.vue
+++ b/src/components/stepforms/widgets/Multiselect.vue
@@ -19,6 +19,7 @@
 <script lang="ts">
 import { Component, Prop, Watch, Mixins } from 'vue-property-decorator';
 import Multiselect from 'vue-multiselect';
+
 import FormWidget from './FormWidget.vue';
 
 @Component({

--- a/src/components/stepforms/widgets/Replace.vue
+++ b/src/components/stepforms/widgets/Replace.vue
@@ -19,8 +19,9 @@
 <script lang="ts">
 import _ from 'lodash';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
-import InputTextWidget from './InputText.vue';
 import { ErrorObject } from 'ajv';
+
+import InputTextWidget from './InputText.vue';
 
 @Component({
   name: 'replace-widget',

--- a/src/components/stepforms/widgets/SortColumn.vue
+++ b/src/components/stepforms/widgets/SortColumn.vue
@@ -23,12 +23,14 @@
 </template>
 <script lang="ts">
 import _ from 'lodash';
-import { VQBModule } from '@/store';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
-import { MutationCallbacks } from '@/store/mutations';
-import AutocompleteWidget from './Autocomplete.vue';
-import { SortColumnType } from '@/lib/steps';
 import { ErrorObject } from 'ajv';
+
+import { VQBModule } from '@/store';
+import { MutationCallbacks } from '@/store/mutations';
+import { SortColumnType } from '@/lib/steps';
+
+import AutocompleteWidget from './Autocomplete.vue';
 
 @Component({
   name: 'sort-column-widget',

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -4,8 +4,9 @@
  * This module define the mongo → standard pipeline steps implementation.
  */
 
-import { Pipeline } from './steps';
 import { MongoStep } from '@/lib/translators/mongo';
+
+import { Pipeline } from './steps';
 
 /**
  * extract the requested domain from the first step and return the rest of the

--- a/src/lib/translators/index.ts
+++ b/src/lib/translators/index.ts
@@ -6,6 +6,7 @@
  *
  */
 import { PipelineStepName } from '@/lib/steps';
+
 import { BaseTranslator } from './base';
 import { Mongo36Translator } from './mongo';
 import { Mongo40Translator } from './mongo4';

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -1,11 +1,12 @@
 /** This module contains mongo specific translation operations */
 
 import _ from 'lodash';
+import * as math from 'mathjs';
+
 import * as S from '@/lib/steps';
 import { OutputStep, StepMatcher } from '@/lib/matcher';
 import { BaseTranslator } from '@/lib/translators/base';
 import { $$ } from '@/lib/helpers';
-import * as math from 'mathjs';
 import { MathNode } from '@/typings/mathjs';
 
 type PropMap<T> = { [prop: string]: T };

--- a/src/store/backend-plugin.ts
+++ b/src/store/backend-plugin.ts
@@ -13,11 +13,11 @@ import { BackendResponse } from '@/lib/backend-response';
 import { DataSet } from '@/lib/dataset';
 import { Pipeline } from '@/lib/steps';
 import { PipelineInterpolator } from '@/lib/templating';
-
-import { StateMutation } from './mutations';
 import { VQBnamespace, VQB_MODULE_NAME } from '@/store';
 import { activePipeline } from '@/store/state';
 import { pageOffset } from '@/lib/dataset/pagination';
+
+import { StateMutation } from './mutations';
 
 type PipelinesScopeContext = {
   [pipelineName: string]: Pipeline;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -17,9 +17,9 @@
  * ```
  */
 import Vue from 'vue';
-
 import Vuex, { Store, StoreOptions } from 'vuex';
 import { namespace } from 'vuex-class';
+
 import { VQBState, emptyState } from './state';
 import getters from './getters';
 import mutations from './mutations';

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -3,6 +3,7 @@
  */
 
 import { DomainStep, PipelineStepName } from '@/lib/steps';
+
 import { VQBState } from './state';
 
 // provide types for each possible mutations' payloads

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -1,7 +1,9 @@
 import { mount, createLocalVue, shallowMount } from '@vue/test-utils';
-import ActionMenu from '@/components/ActionMenu.vue';
 import Vuex from 'vuex';
+
+import ActionMenu from '@/components/ActionMenu.vue';
 import { VQBnamespace } from '@/store';
+
 import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/action-toolbar-button.spec.ts
+++ b/tests/unit/action-toolbar-button.spec.ts
@@ -1,6 +1,8 @@
 import { mount, createLocalVue } from '@vue/test-utils';
-import ActionToolbarButton from '@/components/ActionToolbarButton.vue';
 import Vuex from 'vuex';
+
+import ActionToolbarButton from '@/components/ActionToolbarButton.vue';
+
 import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/action-toolbar.spec.ts
+++ b/tests/unit/action-toolbar.spec.ts
@@ -1,8 +1,10 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+
 import ActionToolbar from '@/components/ActionToolbar.vue';
 import ActionToolbarButton from '@/components/ActionToolbarButton.vue';
 import { CATEGORY_BUTTONS } from '@/components/constants';
-import Vuex from 'vuex';
+
 import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/add-text-column.spec.ts
+++ b/tests/unit/add-text-column.spec.ts
@@ -1,6 +1,8 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import AddTextColumnStepForm from '@/components/stepforms/AddTextColumnStepForm.vue';
 import Vuex, { Store } from 'vuex';
+
+import AddTextColumnStepForm from '@/components/stepforms/AddTextColumnStepForm.vue';
+
 import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/aggregate-step-form.spec.ts
+++ b/tests/unit/aggregate-step-form.spec.ts
@@ -1,10 +1,13 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import Vuex, { Store } from 'vuex';
+
 import AggregateStepForm from '@/components/stepforms/AggregateStepForm.vue';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
-import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
+
+import { setupMockStore, RootState } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/aggregation-widget.spec.ts
+++ b/tests/unit/aggregation-widget.spec.ts
@@ -1,6 +1,8 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import AggregationWidget from '@/components/stepforms/widgets/Aggregation.vue';
 import Vuex, { Store } from 'vuex';
+
+import AggregationWidget from '@/components/stepforms/widgets/Aggregation.vue';
+
 import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/append-step-form.spec.ts
+++ b/tests/unit/append-step-form.spec.ts
@@ -1,8 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import AppendStepForm from '@/components/stepforms/AppendStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import AppendStepForm from '@/components/stepforms/AppendStepForm.vue';
 import { Pipeline } from '@/lib/steps';
+
+import { setupMockStore, RootState } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/argmax-step-form.spec.ts
+++ b/tests/unit/argmax-step-form.spec.ts
@@ -1,8 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import ArgmaxStepForm from '@/components/stepforms/ArgmaxStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import ArgmaxStepForm from '@/components/stepforms/ArgmaxStepForm.vue';
 import { Pipeline } from '@/lib/steps';
+
+import { setupMockStore, RootState } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/argmin-step-form.spec.ts
+++ b/tests/unit/argmin-step-form.spec.ts
@@ -1,8 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import ArgminStepForm from '@/components/stepforms/ArgminStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import ArgminStepForm from '@/components/stepforms/ArgminStepForm.vue';
 import { Pipeline } from '@/lib/steps';
+
+import { setupMockStore, RootState } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/autocomplete-widget.spec.ts
+++ b/tests/unit/autocomplete-widget.spec.ts
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 
 describe('Widget Autocomplete', () => {

--- a/tests/unit/checkbox-widget.spec.ts
+++ b/tests/unit/checkbox-widget.spec.ts
@@ -1,4 +1,5 @@
 import { mount, createLocalVue, shallowMount } from '@vue/test-utils';
+
 import CheckboxWidget from '@/components/stepforms/widgets/Checkbox.vue';
 
 const localVue = createLocalVue();

--- a/tests/unit/column-picker.spec.ts
+++ b/tests/unit/column-picker.spec.ts
@@ -1,8 +1,11 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import { VQBnamespace } from '@/store';
+
+import { setupMockStore, RootState } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/concatenate-step-form.spec.ts
+++ b/tests/unit/concatenate-step-form.spec.ts
@@ -1,9 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import ConcatenateStepForm from '@/components/stepforms/ConcatenateStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import ConcatenateStepForm from '@/components/stepforms/ConcatenateStepForm.vue';
 import { Pipeline } from '@/lib/steps';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
+
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/convert-step.spec.ts
+++ b/tests/unit/convert-step.spec.ts
@@ -1,6 +1,8 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import ConvertStepForm from '@/components/stepforms/ConvertStepForm.vue';
 import Vuex, { Store } from 'vuex';
+
+import ConvertStepForm from '@/components/stepforms/ConvertStepForm.vue';
+
 import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/data-types-menu.spec.ts
+++ b/tests/unit/data-types-menu.spec.ts
@@ -1,6 +1,8 @@
 import { mount, createLocalVue, shallowMount } from '@vue/test-utils';
-import DataTypesMenu from '@/components/DataTypesMenu.vue';
 import Vuex from 'vuex';
+
+import DataTypesMenu from '@/components/DataTypesMenu.vue';
+
 import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/data-viewer-cell.spec.ts
+++ b/tests/unit/data-viewer-cell.spec.ts
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+
 import DataViewerCell from '@/components/DataViewerCell.vue';
 
 describe('Data Viewer Cell', () => {

--- a/tests/unit/data-viewer.spec.ts
+++ b/tests/unit/data-viewer.spec.ts
@@ -1,8 +1,10 @@
 import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuex from 'vuex';
-import { setupMockStore } from './utils';
+
 import DataViewer from '../../src/components/DataViewer.vue';
+
+import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/delete-column-step-form.spec.ts
+++ b/tests/unit/delete-column-step-form.spec.ts
@@ -1,9 +1,12 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import Vuex, { Store } from 'vuex';
+
 import DeleteColumnStepForm from '@/components/stepforms/DeleteColumnStepForm.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
-import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
+
+import { setupMockStore, RootState } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/domain-step-form.spec.ts
+++ b/tests/unit/domain-step-form.spec.ts
@@ -1,6 +1,8 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import DomainStepForm from '@/components/stepforms/DomainStepForm.vue';
 import Vuex, { Store } from 'vuex';
+
+import DomainStepForm from '@/components/stepforms/DomainStepForm.vue';
+
 import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/duplicate-column-step-form.spec.ts
+++ b/tests/unit/duplicate-column-step-form.spec.ts
@@ -1,8 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import DuplicateColumnStepForm from '@/components/stepforms/DuplicateColumnStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import DuplicateColumnStepForm from '@/components/stepforms/DuplicateColumnStepForm.vue';
 import { Pipeline } from '@/lib/steps';
+
+import { setupMockStore, RootState } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/fillna-step-form.spec.ts
+++ b/tests/unit/fillna-step-form.spec.ts
@@ -1,9 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import FillnaStepForm from '@/components/stepforms/FillnaStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import FillnaStepForm from '@/components/stepforms/FillnaStepForm.vue';
 import { Pipeline } from '@/lib/steps';
 import { VQBnamespace } from '@/store';
+
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -1,8 +1,10 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import Vuex, { Store } from 'vuex';
+
 import FilterSimpleConditionWidget from '@/components/stepforms/widgets/FilterSimpleCondition.vue';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import MultiInputTextWidget from '@/components/stepforms/widgets/MultiInputText.vue';
-import Vuex, { Store } from 'vuex';
+
 import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/filter-step-form.spec.ts
+++ b/tests/unit/filter-step-form.spec.ts
@@ -1,8 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import FilterStepForm from '@/components/stepforms/FilterStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import FilterStepForm from '@/components/stepforms/FilterStepForm.vue';
 import { Pipeline } from '@/lib/steps';
+
+import { setupMockStore, RootState } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/form-widget.spec.ts
+++ b/tests/unit/form-widget.spec.ts
@@ -1,6 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
-import FormWidget from '@/components/stepforms/widgets/FormWidget.vue';
 import { Component, Mixins } from 'vue-property-decorator';
+
+import FormWidget from '@/components/stepforms/widgets/FormWidget.vue';
 
 /* Fake widget use to manage the mixins render issue */
 @Component({

--- a/tests/unit/formlib.spec.ts
+++ b/tests/unit/formlib.spec.ts
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+
 import { StepFormComponent, StepMapper } from '@/components/formlib';
 import { PipelineStepName } from '@/lib/steps';
 

--- a/tests/unit/formula-step-form.spec.ts
+++ b/tests/unit/formula-step-form.spec.ts
@@ -1,8 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import FormulaStepForm from '@/components/stepforms/FormulaStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import FormulaStepForm from '@/components/stepforms/FormulaStepForm.vue';
 import { Pipeline } from '@/lib/steps';
+
+import { setupMockStore, RootState } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/fromdate-step-form.spec.ts
+++ b/tests/unit/fromdate-step-form.spec.ts
@@ -1,6 +1,8 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import FromDateStepForm from '@/components/stepforms/FromDateStepForm.vue';
 import Vuex, { Store } from 'vuex';
+
+import FromDateStepForm from '@/components/stepforms/FromDateStepForm.vue';
+
 import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/input-text-widget.spec.ts
+++ b/tests/unit/input-text-widget.spec.ts
@@ -1,5 +1,6 @@
 import { mount, shallowMount } from '@vue/test-utils';
 import Vue from 'vue';
+
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 
 describe('Widget Input Text', () => {

--- a/tests/unit/list-widget.spec.ts
+++ b/tests/unit/list-widget.spec.ts
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+
 import ListWidget from '@/components/stepforms/widgets/List.vue';
 import AggregationWidget from '@/components/stepforms/widgets/Aggregation.vue';
 import FilterSimpleConditionWidget from '@/components/stepforms/widgets/FilterSimpleCondition.vue';

--- a/tests/unit/multi-input-text-widget.spec.ts
+++ b/tests/unit/multi-input-text-widget.spec.ts
@@ -1,6 +1,7 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import MultiInputTextWidget from '@/components/stepforms/widgets/MultiInputText.vue';
 import Vuex from 'vuex';
+
+import MultiInputTextWidget from '@/components/stepforms/widgets/MultiInputText.vue';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/multiselect-widget.spec.ts
+++ b/tests/unit/multiselect-widget.spec.ts
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+
 import MultiSelectWidget from '@/components/stepforms/widgets/InputText.vue';
 
 describe('Widget Multiselect', () => {

--- a/tests/unit/pagination-component.spec.ts
+++ b/tests/unit/pagination-component.spec.ts
@@ -1,10 +1,11 @@
 import { createLocalVue, shallowMount, mount } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
-import { Pipeline } from '@/lib/steps';
-import { setupMockStore } from './utils';
-import { BackendService, servicePluginFactory } from '@/store/backend-plugin';
 
+import { Pipeline } from '@/lib/steps';
+import { BackendService, servicePluginFactory } from '@/store/backend-plugin';
 import Pagination from '@/components/Pagination.vue';
+
+import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/percentage-step-form.spec.ts
+++ b/tests/unit/percentage-step-form.spec.ts
@@ -1,9 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import PercentageStepForm from '@/components/stepforms/PercentageStepForm.vue';
 import Vuex, { Store } from 'vuex';
+
+import PercentageStepForm from '@/components/stepforms/PercentageStepForm.vue';
 import { VQBnamespace } from '@/store';
-import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
+
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -1,8 +1,10 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
+
 import { Pipeline } from '@/lib/steps';
-import { setupMockStore } from './utils';
 import PipelineComponent from '@/components/Pipeline.vue';
+
+import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/pivot-step-form.spec.ts
+++ b/tests/unit/pivot-step-form.spec.ts
@@ -1,7 +1,9 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import PivotStepForm from '@/components/stepforms/PivotStepForm.vue';
 import Vuex, { Store } from 'vuex';
+
+import PivotStepForm from '@/components/stepforms/PivotStepForm.vue';
 import { VQBnamespace } from '@/store';
+
 import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/plugins.spec.ts
+++ b/tests/unit/plugins.spec.ts
@@ -6,10 +6,11 @@ import flushPromises from 'flush-promises';
 import { Pipeline } from '@/lib/steps';
 import { ScopeContext } from '@/lib/templating';
 import { VQBnamespace } from '@/store';
-import { setupMockStore } from './utils';
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 import { BackendService, servicePluginFactory } from '@/store/backend-plugin';
 import PipelineComponent from '@/components/Pipeline.vue';
+
+import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/query-builder.spec.ts
+++ b/tests/unit/query-builder.spec.ts
@@ -1,6 +1,7 @@
 import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuex, { Store } from 'vuex';
+
 import { registerModule, VQBnamespace } from '@/store';
 import QueryBuilder from '@/components/QueryBuilder.vue';
 import { VQBState } from '@/store/state';

--- a/tests/unit/rename-step-form.spec.ts
+++ b/tests/unit/rename-step-form.spec.ts
@@ -1,9 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import RenameStepForm from '@/components/stepforms/RenameStepForm.vue';
 import Vuex, { Store } from 'vuex';
+
+import RenameStepForm from '@/components/stepforms/RenameStepForm.vue';
 import { VQBnamespace } from '@/store';
-import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
+
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/replace-step-form.spec.ts
+++ b/tests/unit/replace-step-form.spec.ts
@@ -1,7 +1,9 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import ReplaceStepForm from '@/components/stepforms/ReplaceStepForm.vue';
 import Vuex, { Store } from 'vuex';
+
+import ReplaceStepForm from '@/components/stepforms/ReplaceStepForm.vue';
 import { Pipeline } from '@/lib/steps';
+
 import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/replace-widget.spec.ts
+++ b/tests/unit/replace-widget.spec.ts
@@ -1,6 +1,8 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import ReplaceWidget from '@/components/stepforms/widgets/Replace.vue';
 import Vuex, { Store } from 'vuex';
+
+import ReplaceWidget from '@/components/stepforms/widgets/Replace.vue';
+
 import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/resizable-panels.spec.ts
+++ b/tests/unit/resizable-panels.spec.ts
@@ -1,4 +1,5 @@
 import { shallowMount, WrapperArray } from '@vue/test-utils';
+
 import ResizablePanels from '../../src/components/ResizablePanels.vue';
 
 describe('Resizable Panels', () => {

--- a/tests/unit/search-bar.spec.ts
+++ b/tests/unit/search-bar.spec.ts
@@ -1,8 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import SearchBar from '@/components/SearchBar.vue';
 import Vuex from 'vuex';
-import { setupMockStore } from './utils';
+
+import SearchBar from '@/components/SearchBar.vue';
 import { ActionCategories } from '@/components/constants';
+
+import { setupMockStore } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/select-column-step-form.spec.ts
+++ b/tests/unit/select-column-step-form.spec.ts
@@ -1,8 +1,10 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import Vuex, { Store } from 'vuex';
+
 import SelectColumnStepForm from '@/components/stepforms/SelectColumnStepForm.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
-import Vuex, { Store } from 'vuex';
 import { Pipeline } from '@/lib/steps';
+
 import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/sort-column-widget.spec.ts
+++ b/tests/unit/sort-column-widget.spec.ts
@@ -1,6 +1,8 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import SortColumnWidget from '@/components/stepforms/widgets/SortColumn.vue';
 import Vuex, { Store } from 'vuex';
+
+import SortColumnWidget from '@/components/stepforms/widgets/SortColumn.vue';
+
 import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/sort-step-form.spec.ts
+++ b/tests/unit/sort-step-form.spec.ts
@@ -1,8 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import SortStepForm from '@/components/stepforms/SortStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import SortStepForm from '@/components/stepforms/SortStepForm.vue';
 import { Pipeline } from '@/lib/steps';
+
+import { setupMockStore, RootState } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/split-step-form.spec.ts
+++ b/tests/unit/split-step-form.spec.ts
@@ -1,8 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import SplitStepForm from '@/components/stepforms/SplitStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import SplitStepForm from '@/components/stepforms/SplitStepForm.vue';
 import { Pipeline } from '@/lib/steps';
+
+import { setupMockStore, RootState } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -1,10 +1,12 @@
 import { mount, createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuex from 'vuex';
+
 import { Pipeline } from '@/lib/steps';
-import { setupMockStore } from './utils';
 import DeleteConfirmationModal from '@/components/DeleteConfirmationModal.vue';
 import PipelineComponent from '@/components/Pipeline.vue';
 import Step from '@/components/Step.vue';
+
+import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/substring-step-form.spec.ts
+++ b/tests/unit/substring-step-form.spec.ts
@@ -1,6 +1,8 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import SubstringStepForm from '@/components/stepforms/SubstringStepForm.vue';
 import Vuex, { Store } from 'vuex';
+
+import SubstringStepForm from '@/components/stepforms/SubstringStepForm.vue';
+
 import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+
 import { PipelineInterpolator, ScopeContext } from '@/lib/templating';
 import { ColumnTypeMapping } from '@/lib/dataset';
 import { Pipeline } from '@/lib/steps';

--- a/tests/unit/todate-step-form.spec.ts
+++ b/tests/unit/todate-step-form.spec.ts
@@ -1,6 +1,8 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import ToDateStepForm from '@/components/stepforms/ToDateStepForm.vue';
 import Vuex, { Store } from 'vuex';
+
+import ToDateStepForm from '@/components/stepforms/ToDateStepForm.vue';
+
 import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/tolower-step-form.spec.ts
+++ b/tests/unit/tolower-step-form.spec.ts
@@ -1,6 +1,8 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import ToLowerStepForm from '@/components/stepforms/ToLowerStepForm.vue';
 import Vuex, { Store } from 'vuex';
+
+import ToLowerStepForm from '@/components/stepforms/ToLowerStepForm.vue';
+
 import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/top-step-form.spec.ts
+++ b/tests/unit/top-step-form.spec.ts
@@ -1,10 +1,12 @@
 import _ from 'lodash';
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import TopStepForm from '@/components/stepforms/TopStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import TopStepForm from '@/components/stepforms/TopStepForm.vue';
 import { Pipeline } from '@/lib/steps';
 import { ScopeContext } from '@/lib/templating';
+
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/toupper-step-form.spec.ts
+++ b/tests/unit/toupper-step-form.spec.ts
@@ -1,6 +1,8 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import ToUpperStepForm from '@/components/stepforms/ToUpperStepForm.vue';
 import Vuex, { Store } from 'vuex';
+
+import ToUpperStepForm from '@/components/stepforms/ToUpperStepForm.vue';
+
 import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();

--- a/tests/unit/unpivot-step-form.spec.ts
+++ b/tests/unit/unpivot-step-form.spec.ts
@@ -1,9 +1,11 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import UnpivotStepForm from '@/components/stepforms/UnpivotStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore, RootState } from './utils';
+
+import UnpivotStepForm from '@/components/stepforms/UnpivotStepForm.vue';
 import { Pipeline } from '@/lib/steps';
 import CheckboxWidget from '@/components/stepforms/widgets/Checkbox.vue';
+
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -1,6 +1,6 @@
 import Vuex, { Store } from 'vuex';
-import { registerModule } from '@/store';
 
+import { registerModule } from '@/store';
 import { VQBState } from '@/store/state';
 
 export type RootState = {

--- a/tests/unit/vqb.spec.ts
+++ b/tests/unit/vqb.spec.ts
@@ -1,6 +1,8 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
+
 import { setupStore } from '@/store';
+
 import Vqb from '../../src/components/Vqb.vue';
 
 const localVue = createLocalVue();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,24 +1623,24 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.6.1.tgz#e34972a24f8aba0861f9ccf7130acd74fd11e079"
-  integrity sha512-Z0rddsGqioKbvqfohg7BwkFC3PuNLsB+GE9QkFza7tiDzuHoy0y823Y+oGNDzxNZrYyLjqkZtCTl4vCqOmEN4g==
+"@typescript-eslint/eslint-plugin@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.10.0.tgz#c4cb103275e555e8a7e9b3d14c5951eb6d431e70"
+  integrity sha512-rT51fNLW0u3fnDGnAHVC5nu+Das+y2CpW10yqvf6/j5xbuUV3FxA3mBaIbM24CXODXjbgUznNb4Kg9XZOUxKAw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.6.1"
-    eslint-utils "^1.4.2"
+    "@typescript-eslint/experimental-utils" "2.10.0"
+    eslint-utils "^1.4.3"
     functional-red-black-tree "^1.0.1"
-    regexpp "^2.0.1"
+    regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.6.1.tgz#eddaca17a399ebf93a8628923233b4f93793acfd"
-  integrity sha512-EVrrUhl5yBt7fC7c62lWmriq4MIc49zpN3JmrKqfiFXPXCM5ErfEcZYfKOhZXkW6MBjFcJ5kGZqu1b+lyyExUw==
+"@typescript-eslint/experimental-utils@2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz#8db1656cdfd3d9dcbdbf360b8274dea76f0b2c2c"
+  integrity sha512-FZhWq6hWWZBP76aZ7bkrfzTMP31CCefVIImrwP3giPLcoXocmLTmr92NLZxuIcTL4GTEOE33jQMWy9PwelL+yQ==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.6.1"
+    "@typescript-eslint/typescript-estree" "2.10.0"
     eslint-scope "^5.0.0"
 
 "@typescript-eslint/experimental-utils@^1.13.0":
@@ -1652,14 +1652,14 @@
     "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-scope "^4.0.0"
 
-"@typescript-eslint/parser@^2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.6.1.tgz#3c00116baa0d696bc334ca18ac5286b34793993c"
-  integrity sha512-PDPkUkZ4c7yA+FWqigjwf3ngPUgoLaGjMlFh6TRtbjhqxFBnkElDfckSjm98q9cMr4xRzZ15VrS/xKm6QHYf0w==
+"@typescript-eslint/parser@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.10.0.tgz#24b2e48384ab6d5a6121e4c4faf8892c79657ad3"
+  integrity sha512-wQNiBokcP5ZsTuB+i4BlmVWq6o+oAhd8en2eSm/EE9m7BgZUIfEeYFd6z3S+T7bgNuloeiHA1/cevvbBDLr98g==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.6.1"
-    "@typescript-eslint/typescript-estree" "2.6.1"
+    "@typescript-eslint/experimental-utils" "2.10.0"
+    "@typescript-eslint/typescript-estree" "2.10.0"
     eslint-visitor-keys "^1.1.0"
 
 "@typescript-eslint/typescript-estree@1.13.0":
@@ -1670,13 +1670,14 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@typescript-eslint/typescript-estree@2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.1.tgz#fb363dd4ca23384745c5ea4b7f4c867432b00d31"
-  integrity sha512-+sTnssW6bcbDZKE8Ce7VV6LdzkQz2Bxk7jzk1J8H1rovoTxnm6iXvYIyncvNsaB/kBCOM63j/LNJfm27bNdUoA==
+"@typescript-eslint/typescript-estree@2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz#89cdabd5e8c774e9d590588cb42fb9afd14dcbd9"
+  integrity sha512-oOYnplddQNm/LGVkqbkAwx4TIBuuZ36cAQq9v3nFIU9FmhemHuVzAesMSXNQDdAzCa5bFgCrfD3JWhYVKlRN2g==
   dependencies:
     debug "^4.1.1"
-    glob "^7.1.4"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
     is-glob "^4.0.1"
     lodash.unescape "4.0.1"
     semver "^6.3.0"
@@ -4442,7 +4443,7 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.1, eslint-utils@^1.4.2:
+eslint-utils@^1.3.1, eslint-utils@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
   integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
@@ -5292,7 +5293,7 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -9289,6 +9290,11 @@ regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
+regexpp@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.0.0.tgz#dd63982ee3300e67b41c1956f850aa680d9d330e"
+  integrity sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==
 
 regexpu-core@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3492,6 +3492,11 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+  integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
+
 content-disposition@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
@@ -3831,7 +3836,7 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -4079,6 +4084,14 @@ dir-glob@2.0.0:
   dependencies:
     arrify "^1.0.1"
     path-type "^3.0.0"
+
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  integrity sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -4405,6 +4418,44 @@ escodegen@^1.11.1, escodegen@^1.9.1:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+eslint-import-resolver-alias@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz#297062890e31e4d6651eb5eba9534e1f6e68fc97"
+  integrity sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==
+
+eslint-import-resolver-node@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
+  integrity sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.5.0"
+
+eslint-module-utils@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz#7b4675875bf96b0dbf1b21977456e5bb1f5e018c"
+  integrity sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^2.0.0"
+
+eslint-plugin-import@^2.18.2:
+  version "2.18.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz#02f1180b90b077b33d447a17a2326ceb400aceb6"
+  integrity sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==
+  dependencies:
+    array-includes "^3.0.3"
+    contains-path "^0.1.0"
+    debug "^2.6.9"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.2"
+    eslint-module-utils "^2.4.0"
+    has "^1.0.3"
+    minimatch "^3.0.4"
+    object.values "^1.1.0"
+    read-pkg-up "^2.0.0"
+    resolve "^1.11.0"
 
 eslint-plugin-jest@^22.13.0:
   version "22.21.0"
@@ -6964,6 +7015,16 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  integrity sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
 load-json-file@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
@@ -8318,6 +8379,13 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
+  dependencies:
+    pify "^2.0.0"
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -8379,6 +8447,13 @@ pirates@^4.0.1:
   integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
   dependencies:
     node-modules-regexp "^1.0.0"
+
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+  dependencies:
+    find-up "^2.1.0"
 
 pkg-dir@^3.0.0:
   version "3.0.0"
@@ -9107,6 +9182,14 @@ read-pkg-up@^1.0.1:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
 
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  integrity sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
 read-pkg-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
@@ -9131,6 +9214,15 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  integrity sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 read-pkg@^3.0.0:
   version "3.0.0"
@@ -9510,6 +9602,13 @@ resolve@1.x, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.3.2:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.5.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.1.tgz#be0aa4c06acd53083505abb35f4d66932ab35d16"
+  integrity sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==
   dependencies:
     path-parse "^1.0.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9605,7 +9605,7 @@ resolve@1.x, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.5.0:
+resolve@^1.5.0, resolve@^1.6.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.1.tgz#be0aa4c06acd53083505abb35f4d66932ab35d16"
   integrity sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==


### PR DESCRIPTION
They are useful when specifying default property values in Vue components.

Migrate to typescript-eslint 2.10 on the way.