### PR TITLE
Fix :: add form input text ellipsis and wrong height dataset cells

### DIFF
--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -109,6 +109,11 @@ export default class AutocompleteWidget extends Mixins(FormWidget) {
   color: $base-color-light;
   font-size: 14px;
   margin-bottom: 0;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  white-space: nowrap;
 }
 
 .widget-autocomplete__container .multiselect__content-wrapper {

--- a/src/styles/DataViewer.scss
+++ b/src/styles/DataViewer.scss
@@ -44,6 +44,7 @@
 
 .data-viewer-cell {
   background-color: #fafafa;
+  white-space: normal;
 }
 
 .data-viewer__header-cell--active,


### PR DESCRIPTION
All in the title ⬆️ 

** Form multiselect add ellipsis **
before :
![image](https://user-images.githubusercontent.com/4438175/73863140-e7f5b300-483f-11ea-9287-1103d0ac7d4b.png)

after :
![image](https://user-images.githubusercontent.com/4438175/73863155-ec21d080-483f-11ea-8674-8c2ca291d60f.png)

** Dataset wrong height **
before :
![image](https://user-images.githubusercontent.com/4438175/73863281-1c696f00-4840-11ea-81f9-a0c3d1f6b972.png)

Now:
![image](https://user-images.githubusercontent.com/4438175/73863312-27240400-4840-11ea-9307-a31f8c1c5857.png)
