### PR TITLE
add basic support for regexp in filter steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - add "date extraction" operations
+- added basic regexp support in filter steps
 
 ### Changed
 

--- a/docs/_docs/tech/steps.md
+++ b/docs/_docs/tech/steps.md
@@ -685,11 +685,13 @@ Filter out lines that don't match a filter definition.
 ```
 
 `operator` is optional, and defaults to `eq`. Allowed operators are `eq`, `ne`,
-`gt`, `ge`, `lt`, `le`, `in`, `nin`, `isnull` or `notnull`.
+`gt`, `ge`, `lt`, `le`, `in`, `nin`, `matches`, `notmatches` `isnull` or `notnull`.
 
-`value` can be an arbitrary value depending on the selected operator (e.g a list 
-when used with the `in` operator, or `null` when used with the `isnull` 
+`value` can be an arbitrary value depending on the selected operator (e.g a list
+when used with the `in` operator, or `null` when used with the `isnull`
 operator).
+
+`matches` and `notmatches` operators are used to test value against a regular expression.
 
 **This step is supported by the following backends:**
 

--- a/docs/_docs/user-interface/filter.md
+++ b/docs/_docs/user-interface/filter.md
@@ -27,10 +27,11 @@ moment, we only support `and` as logical link between conditions.
 
 - `Must...`: a comparison operator (equal, not equal etc.)
 
-- Then you can enter value(s) to be compared to. For `be one of` and
-  `not be one of` operators, you can enter several values. For the `be null` and
-  `not be null` operators, you do not need to enter any value as it is a
-  comparison aginst `null` values.
+- Then you can enter value(s) to be compared to. For `be one of` and `not be one
+  of` operators, you can enter several values. For the `be null` and `not be
+  null` operators, you do not need to enter any value as it is a comparison
+  aginst `null` values. `matches` and `notmatches` operators are used to test
+  value against a regular expression.
 
 - `Add condition`: use this button if you need to add a new condition line. The
   retained rows will be those match every condition (logical `and`)

--- a/src/components/stepforms/schemas/filter.ts
+++ b/src/components/stepforms/schemas/filter.ts
@@ -45,7 +45,20 @@ export default {
         },
         operator: {
           type: 'string',
-          enum: ['eq', 'ne', 'gt', 'ge', 'lt', 'le', 'in', 'nin', 'isnull', 'notnull'],
+          enum: [
+            'eq',
+            'ne',
+            'gt',
+            'ge',
+            'lt',
+            'le',
+            'in',
+            'nin',
+            'matches',
+            'notmatches',
+            'isnull',
+            'notnull',
+          ],
           title: 'Operator',
           description: 'The filter operator',
           attrs: {

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -23,6 +23,7 @@
       />
     </div>
     <component
+      id="filterValue"
       v-if="inputWidget"
       :is="inputWidget"
       v-model="editedValue.value"
@@ -55,6 +56,8 @@ type LiteralOperator =
   | 'be less than or equal to'
   | 'be one of'
   | 'not be one of'
+  | 'matches pattern'
+  | "doesn't match pattern"
   | 'be null'
   | 'not be null';
 
@@ -101,11 +104,18 @@ export default class FilterSimpleConditionWidget extends Vue {
     { operator: 'le', label: 'be less than or equal to', inputWidget: InputTextWidget },
     { operator: 'in', label: 'be one of', inputWidget: MultiInputTextWidget },
     { operator: 'nin', label: 'not be one of', inputWidget: MultiInputTextWidget },
+    { operator: 'matches', label: 'matches pattern', inputWidget: InputTextWidget },
+    { operator: 'notmatches', label: "doesn't match pattern", inputWidget: InputTextWidget },
     { operator: 'isnull', label: 'be null' },
     { operator: 'notnull', label: 'not be null' },
   ];
 
-  readonly placeholder = 'Enter a value';
+  get placeholder() {
+    if (this.editedValue.operator === 'matches' || this.editedValue.operator === 'notmatches') {
+      return 'Enter a regex, e.g. "[Ss]ales"';
+    }
+    return 'Enter a value';
+  }
 
   get operator(): OperatorOption {
     return this.operators.filter(d => d.operator === this.editedValue.operator)[0];

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -65,6 +65,10 @@ function filterExpression(
         return `"${condition.column}" in (${condition.value.join(MULTIVALUE_SEP)})`;
       case 'nin':
         return `"${condition.column}" not in (${condition.value.join(MULTIVALUE_SEP)})`;
+      case 'matches':
+        return `"${condition.column}" matches regex "${condition.value}"`;
+      case 'notmatches':
+        return `"${condition.column}" doesn't match regex "${condition.value}"`;
       case 'isnull':
         return `"${condition.column}" is null`;
       case 'notnull':

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -124,7 +124,7 @@ type FilterConditionComparison = {
 type FilterConditionEquality = {
   column: string;
   value: any;
-  operator: 'eq' | 'ne' | 'isnull' | 'notnull';
+  operator: 'eq' | 'ne' | 'isnull' | 'notnull' | 'matches' | 'notmatches';
 };
 
 type FilterConditionInclusion = {

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -89,6 +89,11 @@ function buildMatchTree(
   if (S.isFilterComboOr(cond)) {
     return { $or: cond.or.map(elem => buildMatchTree(elem, 'or')) };
   }
+  if (cond.operator === 'matches') {
+    return { [cond.column]: { $regex: cond.value } };
+  } else if (cond.operator === 'notmatches') {
+    return { [cond.column]: { $not: { $regex: cond.value } } };
+  }
   return { [cond.column]: { [operatorMapping[cond.operator]]: cond.value } };
 }
 

--- a/tests/unit/filter-step-form.spec.ts
+++ b/tests/unit/filter-step-form.spec.ts
@@ -71,6 +71,42 @@ describe('Filter Step Form', () => {
     expect(wrapper.classes()).toContain('filter-form--multiple-conditions');
   });
 
+  describe('PlaceHolders', () => {
+    it('should have a default placeholder', async () => {
+      const wrapper = runner.mount(
+        {},
+        {
+          data: {
+            editedStep: {
+              name: 'filter',
+              condition: { and: [{ column: 'foo', value: 'bar', operator: 'gt' }] },
+            },
+          },
+        },
+      );
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('#filterValue').attributes('placeholder')).toEqual('Enter a value');
+    });
+
+    it('should have a specific placeholder for regular expressions', async () => {
+      const wrapper = runner.mount(
+        {},
+        {
+          data: {
+            editedStep: {
+              name: 'filter',
+              condition: { and: [{ column: 'foo', value: 'bar', operator: 'matches' }] },
+            },
+          },
+        },
+      );
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('#filterValue').attributes('placeholder')).toEqual(
+        'Enter a regex, e.g. "[Ss]ales"',
+      );
+    });
+  });
+
   describe('ListWidget', () => {
     it('should pass down the "condition" prop to the ListWidget value prop', async () => {
       const wrapper = runner.shallowMount(undefined, {

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -229,6 +229,30 @@ describe('Labeller', () => {
     expect(hrl(step)).toEqual('Keep rows where "column1" not in (4, 2)');
   });
 
+  it('generates label for simple filter steps / operator "matches"', () => {
+    const step: S.FilterStep = {
+      name: 'filter',
+      condition: {
+        column: 'column1',
+        value: '[a-z]+',
+        operator: 'matches',
+      },
+    };
+    expect(hrl(step)).toEqual('Keep rows where "column1" matches regex "[a-z]+"');
+  });
+
+  it('generates label for simple filter steps / operator "notmatches"', () => {
+    const step: S.FilterStep = {
+      name: 'filter',
+      condition: {
+        column: 'column1',
+        value: '[a-z]+',
+        operator: 'notmatches',
+      },
+    };
+    expect(hrl(step)).toEqual('Keep rows where "column1" doesn\'t match regex "[a-z]+"');
+  });
+
   it('generates label for simple filter steps / operator "isnull"', () => {
     const step: S.FilterStep = {
       name: 'filter',

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -110,6 +110,11 @@ describe('Pipeline to mongo translator', () => {
       { name: 'filter', condition: { column: 'Value', value: 100, operator: 'ge' } },
       { name: 'filter', condition: { column: 'Category', value: ['Foo', 'Bar'], operator: 'in' } },
       { name: 'filter', condition: { column: 'Code', value: [0, 42], operator: 'nin' } },
+      { name: 'filter', condition: { column: 'Name', value: '/^[a-z]+$/i', operator: 'matches' } },
+      {
+        name: 'filter',
+        condition: { column: 'Pin', value: '/^[a-z]+$/i', operator: 'notmatches' },
+      },
       { name: 'filter', condition: { column: 'IsNull', value: null, operator: 'isnull' } },
       { name: 'filter', condition: { column: 'NotNull', value: null, operator: 'notnull' } },
     ];
@@ -126,6 +131,8 @@ describe('Pipeline to mongo translator', () => {
           Weight: { $gt: 60 },
           Value: { $gte: 100 },
           Category: { $in: ['Foo', 'Bar'] },
+          Name: { $regex: '/^[a-z]+$/i' },
+          Pin: { $not: { $regex: '/^[a-z]+$/i' } },
           Code: { $nin: [0, 42] },
           IsNull: { $eq: null },
           NotNull: { $ne: null },


### PR DESCRIPTION
This commit introduces two new filter operators:

- `matches` to test a value against a regexp
- `notmatches` to make sure a value doesn't match a regexp

This is translated directly to the `$regex` operator in mongo.

UI wise, we chose to add two new operatoers in the operator dropdown and
use the standard input widget for the user to type its regexp.

Current known limitations:

- it is not possible to use regexp with `in` / `nin` operators
- it is not possible to use flags (such as `i` to ignore case) but this
  can be circumvented most of the time by adding a column with a
  normalized value (e.g. lowercased) before testing the regexp.

closes #415