### PR TITLE
tests :: introduce a runner class

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "mongodb-prebuilt": "^6.5.0",
     "multer": "^1.4.1",
     "node-sass": "^4.11.0",
+    "prettier": "^1.19.1",
     "puppeteer": "^1.16.0",
     "rollup": "^1.5.0",
     "rollup-plugin-alias": "^1.5.1",

--- a/tests/unit/add-text-column.spec.ts
+++ b/tests/unit/add-text-column.spec.ts
@@ -3,15 +3,11 @@ import Vuex, { Store } from 'vuex';
 
 import AddTextColumnStepForm from '@/components/stepforms/AddTextColumnStepForm.vue';
 
-import { setupMockStore, RootState } from './utils';
+import { setupMockStore, RootState, BasicStepFormTestRunner } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Add Text Column Step Form', () => {
   let emptyStore: Store<RootState>;
@@ -19,16 +15,10 @@ describe('Add Text Column Step Form', () => {
     emptyStore = setupMockStore({});
   });
 
-  it('should instantiate', () => {
-    const wrapper = shallowMount(AddTextColumnStepForm, { store: emptyStore, localVue });
-    expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.vm.$data.stepname).toEqual('text');
-  });
-
-  it('should have exactly 2 widgetinputtext component', () => {
-    const wrapper = shallowMount(AddTextColumnStepForm, { store: emptyStore, localVue });
-    const inputWrappers = wrapper.findAll('inputtextwidget-stub');
-    expect(inputWrappers.length).toEqual(2);
+  const runner = new BasicStepFormTestRunner(AddTextColumnStepForm, 'text', localVue);
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'inputtextwidget-stub': 2,
   });
 
   it('should pass down properties', async () => {

--- a/tests/unit/aggregate-step-form.spec.ts
+++ b/tests/unit/aggregate-step-form.spec.ts
@@ -4,17 +4,11 @@ import Vuex, { Store } from 'vuex';
 import AggregateStepForm from '@/components/stepforms/AggregateStepForm.vue';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
-
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Aggregate Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/aggregate-step-form.spec.ts
+++ b/tests/unit/aggregate-step-form.spec.ts
@@ -12,7 +12,6 @@ describe('Aggregate Step Form', () => {
   });
 
   describe('MultiselectWidget', () => {
-
     it('should instantiate an MultiselectWidget widget with proper options from the store', () => {
       const initialState = {
         dataset: {
@@ -27,14 +26,16 @@ describe('Aggregate Step Form', () => {
 
     it('should pass down the "on" prop to the MultiselectWidget value prop', async () => {
       const wrapper = runner.shallowMount(undefined, {
-        data: { editedStep: { name: 'aggregate', on: ['foo', 'bar'], aggregations: [] }}
+        data: { editedStep: { name: 'aggregate', on: ['foo', 'bar'], aggregations: [] } },
       });
       await wrapper.vm.$nextTick();
       expect(wrapper.find('multiselectwidget-stub').props().value).toEqual(['foo', 'bar']);
     });
 
     it('should call the setColumnMutation on input', async () => {
-      const wrapper = runner.mount(undefined, {data: { editedStep: { name: 'aggregate', on: ['foo'], aggregations: [] } }});
+      const wrapper = runner.mount(undefined, {
+        data: { editedStep: { name: 'aggregate', on: ['foo'], aggregations: [] } },
+      });
       await wrapper.vm.$nextTick();
       expect(wrapper.vm.$store.state.vqb.selectedColumns).toEqual(['foo']);
     });
@@ -72,7 +73,6 @@ describe('Aggregate Step Form', () => {
   });
 
   describe('Validation', () => {
-
     runner.testValidationErrors([
       {
         testlabel: '"on" parameter is an empty string',
@@ -85,13 +85,11 @@ describe('Aggregate Step Form', () => {
                 newcolumn: 'sum_col1',
                 aggfunction: 'sum',
                 column: 'col1',
-              }
+              },
             ],
           },
         },
-        errors: [
-          { keyword: 'minLength', dataPath: '.on[0]' }
-        ],
+        errors: [{ keyword: 'minLength', dataPath: '.on[0]' }],
       },
       {
         testlabel: '"column" parameter is an empty string',
@@ -104,8 +102,8 @@ describe('Aggregate Step Form', () => {
                 newcolumn: '',
                 aggfunction: 'sum',
                 column: '',
-              }
-            ]
+              },
+            ],
           },
         },
         errors: [
@@ -125,28 +123,24 @@ describe('Aggregate Step Form', () => {
                 newcolumn: 'foo_col1',
                 aggfunction: 'foo',
                 column: 'col1',
-              }
-            ]
+              },
+            ],
           },
         },
-        errors: [
-          { keyword: 'enum', dataPath: '.aggregations[0].aggfunction' },
-        ],
+        errors: [{ keyword: 'enum', dataPath: '.aggregations[0].aggfunction' }],
       },
     ]);
 
-    runner.testValidate(
-      {
-        testlabel: 'submitted data is valid',
-        props: {
-          initialStepValue: {
-            name: 'aggregate',
-            on: ['foo'],
-            aggregations: [{ column: 'bar', newcolumn: 'bar', aggfunction: 'sum' }],
-          },
+    runner.testValidate({
+      testlabel: 'submitted data is valid',
+      props: {
+        initialStepValue: {
+          name: 'aggregate',
+          on: ['foo'],
+          aggregations: [{ column: 'bar', newcolumn: 'bar', aggfunction: 'sum' }],
         },
-      }
-    );
+      },
+    });
 
     it('should keep the same column name as newcolumn if only one aggregation is performed', () => {
       const wrapper = runner.mount(undefined, {
@@ -156,7 +150,7 @@ describe('Aggregate Step Form', () => {
             on: ['foo'],
             aggregations: [{ column: 'bar', newcolumn: '', aggfunction: 'sum' }],
           },
-        }
+        },
       });
       wrapper.find('.widget-form-action__button--validate').trigger('click');
       expect(wrapper.vm.$data.errors).toBeNull();
@@ -174,7 +168,7 @@ describe('Aggregate Step Form', () => {
               { column: 'bar', newcolumn: '', aggfunction: 'avg' },
             ],
           },
-        }
+        },
       });
       wrapper.find('.widget-form-action__button--validate').trigger('click');
       expect(wrapper.vm.$data.errors).toBeNull();
@@ -193,7 +187,9 @@ describe('Aggregate Step Form', () => {
 
   it('should change the column focus after input in multiselect', async () => {
     const initialState = { selectedColumns: [] };
-    const wrapper = runner.mount(initialState, { data: { editedStep: { name: 'aggregate', on: ['foo'], aggregations: [] }}});
+    const wrapper = runner.mount(initialState, {
+      data: { editedStep: { name: 'aggregate', on: ['foo'], aggregations: [] } },
+    });
     wrapper.find(MultiselectWidget).trigger('input');
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.$store.state.vqb.selectedColumns).toEqual(['foo']);

--- a/tests/unit/aggregate-step-form.spec.ts
+++ b/tests/unit/aggregate-step-form.spec.ts
@@ -2,7 +2,6 @@ import AggregateStepForm from '@/components/stepforms/AggregateStepForm.vue';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
 import { BasicStepFormTestRunner } from './utils';
-import { Pipeline } from '@/lib/steps';
 
 describe('Aggregate Step Form', () => {
   const runner = new BasicStepFormTestRunner(AggregateStepForm, 'aggregate');
@@ -177,12 +176,16 @@ describe('Aggregate Step Form', () => {
     });
   });
 
-  it('should emit "cancel" event when edition is cancelled', () => {
-    const wrapper = runner.mount();
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(wrapper.emitted()).toEqual({
-      cancel: [[]],
-    });
+  runner.testCancel();
+
+  runner.testResetSelectedIndex({
+    pipeline: [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+      { name: 'rename', oldname: 'baz', newname: 'spam' },
+      { name: 'rename', oldname: 'tic', newname: 'tac' },
+    ],
+    selectedStepIndex: 2,
   });
 
   it('should change the column focus after input in multiselect', async () => {
@@ -193,27 +196,5 @@ describe('Aggregate Step Form', () => {
     wrapper.find(MultiselectWidget).trigger('input');
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.$store.state.vqb.selectedColumns).toEqual(['foo']);
-  });
-
-  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', async () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ];
-    const initialState = {
-      pipeline,
-      selectedStepIndex: 2,
-    };
-    const wrapper = runner.mount(initialState, {
-      propsData: { isStepCreation: true },
-    });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(wrapper.vm.$store.state.vqb.selectedStepIndex).toEqual(2);
-    wrapper.setProps({ isStepCreation: false });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    await wrapper.vm.$nextTick();
-    expect(wrapper.vm.$store.state.vqb.selectedStepIndex).toEqual(3);
   });
 });

--- a/tests/unit/aggregate-step-form.spec.ts
+++ b/tests/unit/aggregate-step-form.spec.ts
@@ -177,16 +177,7 @@ describe('Aggregate Step Form', () => {
   });
 
   runner.testCancel();
-
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 
   it('should change the column focus after input in multiselect', async () => {
     const initialState = { selectedColumns: [] };

--- a/tests/unit/append-step-form.spec.ts
+++ b/tests/unit/append-step-form.spec.ts
@@ -1,6 +1,6 @@
 import AppendStepForm from '@/components/stepforms/AppendStepForm.vue';
 
-import { setupMockStore, BasicStepFormTestRunner } from './utils';
+import { BasicStepFormTestRunner } from './utils';
 
 describe('Append Step Form', () => {
   const runner = new BasicStepFormTestRunner(AppendStepForm, 'append');

--- a/tests/unit/append-step-form.spec.ts
+++ b/tests/unit/append-step-form.spec.ts
@@ -1,15 +1,9 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex from 'vuex';
-
 import AppendStepForm from '@/components/stepforms/AppendStepForm.vue';
 
 import { setupMockStore, BasicStepFormTestRunner } from './utils';
 
-const localVue = createLocalVue();
-localVue.use(Vuex);
-
 describe('Append Step Form', () => {
-  const runner = new BasicStepFormTestRunner(AppendStepForm, 'append', localVue);
+  const runner = new BasicStepFormTestRunner(AppendStepForm, 'append');
   runner.testInstantiate();
   runner.testExpectedComponents({
     'multiselectwidget-stub': 1,
@@ -47,15 +41,15 @@ describe('Append Step Form', () => {
   });
 
   it('should instantiate a multiselect widget with proper options from the store', () => {
-    const store = setupMockStore({
+    const initialState = {
       currentPipelineName: 'my_dataset',
       pipelines: {
         my_dataset: [{ name: 'domain', domain: 'my_data' }],
         dataset1: [{ name: 'domain', domain: 'domain1' }],
         dataset2: [{ name: 'domain', domain: 'domain2' }],
       },
-    });
-    const wrapper = shallowMount(AppendStepForm, { store, localVue });
+    };
+    const wrapper = runner.shallowMount(initialState);
     const widgetMultiselect = wrapper.find('multiselectwidget-stub');
     expect(widgetMultiselect.attributes('options')).toEqual('dataset1,dataset2');
   });

--- a/tests/unit/append-step-form.spec.ts
+++ b/tests/unit/append-step-form.spec.ts
@@ -30,15 +30,7 @@ describe('Append Step Form', () => {
     selectedStepIndex: 1,
   });
 
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 
   it('should instantiate a multiselect widget with proper options from the store', () => {
     const initialState = {

--- a/tests/unit/argmax-step-form.spec.ts
+++ b/tests/unit/argmax-step-form.spec.ts
@@ -2,17 +2,11 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import ArgmaxStepForm from '@/components/stepforms/ArgmaxStepForm.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
-
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Argmax Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/argmax-step-form.spec.ts
+++ b/tests/unit/argmax-step-form.spec.ts
@@ -1,19 +1,8 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import ArgmaxStepForm from '@/components/stepforms/ArgmaxStepForm.vue';
-import { setupMockStore, BasicStepFormTestRunner, RootState } from './utils';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { BasicStepFormTestRunner } from './utils';
 
 describe('Argmax Step Form', () => {
-  let emptyStore: Store<RootState>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
-  });
-
-  const runner = new BasicStepFormTestRunner(ArgmaxStepForm, 'argmax', localVue);
+  const runner = new BasicStepFormTestRunner(ArgmaxStepForm, 'argmax');
   runner.testInstantiate();
   runner.testExpectedComponents({
     'columnpicker-stub': 1,
@@ -46,11 +35,11 @@ describe('Argmax Step Form', () => {
   });
 
   it('should pass down the properties to the input components', async () => {
-    const wrapper = shallowMount(ArgmaxStepForm, { store: emptyStore, localVue });
+    const wrapper = runner.shallowMount();
     wrapper.setData({
       editedStep: { name: 'argmax', column: 'foo', groups: ['bar'] },
     });
-    await localVue.nextTick();
+    await wrapper.vm.$nextTick();
     expect(wrapper.find('multiselectwidget-stub').props('value')).toEqual(['bar']);
   });
 });

--- a/tests/unit/argmax-step-form.spec.ts
+++ b/tests/unit/argmax-step-form.spec.ts
@@ -1,9 +1,8 @@
-import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import ArgmaxStepForm from '@/components/stepforms/ArgmaxStepForm.vue';
-import { setupMockStore, RootState, ValidationError } from './utils';
-import { Pipeline } from '@/lib/steps';
+import { setupMockStore, BasicStepFormTestRunner, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -14,18 +13,36 @@ describe('Argmax Step Form', () => {
     emptyStore = setupMockStore({});
   });
 
-  it('should instantiate', () => {
-    const wrapper = shallowMount(ArgmaxStepForm, { store: emptyStore, localVue });
-    expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.vm.$data.stepname).toEqual('argmax');
+  const runner = new BasicStepFormTestRunner(ArgmaxStepForm, 'argmax', localVue);
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'columnpicker-stub': 1,
+    'multiselectwidget-stub': 1,
   });
 
-  it('should have exactly 2 input components', () => {
-    const wrapper = shallowMount(ArgmaxStepForm, { store: emptyStore, localVue });
-    const autocompleteWrappers = wrapper.findAll('columnpicker-stub');
-    const multiselectWrappers = wrapper.findAll('multiselectwidget-stub');
-    expect(autocompleteWrappers.length).toEqual(1);
-    expect(multiselectWrappers.length).toEqual(1);
+  runner.testValidationErrors([
+    {
+      testlabel: 'submitted data is not valid',
+      errors: [{ dataPath: '.column', keyword: 'minLength' }],
+    },
+  ]);
+
+  runner.testValidate({
+    testlabel: 'submitted data is valid',
+    props: {
+      initialStepValue: { name: 'argmax', column: 'foo', groups: ['bar'] },
+    },
+  });
+
+  runner.testCancel();
+  runner.testResetSelectedIndex({
+    pipeline: [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+      { name: 'rename', oldname: 'baz', newname: 'spam' },
+      { name: 'rename', oldname: 'tic', newname: 'tac' },
+    ],
+    selectedStepIndex: 2,
   });
 
   it('should pass down the properties to the input components', async () => {
@@ -35,62 +52,5 @@ describe('Argmax Step Form', () => {
     });
     await localVue.nextTick();
     expect(wrapper.find('multiselectwidget-stub').props('value')).toEqual(['bar']);
-  });
-
-  it('should report errors if column is empty', async () => {
-    const wrapper = mount(ArgmaxStepForm, { store: emptyStore, localVue });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    const errors = wrapper.vm.$data.errors
-      .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
-      .sort((err1: ValidationError, err2: ValidationError) =>
-        err1.dataPath.localeCompare(err2.dataPath),
-      );
-    expect(errors).toEqual([{ keyword: 'minLength', dataPath: '.column' }]);
-  });
-
-  it('should validate and emit "formSaved" when submitted data is valid', async () => {
-    const wrapper = mount(ArgmaxStepForm, {
-      store: emptyStore,
-      localVue,
-      propsData: {
-        initialStepValue: { name: 'argmax', column: 'foo', groups: ['bar'] },
-      },
-    });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.vm.$data.errors).toBeNull();
-    expect(wrapper.emitted()).toEqual({
-      formSaved: [[{ name: 'argmax', column: 'foo', groups: ['bar'] }]],
-    });
-  });
-
-  it('should emit "cancel" event when edition is cancelled', async () => {
-    const wrapper = mount(ArgmaxStepForm, { store: emptyStore, localVue });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.emitted()).toEqual({
-      cancel: [[]],
-    });
-  });
-
-  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'argmax', column: 'foo' },
-      { name: 'argmax', column: 'baz' },
-      { name: 'argmax', column: 'tic' },
-    ];
-    const store = setupMockStore({
-      pipeline,
-      selectedStepIndex: 2,
-    });
-    const wrapper = mount(ArgmaxStepForm, { store, localVue });
-    wrapper.setProps({ isStepCreation: true });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(2);
-    wrapper.setProps({ isStepCreation: false });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(3);
   });
 });

--- a/tests/unit/argmin-step-form.spec.ts
+++ b/tests/unit/argmin-step-form.spec.ts
@@ -1,9 +1,8 @@
-import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import ArgminStepForm from '@/components/stepforms/ArgminStepForm.vue';
-import { setupMockStore, RootState, ValidationError } from './utils';
-import { Pipeline } from '@/lib/steps';
+import { setupMockStore, BasicStepFormTestRunner, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -14,18 +13,36 @@ describe('Argmin Step Form', () => {
     emptyStore = setupMockStore({});
   });
 
-  it('should instantiate', () => {
-    const wrapper = shallowMount(ArgminStepForm, { store: emptyStore, localVue });
-    expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.vm.$data.stepname).toEqual('argmin');
+  const runner = new BasicStepFormTestRunner(ArgminStepForm, 'argmin', localVue);
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'columnpicker-stub': 1,
+    'multiselectwidget-stub': 1,
   });
 
-  it('should have exactly 2 input components', () => {
-    const wrapper = shallowMount(ArgminStepForm, { store: emptyStore, localVue });
-    const autocompleteWrappers = wrapper.findAll('columnpicker-stub');
-    const multiselectWrappers = wrapper.findAll('multiselectwidget-stub');
-    expect(autocompleteWrappers.length).toEqual(1);
-    expect(multiselectWrappers.length).toEqual(1);
+  runner.testValidationErrors([
+    {
+      testlabel: 'submitted data is not valid',
+      errors: [{ dataPath: '.column', keyword: 'minLength' }],
+    },
+  ]);
+
+  runner.testValidate({
+    testlabel: 'submitted data is valid',
+    props: {
+      initialStepValue: { name: 'argmin', column: 'foo', groups: ['bar'] },
+    },
+  });
+
+  runner.testCancel();
+  runner.testResetSelectedIndex({
+    pipeline: [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+      { name: 'rename', oldname: 'baz', newname: 'spam' },
+      { name: 'rename', oldname: 'tic', newname: 'tac' },
+    ],
+    selectedStepIndex: 2,
   });
 
   it('should pass down the properties to the input components', async () => {
@@ -35,62 +52,5 @@ describe('Argmin Step Form', () => {
     });
     await localVue.nextTick();
     expect(wrapper.find('multiselectwidget-stub').props('value')).toEqual(['bar']);
-  });
-
-  it('should report errors if column is empty', async () => {
-    const wrapper = mount(ArgminStepForm, { store: emptyStore, localVue });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    const errors = wrapper.vm.$data.errors
-      .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
-      .sort((err1: ValidationError, err2: ValidationError) =>
-        err1.dataPath.localeCompare(err2.dataPath),
-      );
-    expect(errors).toEqual([{ keyword: 'minLength', dataPath: '.column' }]);
-  });
-
-  it('should validate and emit "formSaved" when submitted data is valid', async () => {
-    const wrapper = mount(ArgminStepForm, {
-      store: emptyStore,
-      localVue,
-      propsData: {
-        initialStepValue: { name: 'argmin', column: 'foo', groups: ['bar'] },
-      },
-    });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.vm.$data.errors).toBeNull();
-    expect(wrapper.emitted()).toEqual({
-      formSaved: [[{ name: 'argmin', column: 'foo', groups: ['bar'] }]],
-    });
-  });
-
-  it('should emit "cancel" event when edition is cancelled', async () => {
-    const wrapper = mount(ArgminStepForm, { store: emptyStore, localVue });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.emitted()).toEqual({
-      cancel: [[]],
-    });
-  });
-
-  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'argmin', column: 'foo' },
-      { name: 'argmin', column: 'baz' },
-      { name: 'argmin', column: 'tic' },
-    ];
-    const store = setupMockStore({
-      pipeline,
-      selectedStepIndex: 2,
-    });
-    const wrapper = mount(ArgminStepForm, { store, localVue });
-    wrapper.setProps({ isStepCreation: true });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(2);
-    wrapper.setProps({ isStepCreation: false });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(3);
   });
 });

--- a/tests/unit/argmin-step-form.spec.ts
+++ b/tests/unit/argmin-step-form.spec.ts
@@ -2,17 +2,11 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import ArgminStepForm from '@/components/stepforms/ArgminStepForm.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
-
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Argmin Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/argmin-step-form.spec.ts
+++ b/tests/unit/argmin-step-form.spec.ts
@@ -24,15 +24,7 @@ describe('Argmin Step Form', () => {
   });
 
   runner.testCancel();
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 
   it('should pass down the properties to the input components', async () => {
     const wrapper = runner.shallowMount();

--- a/tests/unit/argmin-step-form.spec.ts
+++ b/tests/unit/argmin-step-form.spec.ts
@@ -1,19 +1,8 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import ArgminStepForm from '@/components/stepforms/ArgminStepForm.vue';
-import { setupMockStore, BasicStepFormTestRunner, RootState } from './utils';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { BasicStepFormTestRunner } from './utils';
 
 describe('Argmin Step Form', () => {
-  let emptyStore: Store<RootState>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
-  });
-
-  const runner = new BasicStepFormTestRunner(ArgminStepForm, 'argmin', localVue);
+  const runner = new BasicStepFormTestRunner(ArgminStepForm, 'argmin');
   runner.testInstantiate();
   runner.testExpectedComponents({
     'columnpicker-stub': 1,
@@ -46,11 +35,11 @@ describe('Argmin Step Form', () => {
   });
 
   it('should pass down the properties to the input components', async () => {
-    const wrapper = shallowMount(ArgminStepForm, { store: emptyStore, localVue });
+    const wrapper = runner.shallowMount();
     wrapper.setData({
       editedStep: { name: 'argmin', column: 'foo', groups: ['bar'] },
     });
-    await localVue.nextTick();
+    await wrapper.vm.$nextTick();
     expect(wrapper.find('multiselectwidget-stub').props('value')).toEqual(['bar']);
   });
 });

--- a/tests/unit/column-picker.spec.ts
+++ b/tests/unit/column-picker.spec.ts
@@ -6,7 +6,6 @@ import { VQBnamespace } from '@/store';
 
 import { setupMockStore, RootState } from './utils';
 
-
 const localVue = createLocalVue();
 localVue.use(Vuex);
 

--- a/tests/unit/concatenate-step-form.spec.ts
+++ b/tests/unit/concatenate-step-form.spec.ts
@@ -62,15 +62,7 @@ describe('Concatenate Step Form', () => {
     selectedStepIndex: 2,
   });
 
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 
   describe('ListWidget', () => {
     let emptyStore: Store<RootState>;

--- a/tests/unit/concatenate-step-form.spec.ts
+++ b/tests/unit/concatenate-step-form.spec.ts
@@ -9,7 +9,6 @@ const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Concatenate Step Form', () => {
-
   const runner = new BasicStepFormTestRunner(ConcatenateStepForm, 'concatenate', localVue);
   runner.testInstantiate();
   runner.testExpectedComponents({
@@ -32,25 +31,26 @@ describe('Concatenate Step Form', () => {
     },
   ]);
 
-  runner.testValidate(
-    {
-      testlabel: 'submitted data is valid',
-      store: setupMockStore({
-        dataset: {
-          headers: [{ name: 'foo', type: 'string' }, { name: 'bar', type: 'string' }],
-          data: [[null], [null]],
-        },
-      }),
-      props: {
-        initialStepValue: {
-          name: 'concatenate',
-          columns: ['foo', 'bar'],
-          separator: '-',
-          new_column_name: 'new',
-        },
+  runner.testValidate({
+    testlabel: 'submitted data is valid',
+    store: setupMockStore({
+      dataset: {
+        headers: [
+          { name: 'foo', type: 'string' },
+          { name: 'bar', type: 'string' },
+        ],
+        data: [[null], [null]],
       },
-    }
-  );
+    }),
+    props: {
+      initialStepValue: {
+        name: 'concatenate',
+        columns: ['foo', 'bar'],
+        separator: '-',
+        new_column_name: 'new',
+      },
+    },
+  });
 
   runner.testCancel({
     pipeline: [

--- a/tests/unit/concatenate-step-form.spec.ts
+++ b/tests/unit/concatenate-step-form.spec.ts
@@ -2,18 +2,12 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import ConcatenateStepForm from '@/components/stepforms/ConcatenateStepForm.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 
-import { setupMockStore, RootState } from './utils';
-
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Concatenate Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/concatenate-step-form.spec.ts
+++ b/tests/unit/concatenate-step-form.spec.ts
@@ -1,15 +1,9 @@
-import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import ConcatenateStepForm from '@/components/stepforms/ConcatenateStepForm.vue';
-import { setupMockStore, BasicStepFormTestRunner, RootState } from './utils';
+import { setupMockStore, BasicStepFormTestRunner } from './utils';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 
-const localVue = createLocalVue();
-localVue.use(Vuex);
-
 describe('Concatenate Step Form', () => {
-  const runner = new BasicStepFormTestRunner(ConcatenateStepForm, 'concatenate', localVue);
+  const runner = new BasicStepFormTestRunner(ConcatenateStepForm, 'concatenate');
   runner.testInstantiate();
   runner.testExpectedComponents({
     'listwidget-stub': 1,
@@ -65,34 +59,31 @@ describe('Concatenate Step Form', () => {
   runner.testResetSelectedIndex();
 
   describe('ListWidget', () => {
-    let emptyStore: Store<RootState>;
-    beforeEach(() => {
-      emptyStore = setupMockStore({});
-    });
-
     it('should pass down the "toConcatenate" prop to the ListWidget value prop', async () => {
-      const wrapper = shallowMount(ConcatenateStepForm, { store: emptyStore, localVue });
-      wrapper.setData({
-        editedStep: {
-          name: 'concatenate',
-          columns: ['foo', 'bar'],
-          separator: '-',
-          new_column_name: 'new',
+      const wrapper = runner.shallowMount(
+        {},
+        {
+          data: {
+            editedStep: {
+              name: 'concatenate',
+              columns: ['foo', 'bar'],
+              separator: '-',
+              new_column_name: 'new',
+            },
+          },
         },
-      });
-      await localVue.nextTick();
+      );
+      await wrapper.vm.$nextTick();
       expect(wrapper.find('listwidget-stub').props().value).toEqual(['foo', 'bar']);
     });
   });
 
   it('should not sync selected columns on edition', async () => {
-    const store = setupMockStore({
+    const initialState = {
       selectedStepIndex: 1,
       selectedColumns: ['spam'],
-    });
-    const wrapper = mount(ConcatenateStepForm, {
-      store,
-      localVue,
+    };
+    const wrapper = runner.mount(initialState, {
       propsData: {
         initialStepValue: {
           name: 'concatenate',
@@ -103,8 +94,8 @@ describe('Concatenate Step Form', () => {
         isStepCreation: false,
       },
     });
-    await localVue.nextTick();
-    expect(store.state.vqb.selectedStepIndex).toEqual(1);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.$store.state.vqb.selectedStepIndex).toEqual(1);
     const columnPickers = wrapper.findAll(ColumnPicker);
     expect(columnPickers.length).toEqual(2);
     const [picker1, picker2] = columnPickers.wrappers;

--- a/tests/unit/dataset.spec.ts
+++ b/tests/unit/dataset.spec.ts
@@ -32,18 +32,27 @@ describe('_sortDataset tests', () => {
   it('should be able to leave as is sorted results', () => {
     const dataset: DataSet = {
       headers: [{ name: 'col1' }, { name: 'col2' }, { name: 'col3' }],
-      data: [[1, 2, 3], [4, 5, 6]],
+      data: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
       paginationContext: { pageno: 1, pagesize: 50, totalCount: 2 },
     };
     const sorted = _sortDataset(dataset);
     expect(sorted.headers).toEqual([{ name: 'col1' }, { name: 'col2' }, { name: 'col3' }]);
-    expect(sorted.data).toEqual([[1, 2, 3], [4, 5, 6]]);
+    expect(sorted.data).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
   });
 
   it('should be able to sort results', () => {
     const dataset: DataSet = {
       headers: [{ name: 'col3' }, { name: 'col1' }, { name: 'col4' }, { name: 'col2' }],
-      data: [[1, 2, 3, 4], [5, 6, 7, 8]],
+      data: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ],
       paginationContext: { pageno: 1, pagesize: 50, totalCount: 2 },
     };
     const sorted = _sortDataset(dataset);
@@ -53,7 +62,10 @@ describe('_sortDataset tests', () => {
       { name: 'col3' },
       { name: 'col4' },
     ]);
-    expect(sorted.data).toEqual([[2, 4, 1, 3], [6, 8, 5, 7]]);
+    expect(sorted.data).toEqual([
+      [2, 4, 1, 3],
+      [6, 8, 5, 7],
+    ]);
   });
 });
 
@@ -72,7 +84,10 @@ describe('Dataset helper tests', () => {
     ];
     const dataset = _sortDataset(mongoResultsToDataset(mongoResults));
     expect(dataset.headers).toEqual([{ name: 'col1' }, { name: 'col2' }, { name: 'col3' }]);
-    expect(dataset.data).toEqual([['foo', 42, true], ['bar', 7, false]]);
+    expect(dataset.data).toEqual([
+      ['foo', 42, true],
+      ['bar', 7, false],
+    ]);
   });
 
   it('should be able to convert heterogeneous mongo results', () => {
@@ -87,7 +102,10 @@ describe('Dataset helper tests', () => {
       { name: 'col3' },
       { name: 'col4' },
     ]);
-    expect(dataset.data).toEqual([['foo', null, true, null], ['bar', 7, null, '?']]);
+    expect(dataset.data).toEqual([
+      ['foo', null, true, null],
+      ['bar', 7, null, '?'],
+    ]);
   });
 });
 
@@ -246,7 +264,10 @@ describe('inferTypeFromDataset', () => {
   it("should infer type on column with null values if there's other values in the column", () => {
     const dataset: DataSet = {
       headers: [{ name: 'city' }, { name: 'population' }, { name: 'isCapitalCity' }],
-      data: [['Paris', 10000000, null], ['Paris', 10000000, false]],
+      data: [
+        ['Paris', 10000000, null],
+        ['Paris', 10000000, false],
+      ],
       paginationContext: { pageno: 1, pagesize: 50, totalCount: 2 },
     };
 
@@ -291,7 +312,11 @@ describe('inferTypeFromDataset', () => {
   it('should not infer a float type for mixed integer and float values', () => {
     const dataset: DataSet = {
       headers: [{ name: 'city' }, { name: 'density' }, { name: 'isCapitalCity' }],
-      data: [['Paris', 61.7, true], ['Marseille', 40, false], ['Berlin', 41.5, true]],
+      data: [
+        ['Paris', 61.7, true],
+        ['Marseille', 40, false],
+        ['Berlin', 41.5, true],
+      ],
       paginationContext: { pageno: 1, pagesize: 50, totalCount: 1 },
     };
 

--- a/tests/unit/delete-column-step-form.spec.ts
+++ b/tests/unit/delete-column-step-form.spec.ts
@@ -1,15 +1,9 @@
-import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex from 'vuex';
-
 import DeleteColumnStepForm from '@/components/stepforms/DeleteColumnStepForm.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
-import { setupMockStore, BasicStepFormTestRunner } from './utils';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { BasicStepFormTestRunner } from './utils';
 
 describe('Delete Column Step Form', () => {
-  const runner = new BasicStepFormTestRunner(DeleteColumnStepForm, 'delete', localVue);
+  const runner = new BasicStepFormTestRunner(DeleteColumnStepForm, 'delete');
   runner.testInstantiate();
   runner.testExpectedComponents({
     'multiselectwidget-stub': 1,
@@ -47,38 +41,36 @@ describe('Delete Column Step Form', () => {
   });
 
   it('should instantiate a multiselect widget with proper options from the store', () => {
-    const store = setupMockStore({
+    const initialState = {
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
       },
-    });
-    const wrapper = shallowMount(DeleteColumnStepForm, { store, localVue });
+    };
+    const wrapper = runner.shallowMount(initialState);
     const widgetAutocomplete = wrapper.find('multiselectwidget-stub');
 
     expect(widgetAutocomplete.attributes('options')).toEqual('columnA,columnB,columnC');
   });
 
   it('should update selectedColumn when column is changed', async () => {
-    const store = setupMockStore({
+    const initialState = {
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
       },
       selectedColumns: ['columnA'],
-    });
-    const wrapper = mount(DeleteColumnStepForm, {
+    };
+    const wrapper = runner.mount(initialState, {
       propsData: {
         initialValue: {
           columns: ['columnA'],
         },
       },
-      store,
-      localVue,
+      data: { editedStep: { columns: ['columnB'] } },
     });
-    wrapper.setData({ editedStep: { columns: ['columnB'] } });
     wrapper.find(MultiselectWidget).trigger('input');
     await wrapper.vm.$nextTick();
-    expect(store.state.vqb.selectedColumns).toEqual(['columnB']);
+    expect(wrapper.vm.$store.state.vqb.selectedColumns).toEqual(['columnB']);
   });
 });

--- a/tests/unit/delete-column-step-form.spec.ts
+++ b/tests/unit/delete-column-step-form.spec.ts
@@ -30,15 +30,7 @@ describe('Delete Column Step Form', () => {
     selectedStepIndex: 1,
   });
 
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 
   it('should instantiate a multiselect widget with proper options from the store', () => {
     const initialState = {

--- a/tests/unit/delete-column-step-form.spec.ts
+++ b/tests/unit/delete-column-step-form.spec.ts
@@ -3,17 +3,11 @@ import Vuex, { Store } from 'vuex';
 
 import DeleteColumnStepForm from '@/components/stepforms/DeleteColumnStepForm.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
-
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Delete Column Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/delete-column-step-form.spec.ts
+++ b/tests/unit/delete-column-step-form.spec.ts
@@ -1,30 +1,49 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
+import Vuex from 'vuex';
 
 import DeleteColumnStepForm from '@/components/stepforms/DeleteColumnStepForm.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
-import { setupMockStore, RootState, ValidationError } from './utils';
-import { Pipeline } from '@/lib/steps';
+import { setupMockStore, BasicStepFormTestRunner } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Delete Column Step Form', () => {
-  let emptyStore: Store<RootState>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
+  const runner = new BasicStepFormTestRunner(DeleteColumnStepForm, 'delete', localVue);
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'multiselectwidget-stub': 1,
+  });
+  runner.testValidationErrors([
+    {
+      testlabel: 'submitted data is not valid',
+      errors: [{ dataPath: '.columns', keyword: 'minItems' }],
+    },
+  ]);
+
+  runner.testValidate({
+    testlabel: 'submitted data is valid',
+    props: {
+      initialStepValue: { name: 'delete', columns: ['foo'] },
+    },
   });
 
-  it('should instantiate', () => {
-    const wrapper = shallowMount(DeleteColumnStepForm, { store: emptyStore, localVue });
-    expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.vm.$data.stepname).toEqual('delete');
+  runner.testCancel({
+    pipeline: [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+    ],
+    selectedStepIndex: 1,
   });
 
-  it('should have a widget multiselect', () => {
-    const wrapper = shallowMount(DeleteColumnStepForm, { store: emptyStore, localVue });
-
-    expect(wrapper.find('multiselectwidget-stub').exists()).toBeTruthy();
+  runner.testResetSelectedIndex({
+    pipeline: [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+      { name: 'rename', oldname: 'baz', newname: 'spam' },
+      { name: 'rename', oldname: 'tic', newname: 'tac' },
+    ],
+    selectedStepIndex: 2,
   });
 
   it('should instantiate a multiselect widget with proper options from the store', () => {
@@ -38,51 +57,6 @@ describe('Delete Column Step Form', () => {
     const widgetAutocomplete = wrapper.find('multiselectwidget-stub');
 
     expect(widgetAutocomplete.attributes('options')).toEqual('columnA,columnB,columnC');
-  });
-
-  it('should report errors when submitted data is not valid', () => {
-    const wrapper = mount(DeleteColumnStepForm, { store: emptyStore, localVue });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
-      keyword: err.keyword,
-      dataPath: err.dataPath,
-    }));
-    expect(errors).toEqual([{ keyword: 'minItems', dataPath: '.columns' }]);
-  });
-
-  it('should validate and emit "formSaved" when submitted data is valid', () => {
-    const wrapper = mount(DeleteColumnStepForm, {
-      store: emptyStore,
-      localVue,
-      propsData: {
-        initialStepValue: { name: 'delete', columns: ['foo'] },
-      },
-    });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    expect(wrapper.vm.$data.errors).toBeNull();
-    expect(wrapper.emitted()).toEqual({
-      formSaved: [[{ name: 'delete', columns: ['foo'] }]],
-    });
-  });
-
-  it('should emit "cancel" event when edition is canceled', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-    ];
-    const store = setupMockStore({
-      pipeline,
-      selectedStepIndex: 1,
-    });
-
-    const wrapper = mount(DeleteColumnStepForm, { store, localVue });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(wrapper.emitted()).toEqual({ cancel: [[]] });
-    expect(store.state.vqb.selectedStepIndex).toEqual(1);
-    expect(store.state.vqb.pipeline).toEqual([
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-    ]);
   });
 
   it('should update selectedColumn when column is changed', async () => {
@@ -103,27 +77,8 @@ describe('Delete Column Step Form', () => {
       localVue,
     });
     wrapper.setData({ editedStep: { columns: ['columnB'] } });
-    await wrapper.find(MultiselectWidget).trigger('input');
+    wrapper.find(MultiselectWidget).trigger('input');
+    await wrapper.vm.$nextTick();
     expect(store.state.vqb.selectedColumns).toEqual(['columnB']);
-  });
-
-  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ];
-    const store = setupMockStore({
-      pipeline,
-      selectedStepIndex: 2,
-    });
-    const wrapper = mount(DeleteColumnStepForm, { store, localVue });
-    wrapper.setProps({ isStepCreation: true });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(2);
-    wrapper.setProps({ isStepCreation: false });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(3);
   });
 });

--- a/tests/unit/domain-step-form.spec.ts
+++ b/tests/unit/domain-step-form.spec.ts
@@ -1,15 +1,9 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex from 'vuex';
-
 import DomainStepForm from '@/components/stepforms/DomainStepForm.vue';
 
-import { setupMockStore, BasicStepFormTestRunner } from './utils';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { BasicStepFormTestRunner } from './utils';
 
 describe('Domain Step Form', () => {
-  const runner = new BasicStepFormTestRunner(DomainStepForm, 'domain', localVue);
+  const runner = new BasicStepFormTestRunner(DomainStepForm, 'domain');
   runner.testInstantiate();
   runner.testExpectedComponents({
     'autocompletewidget-stub': 1,
@@ -32,10 +26,7 @@ describe('Domain Step Form', () => {
   runner.testCancel();
 
   it('should instantiate an autocomplete widget with proper options from the store', () => {
-    const store = setupMockStore({
-      domains: ['foo', 'bar'],
-    });
-    const wrapper = shallowMount(DomainStepForm, { store, localVue });
+    const wrapper = runner.shallowMount({ domains: ['foo', 'bar'] });
     const widgetAutocomplete = wrapper.find('autocompletewidget-stub');
 
     expect(widgetAutocomplete.attributes('options')).toEqual('foo,bar');

--- a/tests/unit/domain-step-form.spec.ts
+++ b/tests/unit/domain-step-form.spec.ts
@@ -8,11 +8,6 @@ import { setupMockStore, RootState } from './utils';
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
-
 describe('Domain Step Form', () => {
   let emptyStore: Store<RootState>;
   beforeEach(() => {

--- a/tests/unit/domain-step-form.spec.ts
+++ b/tests/unit/domain-step-form.spec.ts
@@ -3,7 +3,7 @@ import Vuex, { Store } from 'vuex';
 
 import DomainStepForm from '@/components/stepforms/DomainStepForm.vue';
 
-import { setupMockStore, RootState } from './utils';
+import { setupMockStore, RootState, ValidationError } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/duplicate-column-step-form.spec.ts
+++ b/tests/unit/duplicate-column-step-form.spec.ts
@@ -27,18 +27,14 @@ describe('Duplicate Column Step Form', () => {
         },
       }),
       data: { editedStep: { name: 'duplicate', column: 'foo', new_column_name: 'columnA' } },
-      errors: [
-        { keyword: 'columnNameAlreadyUsed', dataPath: '.new_column_name' },
-      ]
+      errors: [{ keyword: 'columnNameAlreadyUsed', dataPath: '.new_column_name' }],
     },
   ]);
 
-  runner.testValidate(
-    {
-      testlabel: 'submitted data is valid',
-      props: { initialStepValue: { name: 'duplicate', column: 'foo', new_column_name: 'bar' } },
-    }
-  );
+  runner.testValidate({
+    testlabel: 'submitted data is valid',
+    props: { initialStepValue: { name: 'duplicate', column: 'foo', new_column_name: 'bar' } },
+  });
 
   runner.testCancel({
     pipeline: [
@@ -56,5 +52,5 @@ describe('Duplicate Column Step Form', () => {
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ],
     selectedStepIndex: 2,
-  })
+  });
 });

--- a/tests/unit/duplicate-column-step-form.spec.ts
+++ b/tests/unit/duplicate-column-step-form.spec.ts
@@ -2,17 +2,11 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import DuplicateColumnStepForm from '@/components/stepforms/DuplicateColumnStepForm.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
-
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Duplicate Column Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/duplicate-column-step-form.spec.ts
+++ b/tests/unit/duplicate-column-step-form.spec.ts
@@ -44,13 +44,5 @@ describe('Duplicate Column Step Form', () => {
     selectedStepIndex: 1,
   });
 
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 });

--- a/tests/unit/duplicate-column-step-form.spec.ts
+++ b/tests/unit/duplicate-column-step-form.spec.ts
@@ -1,125 +1,67 @@
-import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
+import { createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
 
 import DuplicateColumnStepForm from '@/components/stepforms/DuplicateColumnStepForm.vue';
-import { setupMockStore, RootState, ValidationError } from './utils';
-import { Pipeline } from '@/lib/steps';
+import { setupMockStore, BasicStepFormTestRunner } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Duplicate Column Step Form', () => {
-  let emptyStore: Store<RootState>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
+
+  const runner = new BasicStepFormTestRunner(DuplicateColumnStepForm, 'duplicate', localVue);
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'columnpicker-stub': 1,
+    'inputtextwidget-stub': 1,
   });
 
-  it('should instantiate', () => {
-    const wrapper = shallowMount(DuplicateColumnStepForm, { store: emptyStore, localVue });
-
-    expect(wrapper.exists()).toBeTruthy();
-  });
-
-  it('should have exactly 2 input components', () => {
-    const wrapper = shallowMount(DuplicateColumnStepForm, { store: emptyStore, localVue });
-
-    expect(wrapper.findAll('columnpicker-stub').length).toEqual(1);
-    expect(wrapper.findAll('inputtextwidget-stub').length).toEqual(1);
-  });
-
-  describe('Errors', () => {
-    it('should report errors when submitted data is not valid', () => {
-      const wrapper = mount(DuplicateColumnStepForm, {
-        store: emptyStore,
-        localVue,
-        propsData: {
-          initialStepValue: { name: 'duplicate', column: '', new_column_name: '' },
-        },
-      });
-      wrapper.find('.widget-form-action__button--validate').trigger('click');
-      const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
-        keyword: err.keyword,
-        dataPath: err.dataPath,
-      }));
-      expect(errors).toEqual([
+  runner.testValidationErrors([
+    {
+      testlabel: 'no submitted data',
+      props: { initialStepValue: { name: 'duplicate', column: '', new_column_name: '' } },
+      errors: [
         { keyword: 'minLength', dataPath: '.column' },
         { keyword: 'minLength', dataPath: '.new_column_name' },
-      ]);
-    });
-  });
+      ],
+    },
+    {
+      testlabel: 'existing column name',
+      store: setupMockStore({
+        dataset: {
+          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+          data: [],
+        },
+      }),
+      data: { editedStep: { name: 'duplicate', column: 'foo', new_column_name: 'columnA' } },
+      errors: [
+        { keyword: 'columnNameAlreadyUsed', dataPath: '.new_column_name' },
+      ]
+    },
+  ]);
 
-  it('should report errors when new_column_name is an already existing column name', async () => {
-    const store = setupMockStore({
-      dataset: {
-        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-        data: [],
-      },
-    });
-    const wrapper = mount(DuplicateColumnStepForm, { store, localVue });
-    wrapper.setData({
-      editedStep: { name: 'duplicate', column: 'foo', new_column_name: 'columnA' },
-    });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
-      keyword: err.keyword,
-      dataPath: err.dataPath,
-    }));
-    expect(errors).toEqual([{ keyword: 'columnNameAlreadyUsed', dataPath: '.new_column_name' }]);
-  });
+  runner.testValidate(
+    {
+      testlabel: 'submitted data is valid',
+      props: { initialStepValue: { name: 'duplicate', column: 'foo', new_column_name: 'bar' } },
+    }
+  );
 
-  it('should validate and emit "formSaved" when submitted data is valid', () => {
-    const wrapper = mount(DuplicateColumnStepForm, {
-      store: emptyStore,
-      localVue,
-      propsData: {
-        initialStepValue: { name: 'duplicate', column: 'foo', new_column_name: 'bar' },
-      },
-    });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    expect(wrapper.vm.$data.errors).toBeNull();
-    expect(wrapper.emitted()).toEqual({
-      formSaved: [[{ name: 'duplicate', column: 'foo', new_column_name: 'bar' }]],
-    });
-  });
-
-  it('should emit "cancel" event when edition is canceled', () => {
-    const pipeline: Pipeline = [
+  runner.testCancel({
+    pipeline: [
       { name: 'domain', domain: 'foo' },
       { name: 'rename', oldname: 'foo', newname: 'bar' },
-    ];
-    const store = setupMockStore({
-      pipeline,
-      selectedStepIndex: 1,
-    });
-
-    const wrapper = mount(DuplicateColumnStepForm, { store, localVue });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(wrapper.emitted()).toEqual({ cancel: [[]] });
-    expect(store.state.vqb.selectedStepIndex).toEqual(1);
-    expect(store.state.vqb.pipeline).toEqual([
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-    ]);
+    ],
+    selectedStepIndex: 1,
   });
 
-  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
-    const pipeline: Pipeline = [
+  runner.testResetSelectedIndex({
+    pipeline: [
       { name: 'domain', domain: 'foo' },
       { name: 'rename', oldname: 'foo', newname: 'bar' },
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ];
-    const store = setupMockStore({
-      pipeline,
-      selectedStepIndex: 2,
-    });
-    const wrapper = mount(DuplicateColumnStepForm, { store, localVue });
-    wrapper.setProps({ isStepCreation: true });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(2);
-    wrapper.setProps({ isStepCreation: false });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(3);
-  });
+    ],
+    selectedStepIndex: 2,
+  })
 });

--- a/tests/unit/duplicate-column-step-form.spec.ts
+++ b/tests/unit/duplicate-column-step-form.spec.ts
@@ -1,15 +1,8 @@
-import { createLocalVue } from '@vue/test-utils';
-import Vuex from 'vuex';
-
 import DuplicateColumnStepForm from '@/components/stepforms/DuplicateColumnStepForm.vue';
 import { setupMockStore, BasicStepFormTestRunner } from './utils';
 
-const localVue = createLocalVue();
-localVue.use(Vuex);
-
 describe('Duplicate Column Step Form', () => {
-
-  const runner = new BasicStepFormTestRunner(DuplicateColumnStepForm, 'duplicate', localVue);
+  const runner = new BasicStepFormTestRunner(DuplicateColumnStepForm, 'duplicate');
   runner.testInstantiate();
   runner.testExpectedComponents({
     'columnpicker-stub': 1,

--- a/tests/unit/fillna-step-form.spec.ts
+++ b/tests/unit/fillna-step-form.spec.ts
@@ -2,18 +2,12 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import FillnaStepForm from '@/components/stepforms/FillnaStepForm.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
 import { VQBnamespace } from '@/store';
 
-import { setupMockStore, RootState } from './utils';
-
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Fillna Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/fillna-step-form.spec.ts
+++ b/tests/unit/fillna-step-form.spec.ts
@@ -40,16 +40,7 @@ describe('Fillna Step Form', () => {
   });
 
   runner.testCancel();
-
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 
   it('should pass down the value prop to widget value prop', async () => {
     const wrapper = runner.shallowMount();

--- a/tests/unit/filter-step-form.spec.ts
+++ b/tests/unit/filter-step-form.spec.ts
@@ -47,16 +47,7 @@ describe('Filter Step Form', () => {
   });
 
   runner.testCancel();
-
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 
   it('should get a specific class when there is more than one condition to filter-form container', async () => {
     const wrapper = runner.shallowMount(

--- a/tests/unit/filter-step-form.spec.ts
+++ b/tests/unit/filter-step-form.spec.ts
@@ -2,17 +2,11 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import FilterStepForm from '@/components/stepforms/FilterStepForm.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
-
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Filter Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/formula-step-form.spec.ts
+++ b/tests/unit/formula-step-form.spec.ts
@@ -2,17 +2,11 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import FormulaStepForm from '@/components/stepforms/FormulaStepForm.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
-
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Formula Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/formula-step-form.spec.ts
+++ b/tests/unit/formula-step-form.spec.ts
@@ -25,16 +25,7 @@ describe('Formula Step Form', () => {
   });
 
   runner.testCancel();
-
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 
   it('should pass down properties', async () => {
     const wrapper = runner.shallowMount(

--- a/tests/unit/formula-step-form.spec.ts
+++ b/tests/unit/formula-step-form.spec.ts
@@ -1,35 +1,49 @@
-import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import FormulaStepForm from '@/components/stepforms/FormulaStepForm.vue';
-import { setupMockStore, RootState, ValidationError } from './utils';
-import { Pipeline } from '@/lib/steps';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { BasicStepFormTestRunner } from './utils';
 
 describe('Formula Step Form', () => {
-  let emptyStore: Store<RootState>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
+  const runner = new BasicStepFormTestRunner(FormulaStepForm, 'formula');
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'inputtextwidget-stub': 2,
+  });
+  runner.testValidationErrors([
+    {
+      testlabel: 'submitted data is not valid',
+      errors: [
+        { keyword: 'minLength', dataPath: '.formula' },
+        { keyword: 'minLength', dataPath: '.new_column' },
+      ],
+    },
+  ]);
+
+  runner.testValidate({
+    testlabel: 'submitted data is valid',
+    props: {
+      initialStepValue: { name: 'formula', formula: 'ColumnA * 2', new_column: 'foo' },
+    },
   });
 
-  it('should instantiate', () => {
-    const wrapper = shallowMount(FormulaStepForm, { store: emptyStore, localVue });
-    expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.vm.$data.stepname).toEqual('formula');
-  });
+  runner.testCancel();
 
-  it('should have exactly 2 widgetinputtext component', () => {
-    const wrapper = shallowMount(FormulaStepForm, { store: emptyStore, localVue });
-    const inputWrappers = wrapper.findAll('inputtextwidget-stub');
-    expect(inputWrappers.length).toEqual(2);
+  runner.testResetSelectedIndex({
+    pipeline: [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+      { name: 'rename', oldname: 'baz', newname: 'spam' },
+      { name: 'rename', oldname: 'tic', newname: 'tac' },
+    ],
+    selectedStepIndex: 2,
   });
 
   it('should pass down properties', async () => {
-    const wrapper = shallowMount(FormulaStepForm, { store: emptyStore, localVue });
-    wrapper.setData({ editedStep: { name: 'formula', formula: 'ColumnA * 2', new_column: 'foo' } });
-    await localVue.nextTick();
+    const wrapper = runner.shallowMount(
+      {},
+      {
+        data: { editedStep: { name: 'formula', formula: 'ColumnA * 2', new_column: 'foo' } },
+      },
+    );
+    await wrapper.vm.$nextTick();
     expect(
       wrapper
         .findAll('inputtextwidget-stub')
@@ -44,34 +58,18 @@ describe('Formula Step Form', () => {
     ).toEqual('foo');
   });
 
-  describe('Errors', () => {
-    it('should report errors when oldname or newname is empty', async () => {
-      const wrapper = mount(FormulaStepForm, { store: emptyStore, localVue });
-      wrapper.find('.widget-form-action__button--validate').trigger('click');
-      await localVue.nextTick();
-      const errors = wrapper.vm.$data.errors
-        .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
-        .sort((err1: ValidationError, err2: ValidationError) =>
-          err1.dataPath.localeCompare(err2.dataPath),
-        );
-      expect(errors).toEqual([
-        { keyword: 'minLength', dataPath: '.formula' },
-        { keyword: 'minLength', dataPath: '.new_column' },
-      ]);
-    });
-  });
-
   describe('Warning', () => {
     it('should report a warning when new_column is an already existing column name', async () => {
-      const store = setupMockStore({
+      const initialState = {
         dataset: {
           headers: [{ name: 'columnA' }],
           data: [],
         },
+      };
+      const wrapper = runner.shallowMount(initialState, {
+        data: { editedStep: { formula: '', new_column: 'columnA' } },
       });
-      const wrapper = shallowMount(FormulaStepForm, { store, localVue });
-      wrapper.setData({ editedStep: { formula: '', new_column: 'columnA' } });
-      await localVue.nextTick();
+      await wrapper.vm.$nextTick();
       const inputText = wrapper.findAll('inputtextwidget-stub');
       expect(inputText.at(1).props().warning).toEqual(
         'A column name "columnA" already exists. You will overwrite it.',
@@ -79,75 +77,32 @@ describe('Formula Step Form', () => {
     });
 
     it('should not report any warning if new_column is not an already existing column name', async () => {
-      const store = setupMockStore({
+      const initialState = {
         dataset: {
           headers: [{ name: 'columnA' }],
           data: [],
         },
+      };
+      const wrapper = runner.shallowMount(initialState, {
+        data: { editedStep: { formula: '', new_column: 'columnB' } },
       });
-      const wrapper = shallowMount(FormulaStepForm, { store, localVue });
-      wrapper.setData({ editedStep: { formula: '', new_column: 'columnB' } });
-      await localVue.nextTick();
+      await wrapper.vm.$nextTick();
       const inputText = wrapper.findAll('inputtextwidget-stub');
       expect(inputText.at(1).props().warning).toBeNull();
     });
   });
 
-  it('should validate and emit "formSaved" when submitted data is valid', async () => {
-    const wrapper = mount(FormulaStepForm, {
-      store: emptyStore,
-      localVue,
-      propsData: {
-        initialStepValue: { name: 'formula', formula: 'ColumnA * 2', new_column: 'foo' },
-      },
-    });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.vm.$data.errors).toBeNull();
-    expect(wrapper.emitted()).toEqual({
-      formSaved: [[{ name: 'formula', formula: 'ColumnA * 2', new_column: 'foo' }]],
-    });
-  });
-
-  it('should emit "cancel" event when edition is cancelled', async () => {
-    const wrapper = mount(FormulaStepForm, { store: emptyStore, localVue });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.emitted()).toEqual({
-      cancel: [[]],
-    });
-  });
-
-  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ];
-    const store = setupMockStore({
-      pipeline,
-      selectedStepIndex: 2,
-    });
-    const wrapper = mount(FormulaStepForm, { store, localVue });
-    wrapper.setProps({ isStepCreation: true });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(2);
-    wrapper.setProps({ isStepCreation: false });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(3);
-  });
-
   it('should make the focus on the column modified after validation', () => {
-    const store = setupMockStore({
+    const initialState = {
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
       },
+    };
+    const wrapper = runner.mount(initialState, {
+      data: { editedStep: { name: 'formula', formula: 'ColumnA * 2', new_column: 'foo' } },
     });
-    const wrapper = mount(FormulaStepForm, { store, localVue });
-    wrapper.setData({ editedStep: { name: 'formula', formula: 'ColumnA * 2', new_column: 'foo' } });
     wrapper.find('.widget-form-action__button--validate').trigger('click');
-    expect(store.state.vqb.selectedColumns).toEqual(['foo']);
+    expect(wrapper.vm.$store.state.vqb.selectedColumns).toEqual(['foo']);
   });
 });

--- a/tests/unit/fromdate-step-form.spec.ts
+++ b/tests/unit/fromdate-step-form.spec.ts
@@ -1,43 +1,24 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import FromDateStepForm from '@/components/stepforms/FromDateStepForm.vue';
 
-import { setupMockStore } from './utils';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { BasicStepFormTestRunner } from './utils';
 
 describe('Convert Date to String Step Form', () => {
-  let emptyStore: Store<any>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
-  });
-
-  it('should instantiate', () => {
-    const wrapper = shallowMount(FromDateStepForm, { store: emptyStore, localVue });
-    expect(wrapper.exists()).toBeTruthy();
-  });
-
-  it('should have exactly 2 input component', () => {
-    const wrapper = shallowMount(FromDateStepForm, { store: emptyStore, localVue });
-    expect(wrapper.findAll('columnpicker-stub').length).toEqual(1);
-    expect(wrapper.findAll('inputtextwidget-stub').length).toEqual(1);
+  const runner = new BasicStepFormTestRunner(FromDateStepForm, 'fromdate');
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'columnpicker-stub': 1,
+    'inputtextwidget-stub': 1,
   });
 
   it('should update editedStep with the selected column at creation', () => {
-    const store = setupMockStore({
+    const initialState = {
       dataset: {
         headers: [{ name: 'foo', type: 'string' }],
         data: [[null]],
       },
       selectedColumns: ['foo'],
-    });
-    const wrapper = shallowMount(FromDateStepForm, {
-      store,
-      localVue,
-      sync: false,
-    });
+    };
+    const wrapper = runner.shallowMount(initialState);
     expect(wrapper.vm.$data.editedStep.column).toEqual('foo');
   });
 });

--- a/tests/unit/join-step-form.spec.ts
+++ b/tests/unit/join-step-form.spec.ts
@@ -10,16 +10,7 @@ describe('join Step Form', () => {
   });
 
   runner.testCancel();
-
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 
   describe('ListWidget', () => {
     it('should instantiate an autocomplete widget with proper options from the store', () => {

--- a/tests/unit/pagination-component.spec.ts
+++ b/tests/unit/pagination-component.spec.ts
@@ -34,7 +34,10 @@ describe('Pagination Component', () => {
     const store = setupMockStore({
       dataset: {
         headers: [{ name: 'city' }, { name: 'population' }, { name: 'isCapitalCity' }],
-        data: [['Paris', 10000000, true], ['Marseille', 3000000, false]],
+        data: [
+          ['Paris', 10000000, true],
+          ['Marseille', 3000000, false],
+        ],
         paginationContext: {
           totalCount: 7,
           pageno: 1,
@@ -64,7 +67,10 @@ describe('Pagination Component', () => {
         pipeline: [{ name: 'domain', domain: 'foo' }],
         dataset: {
           headers: [{ name: 'city' }, { name: 'population' }, { name: 'isCapitalCity' }],
-          data: [['Paris', 10000000, true], ['Marseille', 3000000, false]],
+          data: [
+            ['Paris', 10000000, true],
+            ['Marseille', 3000000, false],
+          ],
           paginationContext: {
             totalCount: 7,
             pageno: 1,
@@ -88,7 +94,10 @@ describe('Pagination Component', () => {
     const store = setupMockStore({
       dataset: {
         headers: [{ name: 'city' }, { name: 'population' }, { name: 'isCapitalCity' }],
-        data: [['Paris', 10000000, true], ['Marseille', 3000000, false]],
+        data: [
+          ['Paris', 10000000, true],
+          ['Marseille', 3000000, false],
+        ],
         paginationContext: {
           totalCount: 7,
           pageno: 1,

--- a/tests/unit/percentage-step-form.spec.ts
+++ b/tests/unit/percentage-step-form.spec.ts
@@ -3,17 +3,11 @@ import Vuex, { Store } from 'vuex';
 
 import PercentageStepForm from '@/components/stepforms/PercentageStepForm.vue';
 import { VQBnamespace } from '@/store';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
-
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Percentage Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/pivot-step-form.spec.ts
+++ b/tests/unit/pivot-step-form.spec.ts
@@ -1,160 +1,46 @@
-import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import PivotStepForm from '@/components/stepforms/PivotStepForm.vue';
 import { VQBnamespace } from '@/store';
 
-import { setupMockStore, RootState, ValidationError } from './utils';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { setupMockStore, BasicStepFormTestRunner } from './utils';
 
 describe('Pivot Step Form', () => {
-  let emptyStore: Store<RootState>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
+  const runner = new BasicStepFormTestRunner(PivotStepForm, 'pivot');
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'multiselectwidget-stub': 1,
+    'columnpicker-stub': 1,
+    'autocompletewidget-stub': 2,
   });
-
-  it('should instantiate', () => {
-    const wrapper = shallowMount(PivotStepForm, { store: emptyStore, localVue });
-    expect(wrapper.exists()).toBeTruthy();
-  });
-
-  it('should have 4 input components', () => {
-    const wrapper = shallowMount(PivotStepForm, { store: emptyStore, localVue });
-    const multiselectWrappers = wrapper.findAll('multiselectwidget-stub');
-    const columnpickerWrappers = wrapper.findAll('columnpicker-stub');
-    const autocompleteWrappers = wrapper.findAll('autocompletewidget-stub');
-    expect(multiselectWrappers.length).toEqual(1);
-    expect(columnpickerWrappers.length).toEqual(1);
-    expect(autocompleteWrappers.length).toEqual(2);
-  });
-
-  it('should pass down props to widgets', () => {
-    const wrapper = shallowMount(PivotStepForm, {
-      store: emptyStore,
-      localVue,
-      data: () => {
-        return {
-          editedStep: {
-            name: 'pivot',
-            index: ['label'],
-            column_to_pivot: 'country',
-            value_column: 'value',
-            agg_function: 'sum',
-          },
-        };
+  runner.testValidate({
+    testlabel: 'submitted data is valid',
+    props: {
+      initialStepValue: {
+        name: 'pivot',
+        index: ['columnA', 'columnB'],
+        column_to_pivot: 'foo',
+        value_column: 'bar',
+        agg_function: 'sum',
       },
-    });
-    expect(wrapper.find('#indexInput').props('value')).toEqual(['label']);
-    expect(wrapper.find('#valueColumnInput').props('value')).toEqual('value');
-    expect(wrapper.find('#aggregationFunctionInput').props('value')).toEqual('sum');
+    },
   });
-
-  it('should instantiate indexInput widget multiselect with column names', () => {
-    const store = setupMockStore({
-      dataset: {
-        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-        data: [],
-      },
-    });
-    const wrapper = shallowMount(PivotStepForm, { store, localVue });
-    expect(wrapper.find('#indexInput').attributes('options')).toEqual('columnA,columnB,columnC');
-  });
-
-  it('should instantiate valueColumnInput widget autocomplete with column names', () => {
-    const store = setupMockStore({
-      dataset: {
-        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-        data: [],
-      },
-    });
-    const wrapper = shallowMount(PivotStepForm, { store, localVue });
-    expect(wrapper.find('#valueColumnInput').attributes('options')).toEqual(
-      'columnA,columnB,columnC',
-    );
-  });
-
-  it('should instantiate aggregationFunctionInput widget autocomplete with the right aggregation function names', () => {
-    const wrapper = shallowMount(PivotStepForm, { store: emptyStore, localVue });
-    expect(wrapper.find('#aggregationFunctionInput').attributes('options')).toEqual(
-      'sum,avg,count,min,max',
-    );
-  });
-
-  it('should validate and emit "formSaved" when submitted data is valid', async () => {
-    const wrapper = mount(PivotStepForm, {
-      store: emptyStore,
-      localVue,
-      propsData: {
-        initialStepValue: {
-          name: 'pivot',
-          index: ['columnA', 'columnB'],
-          column_to_pivot: 'foo',
-          value_column: 'bar',
-          agg_function: 'sum',
-        },
-      },
-    });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.vm.$data.errors).toBeNull();
-    expect(wrapper.emitted()).toEqual({
-      formSaved: [
-        [
-          {
-            name: 'pivot',
-            index: ['columnA', 'columnB'],
-            column_to_pivot: 'foo',
-            value_column: 'bar',
-            agg_function: 'sum',
-          },
-        ],
-      ],
-    });
-  });
-
-  it('should update step when selectedColumn is changed', async () => {
-    const store = setupMockStore({
-      dataset: {
-        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-        data: [],
-      },
-    });
-    const wrapper = shallowMount(PivotStepForm, { store, localVue });
-    expect(wrapper.vm.$data.editedStep.column_to_pivot).toEqual('');
-    store.commit(VQBnamespace('toggleColumnSelection'), { column: 'columnB' });
-    await localVue.nextTick();
-    expect(wrapper.vm.$data.editedStep.column_to_pivot).toEqual('columnB');
-  });
-
-  describe('Errors', () => {
-    it('should fire errors when fields are missing', () => {
-      const wrapper = mount(PivotStepForm, { store: emptyStore, localVue });
-
-      wrapper.find('.widget-form-action__button--validate').trigger('click');
-      const errors = wrapper.vm.$data.errors
-        .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
-        .sort((err1: ValidationError, err2: ValidationError) =>
-          err1.dataPath.localeCompare(err2.dataPath),
-        );
-
-      expect(errors).toEqual([
+  runner.testValidationErrors([
+    {
+      testlabel: 'submitted data is not valid',
+      errors: [
         { keyword: 'minLength', dataPath: '.column_to_pivot' },
         { keyword: 'minItems', dataPath: '.index' },
         { keyword: 'minLength', dataPath: '.value_column' },
-      ]);
-    });
-
-    it('should fire errors when index and column_to_pivot column names overlap', async () => {
-      const store = setupMockStore({
+      ],
+    },
+    {
+      testlabel: 'index and column_to_pivot column names overlap',
+      store: setupMockStore({
         dataset: {
           headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
           data: [],
         },
-      });
-      const wrapper = mount(PivotStepForm, { store, localVue });
-      wrapper.setData({
+      }),
+      data: {
         editedStep: {
           name: 'pivot',
           index: ['columnA', 'columnC'],
@@ -162,32 +48,23 @@ describe('Pivot Step Form', () => {
           value_column: 'columnB',
           agg_function: 'sum',
         },
-      });
-      wrapper.find('.widget-form-action__button--validate').trigger('click');
-      await localVue.nextTick();
-      const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
-        keyword: err.keyword,
-        dataPath: err.dataPath,
-        message: err.message,
-      }));
-      expect(errors).toEqual([
+      },
+      errors: [
         {
           keyword: 'columnNameConflict',
           dataPath: '.column_to_pivot',
-          message: 'Column name columnA is used at least twice but should be unique',
         },
-      ]);
-    });
-
-    it('should fire errors when index and value_column column names overlap', async () => {
-      const store = setupMockStore({
+      ],
+    },
+    {
+      testlabel: 'index and value_column column names overlap',
+      store: setupMockStore({
         dataset: {
           headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
           data: [],
         },
-      });
-      const wrapper = mount(PivotStepForm, { store, localVue });
-      wrapper.setData({
+      }),
+      data: {
         editedStep: {
           name: 'pivot',
           index: ['columnA', 'columnC'],
@@ -195,32 +72,23 @@ describe('Pivot Step Form', () => {
           value_column: 'columnA',
           agg_function: 'sum',
         },
-      });
-      wrapper.find('.widget-form-action__button--validate').trigger('click');
-      await localVue.nextTick();
-      const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
-        keyword: err.keyword,
-        dataPath: err.dataPath,
-        message: err.message,
-      }));
-      expect(errors).toEqual([
+      },
+      errors: [
         {
           keyword: 'columnNameConflict',
           dataPath: '.value_column',
-          message: 'Column name columnA is used at least twice but should be unique',
         },
-      ]);
-    });
-
-    it('should fire errors when column_to_pivot and value_column are equal', async () => {
-      const store = setupMockStore({
+      ],
+    },
+    {
+      testlabel: 'column_to_pivot and value_column are equal',
+      store: setupMockStore({
         dataset: {
           headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
           data: [],
         },
-      });
-      const wrapper = mount(PivotStepForm, { store, localVue });
-      wrapper.setData({
+      }),
+      data: {
         editedStep: {
           name: 'pivot',
           index: ['columnA', 'columnC'],
@@ -228,21 +96,76 @@ describe('Pivot Step Form', () => {
           value_column: 'columnB',
           agg_function: 'sum',
         },
-      });
-      wrapper.find('.widget-form-action__button--validate').trigger('click');
-      await localVue.nextTick();
-      const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
-        keyword: err.keyword,
-        dataPath: err.dataPath,
-        message: err.message,
-      }));
-      expect(errors).toEqual([
+      },
+      errors: [
         {
           keyword: 'columnNameConflict',
           dataPath: '.column_to_pivot',
-          message: 'Column name columnB is used at least twice but should be unique',
         },
-      ]);
+      ],
+    },
+  ]);
+
+  it('should pass down props to widgets', async () => {
+    const wrapper = runner.shallowMount(undefined, {
+      data: {
+        editedStep: {
+          name: 'pivot',
+          index: ['label'],
+          column_to_pivot: 'country',
+          value_column: 'value',
+          agg_function: 'sum',
+        },
+      },
     });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('#indexInput').props('value')).toEqual(['label']);
+    expect(wrapper.find('#valueColumnInput').props('value')).toEqual('value');
+    expect(wrapper.find('#aggregationFunctionInput').props('value')).toEqual('sum');
+  });
+
+  it('should instantiate indexInput widget multiselect with column names', () => {
+    const initialState = {
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+    };
+    const wrapper = runner.shallowMount(initialState);
+    expect(wrapper.find('#indexInput').attributes('options')).toEqual('columnA,columnB,columnC');
+  });
+
+  it('should instantiate valueColumnInput widget autocomplete with column names', () => {
+    const initialState = {
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+    };
+    const wrapper = runner.shallowMount(initialState);
+    expect(wrapper.find('#valueColumnInput').attributes('options')).toEqual(
+      'columnA,columnB,columnC',
+    );
+  });
+
+  it('should instantiate aggregationFunctionInput widget autocomplete with the right aggregation function names', () => {
+    const wrapper = runner.shallowMount();
+    expect(wrapper.find('#aggregationFunctionInput').attributes('options')).toEqual(
+      'sum,avg,count,min,max',
+    );
+  });
+
+  it('should update step when selectedColumn is changed', async () => {
+    const initialState = {
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+    };
+    const wrapper = runner.shallowMount(initialState);
+    expect(wrapper.vm.$data.editedStep.column_to_pivot).toEqual('');
+    wrapper.vm.$store.commit(VQBnamespace('toggleColumnSelection'), { column: 'columnB' });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.$data.editedStep.column_to_pivot).toEqual('columnB');
   });
 });

--- a/tests/unit/pivot-step-form.spec.ts
+++ b/tests/unit/pivot-step-form.spec.ts
@@ -4,16 +4,10 @@ import Vuex, { Store } from 'vuex';
 import PivotStepForm from '@/components/stepforms/PivotStepForm.vue';
 import { VQBnamespace } from '@/store';
 
-import { setupMockStore, RootState } from './utils';
+import { setupMockStore, RootState, ValidationError } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-  message: string;
-}
 
 describe('Pivot Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/rename-step-form.spec.ts
+++ b/tests/unit/rename-step-form.spec.ts
@@ -35,18 +35,16 @@ describe('Rename Step Form', () => {
         },
       }),
       data: { editedStep: { name: 'rename', oldname: 'columnA', newname: 'columnB' } },
-      errors: [ { keyword: 'columnNameAlreadyUsed', dataPath: '.newname' } ],
-    }
+      errors: [{ keyword: 'columnNameAlreadyUsed', dataPath: '.newname' }],
+    },
   ]);
 
-  runner.testValidate(
-    {
-      testlabel: 'submitted data is valid',
-      props: {
-        initialStepValue: { name: 'rename', oldname: 'foo', newname: 'bar' },
-      },
-    }
-  );
+  runner.testValidate({
+    testlabel: 'submitted data is valid',
+    props: {
+      initialStepValue: { name: 'rename', oldname: 'foo', newname: 'bar' },
+    },
+  });
 
   runner.testCancel({
     pipeline: [

--- a/tests/unit/rename-step-form.spec.ts
+++ b/tests/unit/rename-step-form.spec.ts
@@ -56,15 +56,7 @@ describe('Rename Step Form', () => {
     selectedStepIndex: 2,
   });
 
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 
   it('should pass down the newname prop to widget value prop', async () => {
     const wrapper = shallowMount(RenameStepForm, { store: emptyStore, localVue });

--- a/tests/unit/rename-step-form.spec.ts
+++ b/tests/unit/rename-step-form.spec.ts
@@ -3,17 +3,11 @@ import Vuex, { Store } from 'vuex';
 
 import RenameStepForm from '@/components/stepforms/RenameStepForm.vue';
 import { VQBnamespace } from '@/store';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
-
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Rename Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/rename-step-form.spec.ts
+++ b/tests/unit/rename-step-form.spec.ts
@@ -1,20 +1,9 @@
-import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import RenameStepForm from '@/components/stepforms/RenameStepForm.vue';
 import { VQBnamespace } from '@/store';
-import { setupMockStore, BasicStepFormTestRunner, RootState } from './utils';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { setupMockStore, BasicStepFormTestRunner } from './utils';
 
 describe('Rename Step Form', () => {
-  let emptyStore: Store<RootState>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
-  });
-
-  const runner = new BasicStepFormTestRunner(RenameStepForm, 'rename', localVue);
+  const runner = new BasicStepFormTestRunner(RenameStepForm, 'rename');
   runner.testInstantiate();
   runner.testExpectedComponents({ 'inputtextwidget-stub': 1, 'columnpicker-stub': 1 });
 
@@ -59,70 +48,74 @@ describe('Rename Step Form', () => {
   runner.testResetSelectedIndex();
 
   it('should pass down the newname prop to widget value prop', async () => {
-    const wrapper = shallowMount(RenameStepForm, { store: emptyStore, localVue });
-    wrapper.setData({ editedStep: { name: 'rename', oldname: '', newname: 'foo' } });
-    await localVue.nextTick();
+    const wrapper = runner.shallowMount(
+      {},
+      {
+        data: { editedStep: { name: 'rename', oldname: '', newname: 'foo' } },
+      },
+    );
+    await wrapper.vm.$nextTick();
     expect(wrapper.find('inputtextwidget-stub').props('value')).toEqual('foo');
   });
 
   it('should update step when selectedColumn is changed', async () => {
-    const store = setupMockStore({
+    const initialState = {
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
       },
-    });
-    const wrapper = shallowMount(RenameStepForm, { store, localVue });
+    };
+    const wrapper = runner.shallowMount(initialState);
     expect(wrapper.vm.$data.editedStep.oldname).toEqual('');
-    store.commit(VQBnamespace('toggleColumnSelection'), { column: 'columnB' });
-    await localVue.nextTick();
+    wrapper.vm.$store.commit(VQBnamespace('toggleColumnSelection'), { column: 'columnB' });
+    await wrapper.vm.$nextTick();
     expect(wrapper.vm.$data.editedStep.oldname).toEqual('columnB');
   });
 
   it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
-    const pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ];
-    const store = setupMockStore({
-      pipeline,
+    const initialState = {
+      pipeline: [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', oldname: 'foo', newname: 'bar' },
+        { name: 'rename', oldname: 'baz', newname: 'spam' },
+        { name: 'rename', oldname: 'tic', newname: 'tac' },
+      ],
       selectedStepIndex: 2,
-    });
-    const wrapper = mount(RenameStepForm, { store, localVue });
-    wrapper.setProps({ isStepCreation: true });
+    };
+    const wrapper = runner.mount(initialState, { propsData: { isStepCreation: true } });
     wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(2);
+    expect(wrapper.vm.$store.state.vqb.selectedStepIndex).toEqual(2);
     wrapper.setProps({ isStepCreation: false });
     wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(3);
+    expect(wrapper.vm.$store.state.vqb.selectedStepIndex).toEqual(3);
   });
 
   it('should make the focus on the column modified after rename validation', () => {
-    const store = setupMockStore({
+    const initialState = {
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
       },
+    };
+    const wrapper = runner.mount(initialState, {
+      data: { editedStep: { name: 'rename', oldname: 'columnA', newname: 'toto' } },
     });
-    const wrapper = mount(RenameStepForm, { store, localVue });
-    wrapper.setData({ editedStep: { name: 'rename', oldname: 'columnA', newname: 'toto' } });
     wrapper.find('.widget-form-action__button--validate').trigger('click');
-    expect(store.state.vqb.selectedColumns).toEqual(['toto']);
+    expect(wrapper.vm.$store.state.vqb.selectedColumns).toEqual(['toto']);
   });
 
   it('should not change the column focus if validation fails', () => {
-    const store = setupMockStore({
+    const initialState = {
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
       },
       selectedColumns: ['columnA'],
+    };
+    const wrapper = runner.mount(initialState, {
+      data: { editedStep: { name: 'rename', oldname: 'columnA', newname: 'columnB' } },
     });
-    const wrapper = mount(RenameStepForm, { store, localVue });
-    wrapper.setData({ editedStep: { name: 'rename', oldname: 'columnA', newname: 'columnB' } });
     wrapper.find('.widget-form-action__button--validate').trigger('click');
-    expect(store.state.vqb.selectedColumns).toEqual(['columnA']);
+    expect(wrapper.vm.$store.state.vqb.selectedColumns).toEqual(['columnA']);
   });
 });

--- a/tests/unit/search-bar.spec.ts
+++ b/tests/unit/search-bar.spec.ts
@@ -6,7 +6,6 @@ import { ActionCategories } from '@/components/constants';
 
 import { setupMockStore } from './utils';
 
-
 const localVue = createLocalVue();
 localVue.use(Vuex);
 

--- a/tests/unit/select-column-step-form.spec.ts
+++ b/tests/unit/select-column-step-form.spec.ts
@@ -1,130 +1,62 @@
-import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import SelectColumnStepForm from '@/components/stepforms/SelectColumnStepForm.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
-import { Pipeline } from '@/lib/steps';
 
-import { setupMockStore, ValidationError } from './utils';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { BasicStepFormTestRunner } from './utils';
 
 describe('Select Column Step Form', () => {
-  let emptyStore: Store<any>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
+  const runner = new BasicStepFormTestRunner(SelectColumnStepForm, 'select');
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'multiselectwidget-stub': 1,
+  });
+  runner.testValidationErrors([
+    {
+      testlabel: 'submitted data is not valid',
+      errors: [{ keyword: 'minItems', dataPath: '.columns' }],
+    },
+  ]);
+
+  runner.testValidate({
+    testlabel: 'submitted data is valid',
+    props: {
+      initialStepValue: { name: 'select', columns: ['foo'] },
+    },
   });
 
-  it('should instantiate', () => {
-    const wrapper = shallowMount(SelectColumnStepForm, { store: emptyStore, localVue });
-    expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.vm.$data.stepname).toEqual('select');
-  });
-
-  it('should have a widget multiselect', () => {
-    const wrapper = shallowMount(SelectColumnStepForm, { store: emptyStore, localVue });
-
-    expect(wrapper.find('multiselectwidget-stub').exists()).toBeTruthy();
-  });
+  runner.testCancel();
+  runner.testResetSelectedIndex();
 
   it('should instantiate a multiselect widget with proper options from the store', () => {
-    const store = setupMockStore({
+    const initialState = {
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
       },
-    });
-    const wrapper = shallowMount(SelectColumnStepForm, { store, localVue });
+    };
+    const wrapper = runner.shallowMount(initialState);
     const widgetAutocomplete = wrapper.find('multiselectwidget-stub');
 
     expect(widgetAutocomplete.attributes('options')).toEqual('columnA,columnB,columnC');
   });
 
-  it('should report errors when submitted data is not valid', () => {
-    const wrapper = mount(SelectColumnStepForm, { store: emptyStore, localVue });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
-      keyword: err.keyword,
-      dataPath: err.dataPath,
-    }));
-    expect(errors).toEqual([{ keyword: 'minItems', dataPath: '.columns' }]);
-  });
-
-  it('should validate and emit "formSaved" when submitted data is valid', () => {
-    const wrapper = mount(SelectColumnStepForm, {
-      store: emptyStore,
-      localVue,
-      propsData: {
-        initialStepValue: { name: 'select', columns: ['foo'] },
-      },
-    });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    expect(wrapper.vm.$data.errors).toBeNull();
-    expect(wrapper.emitted()).toEqual({
-      formSaved: [[{ name: 'select', columns: ['foo'] }]],
-    });
-  });
-
-  it('should emit "cancel" event when edition is canceled', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-    ];
-    const store = setupMockStore({
-      pipeline,
-      selectedStepIndex: 1,
-    });
-
-    const wrapper = mount(SelectColumnStepForm, { store, localVue });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(wrapper.emitted()).toEqual({ cancel: [[]] });
-    expect(store.state.vqb.selectedStepIndex).toEqual(1);
-    expect(store.state.vqb.pipeline).toEqual([
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-    ]);
-  });
-
   it('should update selectedColumn when column is changed', async () => {
-    const store = setupMockStore({
+    const initialState = {
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
       },
       selectedColumns: ['columnA'],
-    });
-    const wrapper = mount(SelectColumnStepForm, {
+    };
+    const wrapper = runner.mount(initialState, {
       propsData: {
         initialValue: {
           columns: ['columnA'],
         },
       },
-      store,
-      localVue,
     });
     wrapper.setData({ editedStep: { columns: ['columnB'] } });
-    await wrapper.find(MultiselectWidget).trigger('input');
-    expect(store.state.vqb.selectedColumns).toEqual(['columnB']);
-  });
-
-  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ];
-    const store = setupMockStore({
-      pipeline,
-      selectedStepIndex: 2,
-    });
-    const wrapper = mount(SelectColumnStepForm, { store, localVue });
-    wrapper.setProps({ isStepCreation: true });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(2);
-    wrapper.setProps({ isStepCreation: false });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(3);
+    wrapper.find(MultiselectWidget).trigger('input');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.$store.state.vqb.selectedColumns).toEqual(['columnB']);
   });
 });

--- a/tests/unit/select-column-step-form.spec.ts
+++ b/tests/unit/select-column-step-form.spec.ts
@@ -5,15 +5,10 @@ import SelectColumnStepForm from '@/components/stepforms/SelectColumnStepForm.vu
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
 import { Pipeline } from '@/lib/steps';
 
-import { setupMockStore } from './utils';
+import { setupMockStore, ValidationError } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Select Column Step Form', () => {
   let emptyStore: Store<any>;

--- a/tests/unit/sort-step-form.spec.ts
+++ b/tests/unit/sort-step-form.spec.ts
@@ -1,14 +1,8 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import SortStepForm from '@/components/stepforms/SortStepForm.vue';
-import { setupMockStore, BasicStepFormTestRunner, RootState } from './utils';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { BasicStepFormTestRunner } from './utils';
 
 describe('Sort Step Form', () => {
-  const runner = new BasicStepFormTestRunner(SortStepForm, 'sort', localVue);
+  const runner = new BasicStepFormTestRunner(SortStepForm, 'sort');
   runner.testInstantiate();
   runner.testExpectedComponents({ 'listwidget-stub': 1 });
 
@@ -54,26 +48,25 @@ describe('Sort Step Form', () => {
   runner.testResetSelectedIndex();
 
   describe('ListWidget', () => {
-    let emptyStore: Store<RootState>;
-    beforeEach(() => {
-      emptyStore = setupMockStore({});
-    });
-
     it('should pass the defaultSortColumn props to widgetList', async () => {
-      const wrapper = shallowMount(SortStepForm, { store: emptyStore, localVue, sync: false });
-      await localVue.nextTick();
+      const wrapper = runner.shallowMount();
+      await wrapper.vm.$nextTick();
       expect(wrapper.find('listwidget-stub').props().value).toEqual([{ column: '', order: 'asc' }]);
     });
 
     it('should pass right sort props to widgetList sort column', async () => {
-      const wrapper = shallowMount(SortStepForm, { store: emptyStore, localVue, sync: false });
-      wrapper.setData({
-        editedStep: {
-          name: 'sort',
-          columns: [{ column: 'amazing', order: 'desc' }],
+      const wrapper = runner.shallowMount(
+        {},
+        {
+          data: {
+            editedStep: {
+              name: 'sort',
+              columns: [{ column: 'amazing', order: 'desc' }],
+            },
+          },
         },
-      });
-      await localVue.nextTick();
+      );
+      await wrapper.vm.$nextTick();
       expect(wrapper.find('listwidget-stub').props().value).toEqual([
         { column: 'amazing', order: 'desc' },
       ]);

--- a/tests/unit/sort-step-form.spec.ts
+++ b/tests/unit/sort-step-form.spec.ts
@@ -1,29 +1,72 @@
-import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import SortStepForm from '@/components/stepforms/SortStepForm.vue';
-import { setupMockStore, RootState, ValidationError } from './utils';
-import { Pipeline } from '@/lib/steps';
+import { setupMockStore, BasicStepFormTestRunner, RootState } from './utils';
+
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Sort Step Form', () => {
-  let emptyStore: Store<RootState>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
+
+  const runner = new BasicStepFormTestRunner(SortStepForm, 'sort', localVue);
+  runner.testInstantiate();
+  runner.testExpectedComponents({ 'listwidget-stub': 1 });
+
+  runner.testValidationErrors([
+    {
+      testlabel: 'a column parameter is an empty string',
+      props: {
+        editedStep: {
+          name: 'sort',
+          columns: [{ column: '', order: 'desc' }],
+        },
+      },
+      errors: [{ keyword: 'minLength', dataPath: '.columns[0].column' }],
+    }
+  ]);
+
+  runner.testValidate(
+    {
+      testlabel: 'submitted data is validd',
+      data: {
+        editedStep: {
+          name: 'sort',
+          columns: [{ column: 'amazing', order: 'desc' }],
+        },
+      },
+    },
+    {
+      name: 'sort',
+      columns: [{ column: 'amazing', order: 'desc' }],
+    },
+  );
+
+  runner.testCancel({
+    pipeline: [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+      { name: 'rename', oldname: 'baz', newname: 'spam' },
+      { name: 'rename', oldname: 'tic', newname: 'tac' },
+    ],
+    selectedStepIndex: 2,
   });
 
-  it('should instantiate', () => {
-    const wrapper = shallowMount(SortStepForm, { store: emptyStore, localVue, sync: false });
-    expect(wrapper.exists()).toBeTruthy();
+  runner.testResetSelectedIndex({
+    pipeline: [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+      { name: 'rename', oldname: 'baz', newname: 'spam' },
+      { name: 'rename', oldname: 'tic', newname: 'tac' },
+    ],
+    selectedStepIndex: 2,
   });
 
   describe('ListWidget', () => {
-    it('should have one widgetList component', () => {
-      const wrapper = shallowMount(SortStepForm, { store: emptyStore, localVue, sync: false });
-      const widgetListWrapper = wrapper.findAll('listwidget-stub');
-      expect(widgetListWrapper.length).toEqual(1);
+    let emptyStore: Store<RootState>;
+    beforeEach(() => {
+      emptyStore = setupMockStore({});
     });
 
     it('should pass the defaultSortColumn props to widgetList', async () => {
@@ -45,85 +88,5 @@ describe('Sort Step Form', () => {
         { column: 'amazing', order: 'desc' },
       ]);
     });
-  });
-
-  describe('Validation', () => {
-    it('should report errors when a column parameter is an empty string', () => {
-      const wrapper = mount(SortStepForm, {
-        store: emptyStore,
-        localVue,
-        sync: false,
-      });
-      wrapper.setData({
-        editedStep: {
-          name: 'sort',
-          columns: [{ column: '', order: 'desc' }],
-        },
-      });
-      wrapper.find('.widget-form-action__button--validate').trigger('click');
-      // await localVue.nextTick();
-      const errors = wrapper.vm.$data.errors
-        .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
-        .sort((err1: ValidationError, err2: ValidationError) =>
-          err1.dataPath.localeCompare(err2.dataPath),
-        );
-      expect(errors).toEqual([{ keyword: 'minLength', dataPath: '.columns[0].column' }]);
-    });
-
-    it('should validate and emit "formSaved" when submitted data is valid', async () => {
-      const wrapper = mount(SortStepForm, { store: emptyStore, localVue, sync: false });
-      wrapper.setData({
-        editedStep: {
-          name: 'sort',
-          columns: [{ column: 'amazing', order: 'desc' }],
-        },
-      });
-      wrapper.find('.widget-form-action__button--validate').trigger('click');
-      await localVue.nextTick();
-      expect(wrapper.vm.$data.errors).toBeNull();
-      expect(wrapper.emitted()).toEqual({
-        formSaved: [
-          [
-            {
-              name: 'sort',
-              columns: [{ column: 'amazing', order: 'desc' }],
-            },
-          ],
-        ],
-      });
-    });
-  });
-
-  it('should emit "cancel" event when edition is cancelled', async () => {
-    const wrapper = mount(SortStepForm, { store: emptyStore, localVue, sync: false });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.emitted()).toEqual({
-      cancel: [[]],
-    });
-  });
-
-  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ];
-    const store = setupMockStore({
-      pipeline,
-      selectedStepIndex: 2,
-    });
-    const wrapper = mount(SortStepForm, {
-      store,
-      localVue,
-      propsData: { isStepCreation: true },
-      sync: false,
-    });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(2);
-    wrapper.setProps({ isStepCreation: false });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(3);
   });
 });

--- a/tests/unit/sort-step-form.spec.ts
+++ b/tests/unit/sort-step-form.spec.ts
@@ -51,15 +51,7 @@ describe('Sort Step Form', () => {
     selectedStepIndex: 2,
   });
 
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 
   describe('ListWidget', () => {
     let emptyStore: Store<RootState>;

--- a/tests/unit/sort-step-form.spec.ts
+++ b/tests/unit/sort-step-form.spec.ts
@@ -2,17 +2,11 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import SortStepForm from '@/components/stepforms/SortStepForm.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
-
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Sort Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/sort-step-form.spec.ts
+++ b/tests/unit/sort-step-form.spec.ts
@@ -4,12 +4,10 @@ import Vuex, { Store } from 'vuex';
 import SortStepForm from '@/components/stepforms/SortStepForm.vue';
 import { setupMockStore, BasicStepFormTestRunner, RootState } from './utils';
 
-
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Sort Step Form', () => {
-
   const runner = new BasicStepFormTestRunner(SortStepForm, 'sort', localVue);
   runner.testInstantiate();
   runner.testExpectedComponents({ 'listwidget-stub': 1 });
@@ -24,7 +22,7 @@ describe('Sort Step Form', () => {
         },
       },
       errors: [{ keyword: 'minLength', dataPath: '.columns[0].column' }],
-    }
+    },
   ]);
 
   runner.testValidate(

--- a/tests/unit/split-step-form.spec.ts
+++ b/tests/unit/split-step-form.spec.ts
@@ -2,17 +2,12 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import SplitStepForm from '@/components/stepforms/SplitStepForm.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
 
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Split Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/split-step-form.spec.ts
+++ b/tests/unit/split-step-form.spec.ts
@@ -5,7 +5,6 @@ import SplitStepForm from '@/components/stepforms/SplitStepForm.vue';
 import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
 
-
 const localVue = createLocalVue();
 localVue.use(Vuex);
 

--- a/tests/unit/split-step-form.spec.ts
+++ b/tests/unit/split-step-form.spec.ts
@@ -1,101 +1,42 @@
-import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import SplitStepForm from '@/components/stepforms/SplitStepForm.vue';
-import { setupMockStore, RootState, ValidationError } from './utils';
-import { Pipeline } from '@/lib/steps';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { BasicStepFormTestRunner } from './utils';
 
 describe('Split Step Form', () => {
-  let emptyStore: Store<RootState>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
+  const runner = new BasicStepFormTestRunner(SplitStepForm, 'split');
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'columnpicker-stub': 1,
+    'inputtextwidget-stub': 2,
+  });
+  runner.testValidationErrors([
+    {
+      testlabel: 'submitted data is not valid',
+      errors: [
+        { keyword: 'required', dataPath: '' },
+        { keyword: 'minLength', dataPath: '.column' },
+        { keyword: 'minLength', dataPath: '.delimiter' },
+      ],
+    },
+  ]);
+
+  runner.testValidate({
+    testlabel: 'submitted data is valid',
+    props: {
+      initialStepValue: { name: 'split', column: 'foo', delimiter: '-', number_cols_to_keep: 3 },
+    },
   });
 
-  it('should instantiate', () => {
-    const wrapper = shallowMount(SplitStepForm, { store: emptyStore, localVue });
-    expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.vm.$data.stepname).toEqual('split');
-  });
-
-  it('should have exactly 3 input components', () => {
-    const wrapper = shallowMount(SplitStepForm, { store: emptyStore, localVue });
-    expect(wrapper.find('#columnToSplit').exists()).toBeTruthy();
-    expect(wrapper.find('#delimiter').exists()).toBeTruthy();
-    expect(wrapper.find('#numberColsToKeep').exists()).toBeTruthy();
-  });
+  runner.testCancel();
+  runner.testResetSelectedIndex();
 
   it('should pass down the properties to the input components', async () => {
-    const wrapper = shallowMount(SplitStepForm, { store: emptyStore, localVue });
-    wrapper.setData({
-      editedStep: { name: 'split', column: 'foo', delimiter: '-', number_cols_to_keep: 3 },
-    });
-    await localVue.nextTick();
-    expect(wrapper.find('#delimiter').props('value')).toEqual('-');
-    expect(wrapper.find('#numberColsToKeep').props('value')).toEqual(3);
-  });
-
-  it('should report errors when column is empty', async () => {
-    const wrapper = mount(SplitStepForm, { store: emptyStore, localVue });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    const errors = wrapper.vm.$data.errors
-      .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
-      .sort((err1: ValidationError, err2: ValidationError) =>
-        err1.dataPath.localeCompare(err2.dataPath),
-      );
-    expect(errors).toEqual([
-      { keyword: 'required', dataPath: '' },
-      { keyword: 'minLength', dataPath: '.column' },
-      { keyword: 'minLength', dataPath: '.delimiter' },
-    ]);
-  });
-
-  it('should validate and emit "formSaved" when submitted data is valid', async () => {
-    const wrapper = mount(SplitStepForm, {
-      store: emptyStore,
-      localVue,
-      sync: false,
-      propsData: {
-        initialStepValue: { name: 'split', column: 'foo', delimiter: '-', number_cols_to_keep: 3 },
+    const wrapper = runner.shallowMount(undefined, {
+      data: {
+        editedStep: { name: 'split', column: 'foo', delimiter: '-', number_cols_to_keep: 3 },
       },
     });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.vm.$data.errors).toBeNull();
-    expect(wrapper.emitted()).toEqual({
-      formSaved: [[{ name: 'split', column: 'foo', delimiter: '-', number_cols_to_keep: 3 }]],
-    });
-  });
-
-  it('should emit "cancel" event when edition is cancelled', async () => {
-    const wrapper = mount(SplitStepForm, { store: emptyStore, localVue });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.emitted()).toEqual({
-      cancel: [[]],
-    });
-  });
-
-  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ];
-    const store = setupMockStore({
-      pipeline,
-      selectedStepIndex: 2,
-    });
-    const wrapper = mount(SplitStepForm, { store, localVue });
-    wrapper.setProps({ isStepCreation: true });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(2);
-    wrapper.setProps({ isStepCreation: false });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    expect(store.state.vqb.selectedStepIndex).toEqual(3);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('#delimiter').props('value')).toEqual('-');
+    expect(wrapper.find('#numberColsToKeep').props('value')).toEqual(3);
   });
 });

--- a/tests/unit/substring-step-form.spec.ts
+++ b/tests/unit/substring-step-form.spec.ts
@@ -3,15 +3,10 @@ import Vuex, { Store } from 'vuex';
 
 import SubstringStepForm from '@/components/stepforms/SubstringStepForm.vue';
 
-import { setupMockStore } from './utils';
+import { setupMockStore, ValidationError } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Substring Step Form', () => {
   let emptyStore: Store<any>;

--- a/tests/unit/substring-step-form.spec.ts
+++ b/tests/unit/substring-step-form.spec.ts
@@ -1,81 +1,43 @@
-import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import SubstringStepForm from '@/components/stepforms/SubstringStepForm.vue';
-
-import { setupMockStore, ValidationError } from './utils';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { BasicStepFormTestRunner } from './utils';
 
 describe('Substring Step Form', () => {
-  let emptyStore: Store<any>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
+  const runner = new BasicStepFormTestRunner(SubstringStepForm, 'substring');
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'columnpicker-stub': 1,
+    'inputtextwidget-stub': 2,
+  });
+  runner.testValidationErrors([
+    {
+      testlabel: 'submitted data is not valid',
+      errors: [{ keyword: 'minLength', dataPath: '.column' }],
+    },
+  ]);
+
+  runner.testValidate({
+    testlabel: 'submitted data is valid',
+    props: {
+      initialStepValue: {
+        name: 'substring',
+        column: 'foo',
+        start_index: 1,
+        end_index: 3,
+      },
+    },
   });
 
-  it('should instantiate', () => {
-    const wrapper = shallowMount(SubstringStepForm, { store: emptyStore, localVue });
-    expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.vm.$data.stepname).toEqual('substring');
-  });
-
-  it('should have exactly 3 input components', () => {
-    const wrapper = shallowMount(SubstringStepForm, { store: emptyStore, localVue });
-    expect(wrapper.find('#column').exists()).toBeTruthy();
-    expect(wrapper.find('#startIndex').exists()).toBeTruthy();
-    expect(wrapper.find('#endIndex').exists()).toBeTruthy();
-  });
+  runner.testCancel();
+  runner.testResetSelectedIndex();
 
   it('should pass down the properties to the input components', async () => {
-    const wrapper = shallowMount(SubstringStepForm, { store: emptyStore, localVue });
-    wrapper.setData({
-      editedStep: { name: 'Substring', column: 'foo', start_index: 1, end_index: 3 },
-    });
-    await localVue.nextTick();
-    expect(wrapper.find('#startIndex').props('value')).toEqual(1);
-    expect(wrapper.find('#endIndex').props('value')).toEqual(3);
-  });
-
-  it('should report errors when column is empty', async () => {
-    const wrapper = mount(SubstringStepForm, { store: emptyStore, localVue });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    const errors = wrapper.vm.$data.errors
-      .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
-      .sort((err1: ValidationError, err2: ValidationError) =>
-        err1.dataPath.localeCompare(err2.dataPath),
-      );
-    expect(errors).toEqual([{ keyword: 'minLength', dataPath: '.column' }]);
-  });
-
-  it('should validate and emit "formSaved" when submitted data is valid', async () => {
-    const wrapper = mount(SubstringStepForm, {
-      store: emptyStore,
-      localVue,
-      propsData: {
-        initialStepValue: {
-          name: 'substring',
-          column: 'foo',
-          start_index: 1,
-          end_index: 3,
-        },
+    const wrapper = runner.shallowMount(undefined, {
+      data: {
+        editedStep: { name: 'Substring', column: 'foo', start_index: 1, end_index: 3 },
       },
     });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.vm.$data.errors).toBeNull();
-    expect(wrapper.emitted()).toEqual({
-      formSaved: [[{ name: 'substring', column: 'foo', start_index: 1, end_index: 3 }]],
-    });
-  });
-
-  it('should emit "cancel" event when edition is cancelled', async () => {
-    const wrapper = mount(SubstringStepForm, { store: emptyStore, localVue });
-    wrapper.find('.step-edit-form__back-button').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.emitted()).toEqual({
-      cancel: [[]],
-    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('#startIndex').props('value')).toEqual(1);
+    expect(wrapper.find('#endIndex').props('value')).toEqual(3);
   });
 });

--- a/tests/unit/todate-step-form.spec.ts
+++ b/tests/unit/todate-step-form.spec.ts
@@ -1,42 +1,23 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import ToDateStepForm from '@/components/stepforms/ToDateStepForm.vue';
 
-import { setupMockStore } from './utils';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { BasicStepFormTestRunner } from './utils';
 
 describe('Connvert STring to Date Step Form', () => {
-  let emptyStore: Store<any>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
-  });
-
-  it('should instantiate', () => {
-    const wrapper = shallowMount(ToDateStepForm, { store: emptyStore, localVue });
-    expect(wrapper.exists()).toBeTruthy();
-  });
-
-  it('should have exactly 1 input component', () => {
-    const wrapper = shallowMount(ToDateStepForm, { store: emptyStore, localVue });
-    expect(wrapper.findAll('columnpicker-stub').length).toEqual(1);
+  const runner = new BasicStepFormTestRunner(ToDateStepForm, 'todate');
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'columnpicker-stub': 1,
   });
 
   it('should update editedStep with the selected column at creation', () => {
-    const store = setupMockStore({
+    const initialState = {
       dataset: {
         headers: [{ name: 'foo', type: 'string' }],
         data: [[null]],
       },
       selectedColumns: ['foo'],
-    });
-    const wrapper = shallowMount(ToDateStepForm, {
-      store,
-      localVue,
-      sync: false,
-    });
+    };
+    const wrapper = runner.shallowMount(initialState);
     expect(wrapper.vm.$data.editedStep.column).toEqual('foo');
   });
 });

--- a/tests/unit/tolower-step-form.spec.ts
+++ b/tests/unit/tolower-step-form.spec.ts
@@ -1,39 +1,23 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import ToLowerStepForm from '@/components/stepforms/ToLowerStepForm.vue';
 
-import { setupMockStore, RootState } from './utils';
+import { BasicStepFormTestRunner } from './utils';
 
-const localVue = createLocalVue();
-localVue.use(Vuex);
-
-describe('To Uppercase Step Form', () => {
-  let emptyStore: Store<RootState>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
-  });
-
-  it('should instantiate', () => {
-    const wrapper = shallowMount(ToLowerStepForm, { store: emptyStore, localVue });
-
-    expect(wrapper.exists()).toBeTruthy();
-  });
-
-  it('should have exactly 1 input component', () => {
-    const wrapper = shallowMount(ToLowerStepForm, { store: emptyStore, localVue });
-
-    expect(wrapper.findAll('columnpicker-stub').length).toEqual(1);
+describe('To Lowercase Step Form', () => {
+  const runner = new BasicStepFormTestRunner(ToLowerStepForm, 'lowercase');
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'columnpicker-stub': 1,
   });
 
   it('should display step column on edition', () => {
-    const wrapper = shallowMount(ToLowerStepForm, {
-      propsData: {
-        initialStepValue: { name: 'lowercase', column: 'foo' },
+    const wrapper = runner.shallowMount(
+      {},
+      {
+        propsData: {
+          initialStepValue: { name: 'lowercase', column: 'foo' },
+        },
       },
-      store: emptyStore,
-      localVue,
-    });
+    );
     const columnPicker = wrapper.find('columnpicker-stub');
     expect(columnPicker.attributes('value')).toEqual('foo');
   });

--- a/tests/unit/top-step-form.spec.ts
+++ b/tests/unit/top-step-form.spec.ts
@@ -3,18 +3,13 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import TopStepForm from '@/components/stepforms/TopStepForm.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
 import { ScopeContext } from '@/lib/templating';
 
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
 
 describe('Top Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/top-step-form.spec.ts
+++ b/tests/unit/top-step-form.spec.ts
@@ -7,7 +7,6 @@ import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
 import { ScopeContext } from '@/lib/templating';
 
-
 const localVue = createLocalVue();
 localVue.use(Vuex);
 

--- a/tests/unit/toupper-step-form.spec.ts
+++ b/tests/unit/toupper-step-form.spec.ts
@@ -1,39 +1,23 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import ToUpperStepForm from '@/components/stepforms/ToUpperStepForm.vue';
 
-import { setupMockStore, RootState } from './utils';
-
-const localVue = createLocalVue();
-localVue.use(Vuex);
+import { BasicStepFormTestRunner } from './utils';
 
 describe('To Uppercase Step Form', () => {
-  let emptyStore: Store<RootState>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
-  });
-
-  it('should instantiate', () => {
-    const wrapper = shallowMount(ToUpperStepForm, { store: emptyStore, localVue });
-
-    expect(wrapper.exists()).toBeTruthy();
-  });
-
-  it('should have exactly 1 input component', () => {
-    const wrapper = shallowMount(ToUpperStepForm, { store: emptyStore, localVue });
-
-    expect(wrapper.findAll('columnpicker-stub').length).toEqual(1);
+  const runner = new BasicStepFormTestRunner(ToUpperStepForm, 'uppercase');
+  runner.testInstantiate();
+  runner.testExpectedComponents({
+    'columnpicker-stub': 1,
   });
 
   it('should display step column on edition', () => {
-    const wrapper = shallowMount(ToUpperStepForm, {
-      propsData: {
-        initialStepValue: { name: 'uppercase', column: 'foo' },
+    const wrapper = runner.shallowMount(
+      {},
+      {
+        propsData: {
+          initialStepValue: { name: 'uppercase', column: 'foo' },
+        },
       },
-      store: emptyStore,
-      localVue,
-    });
+    );
     const columnPicker = wrapper.find('columnpicker-stub');
     expect(columnPicker.attributes('value')).toEqual('foo');
   });

--- a/tests/unit/unpivot-step-form.spec.ts
+++ b/tests/unit/unpivot-step-form.spec.ts
@@ -1,20 +1,9 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
-
 import UnpivotStepForm from '@/components/stepforms/UnpivotStepForm.vue';
-import { setupMockStore, BasicStepFormTestRunner, RootState } from './utils';
+import { BasicStepFormTestRunner } from './utils';
 import CheckboxWidget from '@/components/stepforms/widgets/Checkbox.vue';
 
-const localVue = createLocalVue();
-localVue.use(Vuex);
-
 describe('Unpivot Step Form', () => {
-  let emptyStore: Store<RootState>;
-  beforeEach(() => {
-    emptyStore = setupMockStore({});
-  });
-
-  const runner = new BasicStepFormTestRunner(UnpivotStepForm, 'unpivot', localVue);
+  const runner = new BasicStepFormTestRunner(UnpivotStepForm, 'unpivot');
   runner.testInstantiate();
   runner.testExpectedComponents({
     'multiselectwidget-stub': 2,
@@ -65,23 +54,20 @@ describe('Unpivot Step Form', () => {
 
   runner.testResetSelectedIndex();
 
-  it('should pass down props to widgets', () => {
-    const wrapper = shallowMount(UnpivotStepForm, {
-      store: emptyStore,
-      localVue,
-      data: () => {
-        return {
-          editedStep: {
-            name: 'unpivot',
-            keep: ['foo', 'bar'],
-            unpivot: ['baz'],
-            unpivot_column_name: 'spam',
-            value_column_name: 'eggs',
-            dropna: false,
-          },
-        };
+  it('should pass down props to widgets', async () => {
+    const wrapper = runner.shallowMount(undefined, {
+      data: {
+        editedStep: {
+          name: 'unpivot',
+          keep: ['foo', 'bar'],
+          unpivot: ['baz'],
+          unpivot_column_name: 'spam',
+          value_column_name: 'eggs',
+          dropna: false,
+        },
       },
     });
+    await wrapper.vm.$nextTick();
     expect(wrapper.find('#keepColumnInput').props('value')).toEqual(['foo', 'bar']);
     expect(wrapper.find('#unpivotColumnInput').props('value')).toEqual(['baz']);
     const widgetCheckbox = wrapper.find(CheckboxWidget);
@@ -89,13 +75,13 @@ describe('Unpivot Step Form', () => {
   });
 
   it('should instantiate an autocomplete widget with proper options from the store', () => {
-    const store = setupMockStore({
+    const initialState = {
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
       },
-    });
-    const wrapper = shallowMount(UnpivotStepForm, { store, localVue });
+    };
+    const wrapper = runner.shallowMount(initialState);
     expect(wrapper.find('#keepColumnInput').attributes('options')).toEqual(
       'columnA,columnB,columnC',
     );

--- a/tests/unit/unpivot-step-form.spec.ts
+++ b/tests/unit/unpivot-step-form.spec.ts
@@ -2,19 +2,13 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import UnpivotStepForm from '@/components/stepforms/UnpivotStepForm.vue';
+import { setupMockStore, RootState, ValidationError } from './utils';
 import { Pipeline } from '@/lib/steps';
 import CheckboxWidget from '@/components/stepforms/widgets/Checkbox.vue';
 
-import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-  message: string;
-}
 
 describe('Unpivot Step Form', () => {
   let emptyStore: Store<RootState>;

--- a/tests/unit/unpivot-step-form.spec.ts
+++ b/tests/unit/unpivot-step-form.spec.ts
@@ -5,7 +5,6 @@ import UnpivotStepForm from '@/components/stepforms/UnpivotStepForm.vue';
 import { setupMockStore, BasicStepFormTestRunner, RootState } from './utils';
 import CheckboxWidget from '@/components/stepforms/widgets/Checkbox.vue';
 
-
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
@@ -14,7 +13,6 @@ describe('Unpivot Step Form', () => {
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
-
 
   const runner = new BasicStepFormTestRunner(UnpivotStepForm, 'unpivot', localVue);
   runner.testInstantiate();
@@ -52,7 +50,8 @@ describe('Unpivot Step Form', () => {
       unpivot_column_name: 'variable',
       value_column_name: 'value',
       dropna: true,
-    });
+    },
+  );
 
   runner.testCancel({
     pipeline: [
@@ -112,5 +111,4 @@ describe('Unpivot Step Form', () => {
       'columnA,columnB,columnC',
     );
   });
-
 });

--- a/tests/unit/unpivot-step-form.spec.ts
+++ b/tests/unit/unpivot-step-form.spec.ts
@@ -63,15 +63,7 @@ describe('Unpivot Step Form', () => {
     selectedStepIndex: 2,
   });
 
-  runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
-    selectedStepIndex: 2,
-  });
+  runner.testResetSelectedIndex();
 
   it('should pass down props to widgets', () => {
     const wrapper = shallowMount(UnpivotStepForm, {

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -176,8 +176,18 @@ export class BasicStepFormTestRunner<StepType> {
     });
   }
 
-  testResetSelectedIndex(initialState: Partial<VQBState>) {
-    const store = setupMockStore(initialState);
+  testResetSelectedIndex(initialState?: Partial<VQBState>) {
+    const store = setupMockStore(
+      initialState ?? {
+        pipeline: [
+          { name: 'domain', domain: 'foo' },
+          { name: 'rename', oldname: 'foo', newname: 'bar' },
+          { name: 'rename', oldname: 'baz', newname: 'spam' },
+          { name: 'rename', oldname: 'tic', newname: 'tac' },
+        ],
+        selectedStepIndex: 2,
+      },
+    );
     const initialStepIndex = store.state.vqb.selectedStepIndex;
 
     it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -7,6 +7,12 @@ export type RootState = {
   vqb: VQBState;
 };
 
+export interface ValidationError {
+  dataPath: string;
+  keyword: string;
+  message?: string;
+}
+
 export function setupMockStore(initialState: object = {}, plugins: any[] = []) {
   const store: Store<RootState> = new Vuex.Store({ plugins });
   registerModule(store, initialState);

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -1,7 +1,10 @@
+import { createLocalVue, mount, shallowMount } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import { registerModule } from '@/store';
 import { VQBState } from '@/store/state';
+import BaseStepForm from '@/components/stepforms/StepForm.vue';
+import { VueConstructor } from 'vue';
 
 export type RootState = {
   vqb: VQBState;
@@ -13,9 +16,166 @@ export interface ValidationError {
   message?: string;
 }
 
+export const localVue = createLocalVue();
+localVue.use(Vuex);
+
 export function setupMockStore(initialState: object = {}, plugins: any[] = []) {
   const store: Store<RootState> = new Vuex.Store({ plugins });
   registerModule(store, initialState);
 
   return store;
+}
+
+type ComponentType = typeof BaseStepForm;
+
+type TestCaseConfiguration = {
+  testlabel?: string;
+  store?: Store<RootState>;
+  props?: {initialStepValue?: object; [prop: string]: any};
+  data?: object;
+};
+
+type ValidationErrorConfiguration = TestCaseConfiguration & {
+  errors: ValidationError[];
+};
+
+type MountOptions = {
+  propsData?: object;
+  data?: object;
+};
+
+export class BasicStepFormTestRunner<StepType> {
+  componentType: ComponentType;
+  stepname: string;
+  vue: VueConstructor;
+
+  constructor(componentType: ComponentType, stepname: string, vue?: VueConstructor) {
+    this.componentType = componentType;
+    this.stepname = stepname;
+    this.vue = vue ?? localVue;
+  }
+
+  _mount(shallow: boolean, initialState: object = {}, optional: MountOptions = {}) {
+    const mountfunc = shallow ? shallowMount : mount;
+    const {propsData, data} = optional;
+    const wrapper = mountfunc(this.componentType, {
+      store: initialState ? setupMockStore(initialState) : undefined,
+      propsData,
+      localVue: this.vue,
+      sync: false,
+    });
+    if (data) {
+      wrapper.setData(data);
+    }
+    return wrapper;
+  }
+
+  mount(initialState: object = {}, optional: MountOptions = {}) {
+    return this._mount(false, initialState, optional);
+  }
+
+  shallowMount(initialState: object = {}, optional: MountOptions = {}) {
+    return this._mount(true, initialState, optional);
+  }
+
+  testInstantiate() {
+    it('should instantiate', () => {
+      const wrapper = this.shallowMount();
+      expect(wrapper.exists()).toBeTruthy();
+      expect(wrapper.vm.$data.stepname).toEqual(this.stepname);
+    });
+  }
+
+  testExpectedComponents(componentSpec: {[prop: string]: number}) {
+    const specStr = Object.entries(componentSpec).map((k, v) => `${v} ${k}`).join(', ');
+    it(`should generate ${specStr} components`, () => {
+      const wrapper = this.shallowMount();
+      for (const [componentName, count] of Object.entries(componentSpec)) {
+        const compWrappers = wrapper.findAll(componentName);
+        expect(compWrappers.length).toEqual(count);
+      }
+    });
+  }
+
+  async checkValidationError(testlabel: any, store: any, propsData: any, data: any, expectedErrors: any) {
+    const wrapper = mount(this.componentType, {
+      store,
+      propsData,
+      localVue: this.vue,
+      sync: false,
+    });
+    if (data) {
+      wrapper.setData(data);
+    }
+    wrapper.find('.widget-form-action__button--validate').trigger('click');
+    const errors = wrapper.vm.$data.errors
+      .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
+      .sort((err1: ValidationError, err2: ValidationError) =>
+        err1.dataPath.localeCompare(err2.dataPath),
+      );
+    await this.vue.nextTick();
+    expect(errors).toEqual(expectedErrors);
+  }
+
+  testValidationErrors(configurations: ValidationErrorConfiguration[]) {
+    const cases = configurations.map( ({testlabel, store, props, data, errors}) => [
+      testlabel,
+      store ?? setupMockStore(),
+      props ?? {},
+      data,
+      errors
+    ])
+    test.each(cases)('should generate validation error if %s (#%#)', this.checkValidationError.bind(this));
+  }
+
+  testValidate(testConfiguration: TestCaseConfiguration, expectedEmit?: object) {
+    const {testlabel, store, props, data} = testConfiguration;
+    // assume by default that the expected output is the initial input
+    expectedEmit = expectedEmit ?? props?.initialStepValue;
+    it(`should validate and emit "formSaved" when ${testlabel}`, async () => {
+      const wrapper = mount(this.componentType, {
+        store: store ?? setupMockStore(),
+        localVue: this.vue,
+        propsData: props ?? {},
+        sync: false,
+      });
+      if (data) {
+        wrapper.setData(data);
+      }
+      wrapper.find('.widget-form-action__button--validate').trigger('click');
+      await this.vue.nextTick();
+      expect(wrapper.vm.$data.errors).toBeNull();
+      expect(wrapper.emitted()).toEqual({
+        formSaved: [[expectedEmit]],
+      });
+    });
+  }
+
+  testCancel(initialState: Partial<VQBState> = {}) {
+    const store = setupMockStore(initialState);
+    const initialPipeline = [... store.state.vqb.pipeline];
+    const initialStepIndex = store.state.vqb.selectedStepIndex;
+
+    it('should emit "cancel" event when edition is canceled', () => {
+      const wrapper = mount(this.componentType, { store, localVue: this.vue, sync: false });
+      wrapper.find('.step-edit-form__back-button').trigger('click');
+      expect(wrapper.emitted()).toEqual({ cancel: [[]] });
+      expect(store.state.vqb.selectedStepIndex).toEqual(initialStepIndex);
+      expect(store.state.vqb.pipeline).toEqual(initialPipeline);
+    });
+  }
+
+  testResetSelectedIndex(initialState: Partial<VQBState>) {
+    const store = setupMockStore(initialState);
+    const initialStepIndex = store.state.vqb.selectedStepIndex;
+
+    it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
+      const wrapper = mount(this.componentType, { store, localVue: this.vue, sync: false });
+      wrapper.find('.step-edit-form__back-button').trigger('click');
+      expect(store.state.vqb.selectedStepIndex).toEqual(initialStepIndex);
+      wrapper.setProps({ isStepCreation: false });
+      wrapper.find('.step-edit-form__back-button').trigger('click');
+      expect(store.state.vqb.selectedStepIndex).toEqual(initialStepIndex + 1);
+    });
+  }
 }

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -31,7 +31,7 @@ type ComponentType = typeof BaseStepForm;
 type TestCaseConfiguration = {
   testlabel?: string;
   store?: Store<RootState>;
-  props?: {initialStepValue?: object; [prop: string]: any};
+  props?: { initialStepValue?: object; [prop: string]: any };
   data?: object;
 };
 
@@ -57,7 +57,7 @@ export class BasicStepFormTestRunner<StepType> {
 
   _mount(shallow: boolean, initialState: object = {}, optional: MountOptions = {}) {
     const mountfunc = shallow ? shallowMount : mount;
-    const {propsData, data} = optional;
+    const { propsData, data } = optional;
     const wrapper = mountfunc(this.componentType, {
       store: initialState ? setupMockStore(initialState) : undefined,
       propsData,
@@ -86,8 +86,10 @@ export class BasicStepFormTestRunner<StepType> {
     });
   }
 
-  testExpectedComponents(componentSpec: {[prop: string]: number}) {
-    const specStr = Object.entries(componentSpec).map((k, v) => `${v} ${k}`).join(', ');
+  testExpectedComponents(componentSpec: { [prop: string]: number }) {
+    const specStr = Object.entries(componentSpec)
+      .map((k, v) => `${v} ${k}`)
+      .join(', ');
     it(`should generate ${specStr} components`, () => {
       const wrapper = this.shallowMount();
       for (const [componentName, count] of Object.entries(componentSpec)) {
@@ -97,7 +99,13 @@ export class BasicStepFormTestRunner<StepType> {
     });
   }
 
-  async checkValidationError(testlabel: any, store: any, propsData: any, data: any, expectedErrors: any) {
+  async checkValidationError(
+    testlabel: any,
+    store: any,
+    propsData: any,
+    data: any,
+    expectedErrors: any,
+  ) {
     const wrapper = mount(this.componentType, {
       store,
       propsData,
@@ -118,18 +126,21 @@ export class BasicStepFormTestRunner<StepType> {
   }
 
   testValidationErrors(configurations: ValidationErrorConfiguration[]) {
-    const cases = configurations.map( ({testlabel, store, props, data, errors}) => [
+    const cases = configurations.map(({ testlabel, store, props, data, errors }) => [
       testlabel,
       store ?? setupMockStore(),
       props ?? {},
       data,
-      errors
-    ])
-    test.each(cases)('should generate validation error if %s (#%#)', this.checkValidationError.bind(this));
+      errors,
+    ]);
+    test.each(cases)(
+      'should generate validation error if %s (#%#)',
+      this.checkValidationError.bind(this),
+    );
   }
 
   testValidate(testConfiguration: TestCaseConfiguration, expectedEmit?: object) {
-    const {testlabel, store, props, data} = testConfiguration;
+    const { testlabel, store, props, data } = testConfiguration;
     // assume by default that the expected output is the initial input
     expectedEmit = expectedEmit ?? props?.initialStepValue;
     it(`should validate and emit "formSaved" when ${testlabel}`, async () => {
@@ -153,7 +164,7 @@ export class BasicStepFormTestRunner<StepType> {
 
   testCancel(initialState: Partial<VQBState> = {}) {
     const store = setupMockStore(initialState);
-    const initialPipeline = [... store.state.vqb.pipeline];
+    const initialPipeline = [...store.state.vqb.pipeline];
     const initialStepIndex = store.state.vqb.selectedStepIndex;
 
     it('should emit "cancel" event when edition is canceled', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8872,7 +8872,7 @@ prettier@1.16.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.3.tgz#8c62168453badef702f34b45b6ee899574a6a65d"
   integrity sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==
 
-prettier@^1.18.2:
+prettier@^1.18.2, prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==


### PR DESCRIPTION
Most of the step form tests use the same scenario:

- test that the component can instantiate properly,
- test that it has the expected sub components
- test that validation errors are raised as expeced if some values are missing or don't match
  the specified jsonschema,
- test that the cancel button work.

This PR introduces a new runner class to help factoring out all those common patterns as well as some small `mount` / `shallowMount` helpers with reasonable defaults. Since Jest doesn't provide a class-based architecture, this class is not meant to be subclassed in each test but rather instantiated and its test method called explicitly.
