### PR TITLE
keep history of error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## UNRELEASED -
+
+### Added
+
+- `logBackendError` and `resetBackendErrors` mutations.
+
+### Breaking
+- removed `setBackendError` mutation, please use `logBackendError` instead.
+
 ## [0.7.0] - 2019-12-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ yarn build-bundle
 
 This will generate an importable JS `VisualQueryBuilder` library in the `dist` directory.
 
+**Important note**: While we do our best to embrace [semantic versioning](https://semver.org/),
+we do not guarantee full backward compatibility until version 1.0.0 is realeased.
+
 ### Run your tests
 
 The basic command to run all tests is:

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  moduleFileExtensions: ['js', 'json', 'vue', 'ts'],
+  moduleFileExtensions: ['js', 'json', 'vue', 'ts', 'd.ts'],
   testEnvironment: 'jsdom',
   testURL: 'http://localhost/',
   testMatch: ['<rootDir>/tests/unit/*.spec.ts'],

--- a/playground/app.js
+++ b/playground/app.js
@@ -177,7 +177,7 @@ async function setupInitialData(store, domain = null) {
       store.state[VQB_MODULE_NAME].pagesize,
     );
     if (response.error) {
-      store.commit(VQBnamespace('setBackendError'), {
+      store.commit(VQBnamespace('logBackendError'), {
         backendError: {
           type: 'error',
           error: response.error,
@@ -315,7 +315,7 @@ async function buildVueApp() {
         return this.$store.getters[VQBnamespace('thereIsABackendError')];
       },
       backendErrorMessage: function() {
-        return this.$store.getters[VQBnamespace('backendErrorMessage')];
+        return this.$store.getters[VQBnamespace('backendErrorMessages')].join('<br/>');
       },
     },
     methods: {

--- a/src/store/backend-plugin.ts
+++ b/src/store/backend-plugin.ts
@@ -109,16 +109,14 @@ async function _updateDataset(store: Store<any>, service: BackendService, pipeli
       pageOffset(store.state[VQB_MODULE_NAME].pagesize, store.getters[VQBnamespace('pageno')]),
     );
     if (response.error) {
-      store.commit(VQBnamespace('setBackendError'), {
+      store.commit(VQBnamespace('logBackendError'), {
         backendError: { type: 'error', message: response.error },
       });
     } else {
       store.commit(VQBnamespace('setDataset'), { dataset: response.data });
-      // reset backend error to undefined:
-      store.commit(VQBnamespace('setBackendError'), { backendError: undefined });
     }
   } catch (error) {
-    store.commit(VQBnamespace('setBackendError'), {
+    store.commit(VQBnamespace('logBackendError'), {
       backendError: { type: 'error', message: error },
     });
   }

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -14,8 +14,7 @@ export default {
   /**
    * current backend's error message
    */
-  backendErrorMessage: (state: VQBState) =>
-    state.backendError ? state.backendError.message : null,
+  backendErrorMessages: (state: VQBState) => state.backendErrors,
   /**
    * the list of current dataset's colum names.
    **/
@@ -72,7 +71,7 @@ export default {
   /**
    * Return true if an error occured in the backend
    */
-  thereIsABackendError: (state: VQBState) => state.backendError !== undefined,
+  thereIsABackendError: (state: VQBState) => state.backendErrors.length > 0,
   /**
    * selected columns in the dataviewer (materialized by a styled focus)
    */

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -2,14 +2,14 @@
  * exports the list of store mutations.
  */
 
+import { BackendError } from '@/lib/backend-response';
 import { DomainStep, PipelineStepName } from '@/lib/steps';
-
 import { VQBState } from './state';
 
 // provide types for each possible mutations' payloads
 type BackendErrorMutation = {
-  type: 'setBackendError';
-  payload: Pick<VQBState, 'backendError'>;
+  type: 'logBackendError';
+  payload: BackendError;
 };
 
 type DatasetMutation = {
@@ -88,6 +88,14 @@ export default {
     state.currentStepFormName = stepName;
     state.stepFormInitialValue = undefined;
   },
+
+  /**
+   * log a backend error message.
+   */
+  logBackendError(state: VQBState, { backendError }: { backendError: BackendError }) {
+    state.backendErrors.push(backendError);
+  },
+
   /**
    * open step form when editing a step
    */
@@ -97,6 +105,13 @@ export default {
   ) {
     state.stepFormInitialValue = { ...initialValue };
     state.currentStepFormName = stepName;
+  },
+
+  /**
+   * empty error log on VQB's state
+   */
+  resetBackendErrors(state: VQBState) {
+    state.backendErrors = [];
   },
 
   /**
@@ -209,13 +224,6 @@ export default {
       const length = state.dataset.data.length;
       state.dataset.paginationContext = { pageno, pagesize: length, totalCount: length };
     }
-  },
-
-  /**
-   * update backendErrorMessage.
-   */
-  setBackendError(state: VQBState, { backendError }: Pick<VQBState, 'backendError'>) {
-    state.backendError = backendError;
   },
 
   /**

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -59,7 +59,7 @@ export interface VQBState {
   /**
    * error send by backend or catch from its interface
    */
-  backendError?: BackendError;
+  backendErrors: BackendError[];
 
   /**
    * whether the data is loading
@@ -105,7 +105,7 @@ export const emptyState: VQBState = {
   pipelines: {},
   selectedColumns: [],
   pagesize: 50,
-  backendError: undefined,
+  backendErrors: [],
   isLoading: false,
   variables: {},
   translator: 'mongo40',

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -195,12 +195,12 @@ describe('getter tests', () => {
 
   describe('message error related test', () => {
     it('should return false if backendError is undefined', () => {
-      const state = buildState({ backendError: undefined });
+      const state = buildState({ backendErrors: [] });
       expect(getters.thereIsABackendError(state)).toBeFalsy();
     });
 
     it('should return true if backendError is not undefined', () => {
-      const state = buildState({ backendError: { type: 'error', message: 'error msg' } });
+      const state = buildState({ backendErrors: [{ type: 'error', message: 'error msg' }] });
       expect(getters.thereIsABackendError(state)).toBeTruthy();
     });
   });
@@ -401,12 +401,28 @@ describe('mutation tests', () => {
     expect(state.selectedColumns).toEqual([]);
   });
 
-  it('set a backend error', () => {
+  it('logs backend errors', () => {
     const state = buildState({});
-    mutations.setBackendError(state, {
+    mutations.logBackendError(state, {
       backendError: { type: 'error', message: 'error msg' },
     });
-    expect(state.backendError).toEqual({ type: 'error', message: 'error msg' });
+    expect(state.backendErrors).toEqual([{ type: 'error', message: 'error msg' }]);
+    mutations.logBackendError(state, {
+      backendError: { type: 'error', message: 'error msg 2' },
+    });
+    expect(state.backendErrors).toEqual([
+      { type: 'error', message: 'error msg' },
+      { type: 'error', message: 'error msg 2' },
+    ]);
+  });
+
+  it('resets backend errors', () => {
+    const state = buildState({});
+    mutations.logBackendError(state, {
+      backendError: { type: 'error', message: 'error msg' },
+    });
+    mutations.resetBackendErrors(state);
+    expect(state.backendErrors).toEqual([]);
   });
 
   it('set loading to true', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9918,13 +9918,6 @@ resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.5.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.1.tgz#be0aa4c06acd53083505abb35f4d66932ab35d16"
-  integrity sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==
-  dependencies:
-    path-parse "^1.0.6"
-
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4009,7 +4009,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
+debug@3.2.6, debug@^3.1.0, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4111,11 +4111,6 @@ deep-equal@^1.1.1:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
-
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -4194,11 +4189,6 @@ detect-indent@^4.0.0:
   integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
   dependencies:
     repeating "^2.0.0"
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -5374,13 +5364,6 @@ fs-extra@^8.0.1, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -5929,7 +5912,7 @@ https-proxy-agent@^2.2.1:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6081,7 +6064,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -7786,21 +7769,6 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
-
 mississippi@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
@@ -7971,15 +7939,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -8099,22 +8058,6 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.29, node-releases@^1.1.42:
   version "1.1.44"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.44.tgz#cd66438a6eb875e3eb012b6a12e48d9f4326ffd7"
@@ -8152,7 +8095,7 @@ node-sass@^4.11.0:
   dependencies:
     abbrev "1"
 
-nopt@^4.0.1, nopt@~4.0.1:
+nopt@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
   integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
@@ -8187,26 +8130,6 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
-  integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -8214,7 +8137,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2, npmlog@^4.1.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -9251,16 +9174,6 @@ raw-loader@^2.0.0:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-clientside-effect@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
@@ -9911,7 +9824,7 @@ resolve@1.x, resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.5.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.1.tgz#9e018c540fcf0c427d678b9931cbf45e984bcaff"
   integrity sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==
@@ -10886,7 +10799,7 @@ strip-indent@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
-strip-json-comments@2.0.1, strip-json-comments@^2.0.0, strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1, strip-json-comments@^2.0.0, strip-json-comments@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -10988,19 +10901,6 @@ tar@^2.0.0:
     block-stream "*"
     fstream "^1.0.12"
     inherits "2"
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 teeny-request@^3.11.3:
   version "3.11.3"
@@ -12085,7 +11985,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
This PR introduces two new mutations:

- `logBackendError` to add a backend error to the logbook
- `resetErrorMessages` to empty the logbook

The former `setBackendError` mutation is removed.

Therefore, rather than having a single error message in the store, keep
track of all of them until the `resetBackendErrors` is called.

This is needed because otherwise the backend-plugin would reset a
previous error once a pipeline execution was successful. Since we
sometimes peform several pipeline executions in a row (e.g. if 2
mutations trigger a pipeline execution consecutively).