### PR TITLE
Filter simple condition form :: Visual improvement

### DIFF
--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -9,8 +9,7 @@
       :placeholder="placeholder"
       @input="clearOptions"
       @search-change="updateOptions"
-    >
-    </multiselect>
+    />
   </div>
 </template>
 

--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="widget-multiinputtext__container">
-    <label class="widget-multiinputtext__label" :for="id">{{ name }}</label>
     <multiselect
       v-model="editedValue"
       :options="options"
@@ -11,7 +10,6 @@
       @input="clearOptions"
       @search-change="updateOptions"
     >
-      <template slot="noOptions">{{ placeholder }}</template>
     </multiselect>
   </div>
 </template>
@@ -80,10 +78,14 @@ export default class MultiInputTextWidget extends Vue {
 .multiselect .multiselect__placeholder {
   margin-bottom: 0;
   color: $grey-dark;
+  font-size: 14px;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
   width: 100%;
+  padding: 0;
+  line-height: 20px;
+  padding-left: 5px;
 }
 
 .multiselect__single {
@@ -136,6 +138,7 @@ export default class MultiInputTextWidget extends Vue {
   max-height: none;
   display: block;
   padding-right: 30px;
+  height: 40px;
   & > input {
     background: transparent;
     margin-bottom: 0;
@@ -143,6 +146,76 @@ export default class MultiInputTextWidget extends Vue {
       color: $grey-dark;
     }
   }
+}
+
+.widget-multiinputtext__container {
+  .multiselect__content-wrapper {
+    display: none !important;
+  }
+  .multiselect__tags {
+    background: none;
+    box-shadow: rgb(241, 241, 241) 0px 0px 0px 1px inset;
+    display: flex;
+    position: absolute;
+    overflow: hidden;
+    height: 40px;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 0;
+    width: 100%;
+  }
+  .multiselect__placeholder {
+    padding: 8px 30px 8px 10px;
+  }
+  .multiselect__tags-wrap {
+    order: 2;
+    padding: 8px 30px 8px 8px;
+    width: 100%;
+  }
+  .multiselect__input {
+    border-radius: 0px;
+    order: 1;
+    padding: 4px 10px 11px;
+    left: 0px;
+    position: relative;
+    box-shadow: rgb(241, 241, 241) 0px 0px 0px 1px inset;
+    height: 40px;
+  }
+  .multiselect--active .multiselect__tags {
+    overflow: visible;
+    height: auto;
+  }
+  .multiselect--active {
+    .multiselect__tags {
+      box-shadow: none;
+    }
+    .multiselect__tags-wrap {
+      background: #fff;
+      box-shadow: rgb(241, 241, 241) 0px 0px 0px 1px inset;
+      border-radius: 0 0 5px 5px;
+      padding: 8px 10px;
+      max-height: 200px;
+      overflow-y: auto;
+    }
+    .multiselect__input {
+      box-shadow: 0 0 0 1px #2665a3 inset;
+    }
+    .multiselect__tag:last-child {
+      margin-bottom: 0;
+    }
+  }
+  .multiselect__select {
+    z-index: 3;
+  }
+}
+
+.multiselect__select:before {
+  border: 0;
+  content: "\f078";
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+  line-height: 1;
+  top: 8px;
 }
 
 .multiselect__tags .multiselect__tag {

--- a/tests/unit/multi-input-text-widget.spec.ts
+++ b/tests/unit/multi-input-text-widget.spec.ts
@@ -12,16 +12,6 @@ describe('Widget MultisInputText', () => {
     expect(wrapper.exists()).toBeTruthy();
   });
 
-  it('should have a label', () => {
-    const wrapper = shallowMount(MultiInputTextWidget, {
-      propsData: {
-        name: 'Stark',
-      },
-    });
-    const labelWrapper = wrapper.find('label');
-    expect(labelWrapper.text()).toEqual('Stark');
-  });
-
   it('should have an empty placeholder', () => {
     const wrapper = shallowMount(MultiInputTextWidget, {
       propsData: {


### PR DESCRIPTION
Multiselect dropdown enhancement to improve filter simple condition display.

Before the dropdown multiselect tag was pushing the content below : 
![image](https://user-images.githubusercontent.com/17548199/72613750-c4220a00-3930-11ea-8a3b-ec3608498a27.png)

Now it's positionned in absolute with a scrollbar and max-height : 
![image](https://user-images.githubusercontent.com/17548199/72608759-bb770700-3923-11ea-8d4c-37bc01c28ed4.png)

It also contains other form improvement like better height size and change the old ugly arrow by a font awesome one :
![image](https://user-images.githubusercontent.com/17548199/72613806-ed429a80-3930-11ea-9d65-a5a870bd12d9.png)
