### PR TITLE
Reorder aggregate widget

### DIFF
--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -133,6 +133,12 @@ export const CATEGORY_BUTTONS: ButtonDef[] = [
     label: 'Filter',
   },
   {
+    category: 'aggregate',
+    enable: true,
+    icon: 'code-branch',
+    label: 'Aggregate',
+  },
+  {
     category: 'compute',
     enable: true,
     icon: 'calculator',
@@ -149,12 +155,6 @@ export const CATEGORY_BUTTONS: ButtonDef[] = [
     enable: true,
     icon: 'calendar',
     label: 'Date',
-  },
-  {
-    category: 'aggregate',
-    enable: true,
-    icon: 'code-branch',
-    label: 'Aggregate',
   },
   {
     category: 'reshape',

--- a/tests/unit/action-toolbar.spec.ts
+++ b/tests/unit/action-toolbar.spec.ts
@@ -25,13 +25,13 @@ describe('ActionToolbar', () => {
     expect(actionButtons.at(0).classes()).toContain('action-toolbar__btn');
     expect(actionButtons.at(1).props().category).toEqual('filter');
     expect(actionButtons.at(1).classes()).toContain('action-toolbar__btn');
-    expect(actionButtons.at(2).props().category).toEqual('compute');
+    expect(actionButtons.at(2).props().category).toEqual('aggregate');
     expect(actionButtons.at(2).classes()).toContain('action-toolbar__btn');
-    expect(actionButtons.at(3).props().category).toEqual('text');
+    expect(actionButtons.at(3).props().category).toEqual('compute');
     expect(actionButtons.at(3).classes()).toContain('action-toolbar__btn');
-    expect(actionButtons.at(4).props().category).toEqual('date');
+    expect(actionButtons.at(4).props().category).toEqual('text');
     expect(actionButtons.at(4).classes()).toContain('action-toolbar__btn');
-    expect(actionButtons.at(5).props().category).toEqual('aggregate');
+    expect(actionButtons.at(5).props().category).toEqual('date');
     expect(actionButtons.at(5).classes()).toContain('action-toolbar__btn');
     expect(actionButtons.at(6).props().category).toEqual('reshape');
     expect(actionButtons.at(6).classes()).toContain('action-toolbar__btn');


### PR DESCRIPTION
This proposal comes from an interesting user feedback: we should order widgets in accordance with best practices in terms of transformations order.
In best case scenarios, we want the user to filter, then aggregate in order to perform additional computations on a data subset as small as possible.