### PR TITLE
make aggregation column parameters templatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED -
+
+### Changed
+
+- aggregation step input columns are now templatable
+
 ## [0.9.0] - 2020-01-13
 
 ### Changed

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -117,7 +117,15 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   }
 
   aggregate(step: Readonly<S.AggregationStep>) {
-    return { ...step };
+    const aggregations = step.aggregations.map(aggfunc => ({
+      ...aggfunc,
+      column: _interpolate(this.interpolateFunc, aggfunc.column, this.context),
+    }));
+    return {
+      name: step.name,
+      on: step.on.map(col => _interpolate(this.interpolateFunc, col, this.context)),
+      aggregations,
+    };
   }
 
   argmax(step: Readonly<S.ArgmaxStep>) {

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -629,7 +629,10 @@ describe('Pipeline to mongo translator', () => {
       {
         name: 'replace',
         search_column: 'column_1',
-        to_replace: [['foo', 'bar'], ['old', 'new']],
+        to_replace: [
+          ['foo', 'bar'],
+          ['old', 'new'],
+        ],
       },
     ];
     const querySteps = mongo36translator.translate(pipeline);
@@ -673,7 +676,10 @@ describe('Pipeline to mongo translator', () => {
     const pipeline: Pipeline = [
       {
         name: 'sort',
-        columns: [{ column: 'foo', order: 'asc' }, { column: 'bar', order: 'desc' }],
+        columns: [
+          { column: 'foo', order: 'asc' },
+          { column: 'bar', order: 'desc' },
+        ],
       },
     ];
     const querySteps = mongo36translator.translate(pipeline);
@@ -1578,7 +1584,10 @@ describe('Pipeline to mongo translator', () => {
         name: 'join',
         right_pipeline: rightPipeline,
         type: 'inner',
-        on: [['id', 'id'], ['country', 'country']],
+        on: [
+          ['id', 'id'],
+          ['country', 'country'],
+        ],
       },
     ];
     const querySteps = mongo36translator.translate(pipeline);
@@ -1640,7 +1649,10 @@ describe('Pipeline to mongo translator', () => {
         name: 'join',
         right_pipeline: rightPipeline,
         type: 'inner',
-        on: [['id', 'id_right'], ['country', 'country_right']],
+        on: [
+          ['id', 'id_right'],
+          ['country', 'country_right'],
+        ],
       },
     ];
     const querySteps = mongo36translator.translate(pipeline);

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -33,13 +33,53 @@ describe('Pipeline interpolator', () => {
         aggregations: [
           {
             aggfunction: 'avg',
-            column: '<%= foo %>',
+            column: 'spam',
             newcolumn: '<%= egg %>',
           },
         ],
       },
     ];
     expect(translate(pipeline)).toEqual(pipeline);
+  });
+
+  it('should interpolate aggregation steps if needed', () => {
+    const pipeline: Pipeline = [
+      {
+        name: 'aggregate',
+        on: ['column1', '<%= foo %>'],
+        aggregations: [
+          {
+            aggfunction: 'avg',
+            column: '<%= foo %>',
+            newcolumn: '<%= egg %>',
+          },
+          {
+            aggfunction: 'sum',
+            column: '<%= foo %>',
+            newcolumn: '<%= egg %>',
+          },
+        ],
+      },
+    ];
+
+    expect(translate(pipeline)).toEqual([
+      {
+        name: 'aggregate',
+        on: ['column1', 'bar'],
+        aggregations: [
+          {
+            aggfunction: 'avg',
+            column: 'bar',
+            newcolumn: '<%= egg %>',
+          },
+          {
+            aggfunction: 'sum',
+            column: 'bar',
+            newcolumn: '<%= egg %>',
+          },
+        ],
+      },
+    ]);
   });
 
   it('should leave append steps untouched', () => {


### PR DESCRIPTION
```javascript
      {
        name: 'aggregate',
        on: ['column1', '<%= foo %>'],
        aggregations: [
          {
            aggfunction: 'avg',
            column: '<%= foo %>',
            newcolumn: '<%= egg %>',
          },
         ],
      }
```

with the context `{foo: 'bar'}` will generate:

```javascript
      {
        name: 'aggregate',
        on: ['column1', 'bar'],
        aggregations: [
          {
            aggfunction: 'avg',
            column: 'bar'
            newcolumn: '<%= egg %>',
          },
         ],
      }
```

closes #411