### PR TITLE
Condition editor component

### DIFF
--- a/.storybook/bundle.ts
+++ b/.storybook/bundle.ts
@@ -4,10 +4,12 @@
 */
 
 import DataViewer from '../src/components/DataViewer.vue';
-import RenameStepForm from '../src/components/RenameStepForm.vue';
+import RenameStepForm from '../src/components/stepforms/RenameStepForm.vue';
 import Pipeline from '../src/components/Pipeline.vue';
 import ResizablePanels from '../src/components/ResizablePanels.vue';
 import Step from '../src/components/Step.vue';
+import ConditionForm from '../src/components/stepforms/ConditionsEditor/ConditionForm.vue';
+import ConditionsEditor from '../src/components/stepforms/ConditionsEditor/ConditionsEditor.vue';
 
-export { DataViewer, RenameStepForm, Pipeline, ResizablePanels, Step };
+export { ConditionForm, ConditionsEditor, DataViewer, RenameStepForm, Pipeline, ResizablePanels, Step };
 export { setupStore } from '../src/store';

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css"
+  integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous" />

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "@vue/test-utils": "^1.0.0-beta.29",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.8.0",
+    "babel-loader": "^8.0.6",
+    "babel-preset-vue": "^2.0.2",
     "body-parser": "^1.19.0",
     "codecov": "^3.3.0",
     "concurrently": "^4.1.0",

--- a/src/components/stepforms/ConditionsEditor/ConditionForm.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionForm.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="condition-form">
+    <input
+      :value="condition.column"
+      class="condition-form__input condition-form__input--column"
+      @input="updateInput('column', $event.target.value)"
+    >
+    <input
+      :value="condition.comparison"
+      class="condition-form__input condition-form__input--comparison"
+      @input="updateInput('comparison', $event.target.value)"
+    >
+    <input
+      :value="condition.value"
+      class="condition-form__input condition-form__input--value"
+      @input="updateInput('value', $event.target.value)"
+    >
+  </div>
+</template>
+
+<script lang="ts">
+import _ from 'lodash';
+
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+import { TempFilterCondition } from '@/lib/steps';
+
+@Component({
+  name: 'condition-form',
+})
+
+export default class ConditionForm extends Vue {
+  @Prop({
+    type: Object,
+    default: () => ({ column: '', comparison: 'eq', value: ''})
+  })
+  condition!: TempFilterCondition;
+
+  updateInput = _.debounce((type: string, newValue: any) => {
+    const newCondition = {
+      ...this.condition,
+      [type]: newValue,
+    };
+    this.$emit('conditionUpdated', newCondition);
+  }, 500);
+}
+</script>
+
+<style lang="scss">
+
+.condition-form {
+  display: flex;
+  flex-grow: 1;
+}
+
+.condition-form__input {
+  box-sizing: border-box;
+  height: 40px;
+  flex-grow: 1;
+  font-size: 14px;
+  margin: 3px;
+  padding: 8px 10px;
+}
+</style>

--- a/src/components/stepforms/ConditionsEditor/ConditionForm.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionForm.vue
@@ -19,7 +19,6 @@
 </template>
 
 <script lang="ts">
-import _ from 'lodash';
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import { FilterSimpleCondition } from '@/lib/steps';
@@ -43,13 +42,13 @@ export default class ConditionForm extends Vue {
     }
   }
 
-  updateInput = _.debounce((type: string, newValue: any) => {
+  updateInput(type: string, newValue: any) {
     const newCondition = {
       ...this.condition,
       [type]: newValue,
     };
     this.emitUpdatedCondition(newCondition);
-  }, 500);
+  }
 
   emitUpdatedCondition(newCondition: FilterSimpleCondition) {
     this.$emit('conditionUpdated', newCondition);

--- a/src/components/stepforms/ConditionsEditor/ConditionForm.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionForm.vue
@@ -26,7 +26,7 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 import { TempFilterCondition } from '@/lib/steps';
 
 @Component({
-  name: 'condition-form',
+  name: 'ConditionForm',
 })
 
 export default class ConditionForm extends Vue {

--- a/src/components/stepforms/ConditionsEditor/ConditionForm.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionForm.vue
@@ -6,9 +6,9 @@
       @input="updateInput('column', $event.target.value)"
     >
     <input
-      :value="condition.comparison"
-      class="condition-form__input condition-form__input--comparison"
-      @input="updateInput('comparison', $event.target.value)"
+      :value="condition.operator"
+      class="condition-form__input condition-form__input--operator"
+      @input="updateInput('operator', $event.target.value)"
     >
     <input
       :value="condition.value"
@@ -23,7 +23,9 @@ import _ from 'lodash';
 
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
-import { TempFilterCondition } from '@/lib/steps';
+import { FilterSimpleCondition } from '@/lib/steps';
+
+const EMPTY_CONDITION: FilterSimpleCondition = { column: '', operator: 'eq', value: ''};
 
 @Component({
   name: 'ConditionForm',
@@ -32,17 +34,28 @@ import { TempFilterCondition } from '@/lib/steps';
 export default class ConditionForm extends Vue {
   @Prop({
     type: Object,
-    default: () => ({ column: '', comparison: 'eq', value: ''})
+    default: () => (EMPTY_CONDITION)
   })
-  condition!: TempFilterCondition;
+  condition!: FilterSimpleCondition;
+
+  created() {
+    // In absence of condition, emit directly to the parent the default value
+    if (this.condition === EMPTY_CONDITION) {
+      this.emitUpdatedCondition(EMPTY_CONDITION);
+    }
+  }
 
   updateInput = _.debounce((type: string, newValue: any) => {
     const newCondition = {
       ...this.condition,
       [type]: newValue,
     };
-    this.$emit('conditionUpdated', newCondition);
+    this.emitUpdatedCondition(newCondition);
   }, 500);
+
+  emitUpdatedCondition(newCondition: FilterSimpleCondition) {
+    this.$emit('conditionUpdated', newCondition);
+  }
 }
 </script>
 

--- a/src/components/stepforms/ConditionsEditor/ConditionForm.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionForm.vue
@@ -4,37 +4,35 @@
       :value="condition.column"
       class="condition-form__input condition-form__input--column"
       @input="updateInput('column', $event.target.value)"
-    >
+    />
     <input
       :value="condition.operator"
       class="condition-form__input condition-form__input--operator"
       @input="updateInput('operator', $event.target.value)"
-    >
+    />
     <input
       :value="condition.value"
       class="condition-form__input condition-form__input--value"
       @input="updateInput('value', $event.target.value)"
-    >
+    />
   </div>
 </template>
 
 <script lang="ts">
 import _ from 'lodash';
-
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import { FilterSimpleCondition } from '@/lib/steps';
 
-const EMPTY_CONDITION: FilterSimpleCondition = { column: '', operator: 'eq', value: ''};
+const EMPTY_CONDITION: FilterSimpleCondition = { column: '', operator: 'eq', value: '' };
 
 @Component({
   name: 'ConditionForm',
 })
-
 export default class ConditionForm extends Vue {
   @Prop({
     type: Object,
-    default: () => (EMPTY_CONDITION)
+    default: () => EMPTY_CONDITION,
   })
   condition!: FilterSimpleCondition;
 
@@ -60,7 +58,6 @@ export default class ConditionForm extends Vue {
 </script>
 
 <style lang="scss">
-
 .condition-form {
   display: flex;
   flex-grow: 1;

--- a/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
@@ -25,9 +25,7 @@
 */
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
-import { AbstractFilterTree } from '@/lib/steps';
-
-import ConditionsGroup from './ConditionsGroup.vue';
+import ConditionsGroup, { AbstractFilterTree } from './ConditionsGroup.vue';
 
 @Component({
   name: 'ConditionsEditor',

--- a/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
@@ -22,6 +22,13 @@
 </template>
 
 <script lang="ts">
+/*
+  This component allows editing a tree of arbitrary conditions.
+  These abritrary conditions need each a form, which should be defined in the default slot.
+  This scoped slot will receive in `slotProps` its `condition`, and a `updateCondition` function.
+
+  The trees are intentionnaly limited to 2 levels to avoid unnecessary complexity.
+*/
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import { AbstractFilterTree } from '@/lib/steps';

--- a/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
@@ -10,7 +10,9 @@
       @conditionsTreeUpdated="updateConditionsTree"
     >
       <template v-slot:default="slotProps">
-        <slot v-bind="slotProps" />
+        <slot v-bind="slotProps">
+          <input :value="slotProps.condition" @input="slotProps.updateCondition($event.target.value)">
+        </slot>
       </template>
     </ConditionsGroup>
     <div style="font-size: 10px; margin-top: 30px; white-space: pre;">
@@ -22,7 +24,7 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
-import { TempFilterStep } from '@/lib/steps';
+import { AbstractFilterTree } from '@/lib/steps';
 
 import ConditionsGroup from './ConditionsGroup.vue';
 
@@ -38,13 +40,13 @@ export default class ConditionsEditor extends Vue {
     type: Object,
     default: () => {}
   })
-  conditionsTree!: TempFilterStep;
+  conditionsTree!: AbstractFilterTree;
 
   get conditionsStringify() {
     return JSON.stringify(this.conditionsTree, null, '\t');
   }
 
-  updateConditionsTree(newConditionsTree: object | null) {
+  updateConditionsTree(newConditionsTree: AbstractFilterTree) {
     this.$emit('conditionsTreeUpdated', newConditionsTree);
   }
 }

--- a/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
@@ -8,7 +8,10 @@
     >
       <template v-slot:default="slotProps">
         <slot v-bind="slotProps">
-          <input :value="slotProps.condition" @input="slotProps.updateCondition($event.target.value)">
+          <input
+            :value="slotProps.condition"
+            @input="slotProps.updateCondition($event.target.value)"
+          />
         </slot>
       </template>
     </ConditionsGroup>
@@ -33,11 +36,10 @@ import ConditionsGroup, { AbstractFilterTree } from './ConditionsGroup.vue';
     ConditionsGroup,
   },
 })
-
 export default class ConditionsEditor extends Vue {
   @Prop({
     type: Object,
-    default: () => {}
+    default: () => {},
   })
   conditionsTree!: AbstractFilterTree;
 

--- a/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
@@ -2,10 +2,7 @@
   <div class="conditions-editor">
     <div class="conditions-editor__info">Filter rows matching this condition:</div>
     <ConditionsGroup
-      :conditions-tree="conditionsTree"
-      :conditions="conditionsTree.conditions"
-      :groups="conditionsTree.groups"
-      :operator="conditionsTree.operator"
+      :conditionsTree="conditionsTree"
       :is-root-group="true"
       @conditionsTreeUpdated="updateConditionsTree"
     >

--- a/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
@@ -12,9 +12,6 @@
         </slot>
       </template>
     </ConditionsGroup>
-    <div style="font-size: 10px; margin-top: 30px; white-space: pre;">
-      {{ conditionsStringify }}
-    </div>
   </div>
 </template>
 
@@ -45,10 +42,6 @@ export default class ConditionsEditor extends Vue {
     default: () => {}
   })
   conditionsTree!: AbstractFilterTree;
-
-  get conditionsStringify() {
-    return JSON.stringify(this.conditionsTree, null, '\t');
-  }
 
   updateConditionsTree(newConditionsTree: AbstractFilterTree) {
     this.$emit('conditionsTreeUpdated', newConditionsTree);

--- a/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
@@ -27,7 +27,7 @@ import { TempFilterStep } from '@/lib/steps';
 import ConditionsGroup from './ConditionsGroup.vue';
 
 @Component({
-  name: 'conditions-editor',
+  name: 'ConditionsEditor',
   components: {
     ConditionsGroup,
   },

--- a/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsEditor.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="conditions-editor">
+    <div class="conditions-editor__info">Filter rows matching this condition:</div>
+    <ConditionsGroup
+      :conditions-tree="conditionsTree"
+      :conditions="conditionsTree.conditions"
+      :groups="conditionsTree.groups"
+      :operator="conditionsTree.operator"
+      :is-root-group="true"
+      @conditionsTreeUpdated="updateConditionsTree"
+    >
+      <template v-slot:default="slotProps">
+        <slot v-bind="slotProps" />
+      </template>
+    </ConditionsGroup>
+    <div style="font-size: 10px; margin-top: 30px; white-space: pre;">
+      {{ conditionsStringify }}
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+import { TempFilterStep } from '@/lib/steps';
+
+import ConditionsGroup from './ConditionsGroup.vue';
+
+@Component({
+  name: 'conditions-editor',
+  components: {
+    ConditionsGroup,
+  },
+})
+
+export default class ConditionsEditor extends Vue {
+  @Prop({
+    type: Object,
+    default: () => {}
+  })
+  conditionsTree!: TempFilterStep;
+
+  get conditionsStringify() {
+    return JSON.stringify(this.conditionsTree, null, '\t');
+  }
+
+  updateConditionsTree(newConditionsTree: object | null) {
+    this.$emit('conditionsTreeUpdated', newConditionsTree);
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+$blue: #2a66a1;
+$brown-grey: #888888;
+$blue-extra-light: #f4f7fa;
+
+.conditions-editor {
+  font-family: 'Montserrat', sans-serif;
+  letter-spacing: 1px;
+}
+
+.conditions-editor__content {
+  margin-left: 20px;
+  margin-top: 20px;
+  position: relative;
+}
+
+.conditions-editor__content--with-switch {
+  margin-top: 60px;
+}
+
+.conditions-editor__switch {
+  display: inline-flex;
+  left: -20px;
+  position: absolute;
+  top: -40px;
+  z-index: 1;
+}
+
+.conditions-editor__switch-button {
+  background-color: $blue-extra-light;
+  border-radius: 4px 0 0 4px;
+  color: $brown-grey;
+  cursor: pointer;
+  display: flex;
+  font-size: 10px;
+  font-weight: bold;
+  justify-content: center;
+  padding: 6px 8px;
+  text-transform: uppercase;
+  width: 40px;
+}
+
+.conditions-editor__switch-button--active {
+  background-color: $blue;
+  box-shadow: inset -10px 0px 10px -5px rgba(0, 0, 0, 0.3);
+  color: #fff;
+}
+
+.conditions-editor__switch-button--right {
+  border-radius: 0 4px 4px 0;
+}
+
+.conditions-editor__switch-button--right.conditions-editor__switch-button--active {
+  box-shadow: inset 10px 0px 10px -5px rgba(0, 0, 0, 0.3);
+}
+
+.conditions-editor__action-buttons {
+  display: flex;
+  font-size: 10px;
+  font-weight: bold;
+  position: relative;
+  text-transform: uppercase;
+}
+
+.conditions-editor__link {
+  border-bottom: 1px dashed $blue;
+  border-left: 1px dashed $blue;
+  height: 45px;
+  left: -10px;
+  position: absolute;
+  top: -32px;
+  width: 5px;
+}
+
+.conditions-editor__input {
+  height: 40px;
+  flex-grow: 1;
+  font-size: 14px;
+  margin: 3px;
+  padding: 8px 10px;
+}
+
+.conditions-editor__add-button {
+  color: $blue;
+  margin: 5px;
+
+  &:hover {
+    color: black;
+    cursor: pointer;
+  }
+}
+</style>

--- a/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
@@ -29,8 +29,7 @@
         v-if="hasMultipleRows"
         class="condition-row__link"
         :class="{
-          'condition-row__link--last':
-            !(groups && groups.length) && rowIndex === conditions.length - 1,
+          'condition-row__link--last': isLastRow(rowIndex),
         }"
       >
         <div class="condition-row__link__top" />
@@ -53,7 +52,7 @@
     >
       <div
         class="conditions-group__link"
-        :class="{ 'conditions-group__link--last': groupIndex === groups.length - 1 }"
+        :class="{ 'conditions-group__link--last': isLastGroup(groupIndex) }"
       >
         <div class="conditions-group__link__top" />
         <div class="conditions-group__link__middle" />
@@ -183,6 +182,16 @@ export default class ConditionsGroup extends Vue {
     };
 
     this.emitUpdatedConditionTree(newConditionsTree);
+  }
+
+  isLastRow(rowIndex: number) {
+    const hasGroups = this.groups && this.groups.length;
+    const isLastCondition = rowIndex === this.conditions.length - 1;
+    return !hasGroups && isLastCondition;
+  }
+
+  isLastGroup(groupIndex: number) {
+    return groupIndex === this.groups.length - 1;
   }
 
   updateCondition(rowIndex: number) {

--- a/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
@@ -27,7 +27,7 @@
     </div>
     <i
       v-if="!isRootGroup"
-      class="conditions-group__delete fal fa-trash-alt"
+      class="conditions-group__delete far fa-trash-alt"
       @click="$emit('groupDeleted')"
     />
     <div v-for="(condition, rowIndex) in conditions" :key="'row' + rowIndex" class="condition-row">
@@ -35,7 +35,7 @@
       <slot :condition="condition" :updateCondition="updateCondition(rowIndex)" />
       <i
         v-if="hasMultipleRows"
-        class="condition-row__delete fal fa-trash-alt"
+        class="condition-row__delete far fa-trash-alt"
         @click="deleteRow(rowIndex)"
       />
     </div>
@@ -338,6 +338,11 @@ $grey-light-2: #eeeeee;
   color: $brown-grey-two;
   font-size: 16px;
   margin: 0 12px;
+  display: flex;
+  // Align the trash right of the remaining space
+  flex-shrink: 0;
+  flex-grow: 1;
+  justify-content: flex-end;
 
   &:hover {
     color: #000;

--- a/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
@@ -2,27 +2,28 @@
   <div
     class="conditions-group"
     :class="{
-      'conditions-group--root': isRootGroup,
       'conditions-group--with-switch': hasMultipleRows,
     }"
   >
-    <div v-if="!isRoot" class="conditions-group__link" />
     <div v-if="hasMultipleRows" class="conditions-group__switch">
-      <div
-        id="switch-button-and"
-        class="conditions-group__switch-button"
-        :class="{ 'conditions-group__switch-button--active': operator === 'and' }"
-        @click="switchOperator('and')"
-      >
-        and
-      </div>
-      <div
-        id="switch-button-or"
-        class="conditions-group__switch-button"
-        :class="{ 'conditions-group__switch-button--active': operator === 'or' }"
-        @click="switchOperator('or')"
-      >
-        or
+      <div class="condition-group__switch-link" />
+      <div class="conditions-group__switch-buttons">
+        <div
+          id="switch-button-and"
+          class="conditions-group__switch-button"
+          :class="{ 'conditions-group__switch-button--active': operator === 'and' }"
+          @click="switchOperator('and')"
+        >
+          and
+        </div>
+        <div
+          id="switch-button-or"
+          class="conditions-group__switch-button"
+          :class="{ 'conditions-group__switch-button--active': operator === 'or' }"
+          @click="switchOperator('or')"
+        >
+          or
+        </div>
       </div>
     </div>
     <i
@@ -31,27 +32,52 @@
       @click="$emit('groupDeleted')"
     />
     <div v-for="(condition, rowIndex) in conditions" :key="'row' + rowIndex" class="condition-row">
-      <div v-if="hasMultipleRows" class="condition-row__link" />
-      <slot :condition="condition" :updateCondition="updateCondition(rowIndex)" />
+      <div
+        v-if="hasMultipleRows"
+        class="condition-row__link"
+        :class="{'condition-row__link--last': !(groups && groups.length) && (rowIndex === conditions.length - 1)}"
+      >
+        <div class="condition-row__link__top" />
+        <div class="condition-row__link__middle" />
+        <div class="condition-row__link__bottom" />
+      </div>
+      <div class="condition-row__content">
+        <slot :condition="condition" :updateCondition="updateCondition(rowIndex)" />
+      </div>
       <i
         v-if="hasMultipleRows"
         class="condition-row__delete far fa-trash-alt"
         @click="deleteRow(rowIndex)"
       />
     </div>
-    <ConditionsGroup
+    <div
+      class="conditions-group__child-group"
       v-for="(groupConditionTree, groupIndex) in groups"
       :key="'group' + groupIndex"
-      :conditions-tree="groupConditionTree"
-      @conditionsTreeUpdated="updateGroup(groupIndex, $event)"
-      @groupDeleted="deleteGroup(groupIndex)"
     >
-      <template v-slot:default="slotProps">
-        <slot v-bind="slotProps" />
-      </template>
-    </ConditionsGroup>
+      <div
+        class="conditions-group__link"
+        :class="{'conditions-group__link--last': groupIndex === groups.length - 1}"
+      >
+        <div class="conditions-group__link__top" />
+        <div class="conditions-group__link__middle" />
+        <div class="conditions-group__link__bottom" />
+      </div>
+      <ConditionsGroup
+        :conditions-tree="groupConditionTree"
+        @conditionsTreeUpdated="updateGroup(groupIndex, $event)"
+        @groupDeleted="deleteGroup(groupIndex)"
+      >
+        <template v-slot:default="slotProps">
+          <slot v-bind="slotProps" />
+        </template>
+      </ConditionsGroup>
+    </div>
     <div class="conditions-group__action-buttons">
-      <div v-if="hasMultipleRows" class="conditions-group__link conditions-group__link--dashed" />
+      <div v-if="hasMultipleRows" class="action-buttons__link">
+        <div class="action-buttons__link__top" />
+        <div class="action-buttons__link__middle" />
+      </div>
       <div id="add-row-button" class="conditions-group__add-button" @click="addRow">add condition</div>
       <div id="add-group-button" class="conditions-group__add-button" v-if="isRootGroup" @click="addGroup">
         add group
@@ -197,22 +223,17 @@ $brown-grey-two: #aaaaaa;
 $blue-extra-light: #f4f7fa;
 $grey-light-2: #eeeeee;
 
+$conditions-group-top-margin: 20px;
+$conditions-group-top-left-padding: 30px;
+$conditions-group-bottom-right-padding: 15px;
+$conditions-group-border-width: 1px;
+
 .conditions-group {
-  background: $blue-extra-light;
-  border: 1px solid $grey-light-2;
-  border-radius: 3px;
-  margin-top: 20px;
   position: relative;
-  padding: 30px 15px 15px 30px;
-}
-
-.conditions-group--root {
-  background: white;
-  border: none;
-
-  > .condition-row {
-    background-color: $blue-extra-light;
-  }
+  padding-top: $conditions-group-top-left-padding;
+  padding-left: $conditions-group-top-left-padding;
+  padding-bottom: $conditions-group-bottom-right-padding;
+  padding-right: $conditions-group-bottom-right-padding;
 }
 
 .conditions-group--with-switch {
@@ -220,11 +241,14 @@ $grey-light-2: #eeeeee;
 }
 
 .conditions-group__switch {
-  box-sizing: border-box;
-  display: inline-flex;
   left: 10px;
   position: absolute;
   top: 10px;
+}
+
+.conditions-group__switch-buttons {
+  box-sizing: border-box;
+  display: inline-flex;
   z-index: 1;
 }
 
@@ -279,22 +303,24 @@ $grey-light-2: #eeeeee;
   text-transform: uppercase;
 }
 
-.conditions-group__link {
-  border-bottom: 1px solid $blue;
-  border-left: 1px solid $blue;
-  height: 100%;
-  left: -11px;
-  position: absolute;
-  top: -45px;
-  width: 5px;
+.conditions-group__child-group {
+  position: relative;
+  background: $blue-extra-light;
+  border: $conditions-group-border-width solid $grey-light-2;
+  border-radius: 3px;
+  margin-top: $conditions-group-top-margin;
+
+  .condition-row {
+    background-color: darken($blue-extra-light, 5%);
+  }
 }
 
-.conditions-group__link--dashed {
-  border-bottom: 1px dashed $blue;
-  border-left: 1px dashed $blue;
-  height: 45px;
-  top: -32px;
-  left: -10px;
+.condition-group__switch-link {
+  border-left: 1px solid $blue;
+  height: 50%;
+  position: absolute;
+  left: 10px;
+  top: 100%;
 }
 
 .conditions-group__input {
@@ -316,11 +342,11 @@ $grey-light-2: #eeeeee;
 }
 
 $condition-row-margin: 10px;
-$condition-row-border-width: 10px;
+$condition-row-border-width: 1px;
 
 .condition-row {
   align-items: center;
-  background-color: darken($blue-extra-light, 5%);
+  background-color: $blue-extra-light;
   border: $condition-row-border-width solid $grey-light-2;
   border-radius: 3px;
   display: flex;
@@ -328,31 +354,108 @@ $condition-row-border-width: 10px;
   position: relative;
 }
 
-$condition-row-offset: 35px;
-
-.condition-row__link {
-  border-bottom: 1px solid $blue;
-  border-left: 1px solid $blue;
-  height: calc(100% + #{$condition-row-margin + $condition-row-border-width});
-  left: - ($condition-row-margin + $condition-row-border-width);
-  position: absolute;
-  top: -$condition-row-offset;
-  width: $condition-row-margin + $condition-row-border-width;
+.condition-row__content {
+  flex: 1;
+  overflow: auto;
 }
 
 .condition-row__delete {
   color: $brown-grey-two;
   font-size: 16px;
   margin: 0 12px;
-  display: flex;
-  // Align the trash right of the remaining space
-  flex-shrink: 0;
-  flex-grow: 1;
-  justify-content: flex-end;
 
   &:hover {
     color: #000;
     cursor: pointer;
   }
 }
+
+.condition-row__link {
+  $row-link-width: $condition-row-margin + $condition-row-border-width;
+
+  height: calc(100% + #{2 * $condition-row-margin + $condition-row-border-width});
+  left: -$row-link-width;
+  position: absolute;
+  width: $row-link-width;
+
+  .condition-row__link__middle {
+    height: 0;
+    width: 100%;
+    border-bottom: 1px solid $blue;
+  }
+
+  .condition-row__link__top,
+  .condition-row__link__bottom {
+    height: 50%;
+    border-left: 1px solid $blue;
+  }
+}
+
+.conditions-group__link {
+  $link-width: $conditions-group-top-margin / 2 + 2 * $conditions-group-border-width + $conditions-group-top-left-padding / 2;
+
+  display: flex;
+  flex-direction: column;
+  top: -$conditions-group-top-margin;
+
+  height: calc(100% + #{$conditions-group-top-margin + 2 * $conditions-group-border-width});
+  left: -$conditions-group-top-margin / 2 - $conditions-group-border-width;
+  position: absolute;
+  width: $link-width;
+
+  .conditions-group__link__middle {
+    height: 0;
+    width: 100%;
+    border-bottom: 1px solid $blue;
+  }
+
+  .conditions-group__link__top {
+    // Position the middle link centered to the operator buttons
+    height: $conditions-group-top-margin + $conditions-group-top-left-padding / 1.5;
+  }
+
+  .conditions-group__link__bottom {
+    flex: 1;
+    border-left: 1px solid $blue;
+  }
+
+  .conditions-group__link__top,
+  .conditions-group__link__bottom {
+    border-left: 1px solid $blue;
+  }
+}
+
+// Last link is dashed, to the action buttons
+.condition-row__link--last {
+  .condition-row__link__bottom {
+    border-left-style: dashed;
+  }
+}
+
+.conditions-group__link--last {
+  .conditions-group__link__bottom {
+    border-left-style: dashed;
+  }
+}
+
+.action-buttons__link {
+  $action-button-link-width: $condition-row-margin;
+
+  height: 100%;
+  left: -$action-button-link-width;
+  position: absolute;
+  width: $action-button-link-width;
+
+  .action-buttons__link__top {
+    height: 50%;
+    border-left: 1px dashed $blue;
+  }
+
+  .action-buttons__link__middle {
+    height: 0;
+    width: 100%;
+    border-bottom: 1px dashed $blue;
+  }
+}
+
 </style>

--- a/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
@@ -6,7 +6,7 @@
       'conditions-group--with-switch': hasMultipleRows,
     }"
   >
-    <!-- <div v-if="!isRoot" class="conditions-group__link" /> -->
+    <div v-if="!isRoot" class="conditions-group__link" />
     <div v-if="hasMultipleRows" class="conditions-group__switch">
       <div
         id="switch-button-and"
@@ -282,8 +282,8 @@ $grey-light-2: #eeeeee;
 .conditions-group__link {
   border-bottom: 1px solid $blue;
   border-left: 1px solid $blue;
-  height: 209px;
-  left: -10px;
+  height: 100%;
+  left: -11px;
   position: absolute;
   top: -45px;
   width: 5px;
@@ -294,6 +294,7 @@ $grey-light-2: #eeeeee;
   border-left: 1px dashed $blue;
   height: 45px;
   top: -32px;
+  left: -10px;
 }
 
 .conditions-group__input {
@@ -314,24 +315,29 @@ $grey-light-2: #eeeeee;
   }
 }
 
+$condition-row-margin: 10px;
+$condition-row-border-width: 10px;
+
 .condition-row {
   align-items: center;
   background-color: darken($blue-extra-light, 5%);
-  border: 1px solid $grey-light-2;
+  border: $condition-row-border-width solid $grey-light-2;
   border-radius: 3px;
   display: flex;
-  margin: 10px 0;
+  margin: $condition-row-margin 0;
   position: relative;
 }
+
+$condition-row-offset: 35px;
 
 .condition-row__link {
   border-bottom: 1px solid $blue;
   border-left: 1px solid $blue;
-  height: 60px;
-  left: -11px;
+  height: calc(100% + #{$condition-row-margin + $condition-row-border-width});
+  left: - ($condition-row-margin + $condition-row-border-width);
   position: absolute;
-  top: -35px;
-  width: 10px;
+  top: -$condition-row-offset;
+  width: $condition-row-margin + $condition-row-border-width;
 }
 
 .condition-row__delete {

--- a/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
@@ -26,11 +26,6 @@
         </div>
       </div>
     </div>
-    <i
-      v-if="!isRootGroup"
-      class="conditions-group__delete far fa-trash-alt"
-      @click="$emit('groupDeleted')"
-    />
     <div v-for="(condition, rowIndex) in conditions" :key="'row' + rowIndex" class="condition-row">
       <div
         v-if="hasMultipleRows"
@@ -66,21 +61,24 @@
       <ConditionsGroup
         :conditions-tree="groupConditionTree"
         @conditionsTreeUpdated="updateGroup(groupIndex, $event)"
-        @groupDeleted="deleteGroup(groupIndex)"
       >
         <template v-slot:default="slotProps">
           <slot v-bind="slotProps" />
         </template>
       </ConditionsGroup>
+      <i
+        class="conditions-group__delete far fa-trash-alt"
+        @click="deleteGroup(groupIndex)"
+      />
     </div>
     <div class="conditions-group__action-buttons">
       <div v-if="hasMultipleRows" class="action-buttons__link">
         <div class="action-buttons__link__top" />
         <div class="action-buttons__link__middle" />
       </div>
-      <div id="add-row-button" class="conditions-group__add-button" @click="addRow">add condition</div>
-      <div id="add-group-button" class="conditions-group__add-button" v-if="isRootGroup" @click="addGroup">
-        add group
+      <div class="conditions-group__add-button conditions-group__add-button--condition" @click="addRow">Add condition</div>
+      <div class="conditions-group__add-button conditions-group__add-button--group" v-if="isRootGroup" @click="addGroup">
+        Add group
       </div>
     </div>
   </div>
@@ -89,7 +87,15 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
-import { AbstractFilterTree, AbstractCondition, ConditionOperator } from '@/lib/steps';
+export type GenericFilterTree<ConditionType extends AbstractCondition> = {
+  conditions: ConditionType[];
+  groups: GenericFilterTree<ConditionType>[];
+  operator: ConditionOperator;
+};
+
+export type ConditionOperator = 'and' | 'or';
+export type AbstractCondition = any;
+export type AbstractFilterTree = GenericFilterTree<AbstractCondition>;
 
 @Component({
   name: 'ConditionsGroup',
@@ -190,7 +196,7 @@ export default class ConditionsGroup extends Vue {
     };
   }
 
-  updateGroup(groupIndex: number, g: any) {
+  updateGroup(groupIndex: number, g: AbstractFilterTree) {
     const newGroups = [...this.groups];
     newGroups[groupIndex] = g;
 

--- a/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
@@ -28,7 +28,10 @@
       <div
         v-if="hasMultipleRows"
         class="condition-row__link"
-        :class="{'condition-row__link--last': !(groups && groups.length) && (rowIndex === conditions.length - 1)}"
+        :class="{
+          'condition-row__link--last':
+            !(groups && groups.length) && rowIndex === conditions.length - 1,
+        }"
       >
         <div class="condition-row__link__top" />
         <div class="condition-row__link__middle" />
@@ -50,7 +53,7 @@
     >
       <div
         class="conditions-group__link"
-        :class="{'conditions-group__link--last': groupIndex === groups.length - 1}"
+        :class="{ 'conditions-group__link--last': groupIndex === groups.length - 1 }"
       >
         <div class="conditions-group__link__top" />
         <div class="conditions-group__link__middle" />
@@ -64,18 +67,24 @@
           <slot v-bind="slotProps" />
         </template>
       </ConditionsGroup>
-      <i
-        class="conditions-group__delete far fa-trash-alt"
-        @click="deleteGroup(groupIndex)"
-      />
+      <i class="conditions-group__delete far fa-trash-alt" @click="deleteGroup(groupIndex)" />
     </div>
     <div class="conditions-group__action-buttons">
       <div v-if="hasMultipleRows" class="action-buttons__link">
         <div class="action-buttons__link__top" />
         <div class="action-buttons__link__middle" />
       </div>
-      <div class="conditions-group__add-button conditions-group__add-button--condition" @click="addRow">Add condition</div>
-      <div class="conditions-group__add-button conditions-group__add-button--group" v-if="isRootGroup" @click="addGroup">
+      <div
+        class="conditions-group__add-button conditions-group__add-button--condition"
+        @click="addRow"
+      >
+        Add condition
+      </div>
+      <div
+        class="conditions-group__add-button conditions-group__add-button--group"
+        v-if="isRootGroup"
+        @click="addGroup"
+      >
         Add group
       </div>
     </div>
@@ -98,17 +107,16 @@ export type AbstractFilterTree = GenericFilterTree<AbstractCondition>;
 @Component({
   name: 'ConditionsGroup',
 })
-
 export default class ConditionsGroup extends Vue {
   @Prop({
     type: Object,
-    default: () => ({ operator: 'and', conditions: [], groups: []})
+    default: () => ({ operator: 'and', conditions: [], groups: [] }),
   })
   conditionsTree!: AbstractFilterTree;
 
   @Prop({
     type: Boolean,
-    default: false
+    default: false,
   })
   isRootGroup!: boolean;
 
@@ -133,11 +141,8 @@ export default class ConditionsGroup extends Vue {
     newGroups.push({
       operator: 'and',
       // Pass undefined values to force ConditionForm to use its default condition prop value
-      conditions: [
-        undefined,
-        undefined,
-      ],
-      groups: []
+      conditions: [undefined, undefined],
+      groups: [],
     });
 
     const newConditionsTree = {
@@ -396,7 +401,8 @@ $condition-row-border-width: 1px;
 }
 
 .conditions-group__link {
-  $link-width: $conditions-group-top-margin / 2 + 2 * $conditions-group-border-width + $conditions-group-top-left-padding / 2;
+  $link-width: $conditions-group-top-margin / 2 + 2 * $conditions-group-border-width +
+    $conditions-group-top-left-padding / 2;
 
   display: flex;
   flex-direction: column;
@@ -461,5 +467,4 @@ $condition-row-border-width: 1px;
     border-bottom: 1px dashed $blue;
   }
 }
-
 </style>

--- a/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
@@ -1,0 +1,345 @@
+<template>
+  <div
+    class="conditions-group"
+    :class="{
+      'conditions-group--root': isRootGroup,
+      'conditions-group--with-switch': hasMultipleRows,
+    }"
+  >
+    <!-- <div v-if="!isRoot" class="conditions-group__link" /> -->
+    <div v-if="hasMultipleRows" class="conditions-group__switch">
+      <div
+        id="switch-button-and"
+        class="conditions-group__switch-button"
+        :class="{ 'conditions-group__switch-button--active': operator === 'and' }"
+        @click="switchOperator('and')"
+      >
+        and
+      </div>
+      <div
+        id="switch-button-or"
+        class="conditions-group__switch-button"
+        :class="{ 'conditions-group__switch-button--active': operator === 'or' }"
+        @click="switchOperator('or')"
+      >
+        or
+      </div>
+    </div>
+    <i
+      v-if="!isRootGroup"
+      class="conditions-group__delete fal fa-trash-alt"
+      @click="$emit('groupDeleted')"
+    />
+    <div v-for="(condition, rowIndex) in conditions" :key="'row' + rowIndex" class="condition-row">
+      <div v-if="hasMultipleRows" class="condition-row__link" />
+      <slot :condition="condition" :updateCondition="updateCondition(rowIndex)" />
+      <i
+        v-if="hasMultipleRows"
+        class="condition-row__delete fal fa-trash-alt"
+        @click="deleteRow(rowIndex)"
+      />
+    </div>
+    <ConditionsGroup
+      v-for="(groupConditionTree, groupIndex) in groups"
+      :key="'group' + groupIndex"
+      :conditions-tree="groupConditionTree"
+      @conditionsTreeUpdated="updateGroup(groupIndex, $event)"
+      @groupDeleted="deleteGroup(groupIndex)"
+    >
+      <template v-slot:default="slotProps">
+        <slot v-bind="slotProps" />
+      </template>
+    </ConditionsGroup>
+    <div class="conditions-group__action-buttons">
+      <div v-if="hasMultipleRows" class="conditions-group__link conditions-group__link--dashed" />
+      <div id="add-row-button" class="conditions-group__add-button" @click="addRow">add condition</div>
+      <div id="add-group-button" class="conditions-group__add-button" v-if="isRootGroup" @click="addGroup">
+        add group
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+import { TempFilterStep } from '@/lib/steps';
+
+@Component({
+  name: 'conditionsGroup',
+})
+
+export default class ConditionsGroup extends Vue {
+  @Prop({
+    type: Object,
+    default: () => ({ operator: 'and', conditions: [], groups: []})
+  })
+  conditionsTree!: TempFilterStep;
+
+  @Prop({
+    type: Boolean,
+    default: false
+  })
+  isRootGroup!: boolean;
+
+  get operator() {
+    return this.conditionsTree.operator;
+  }
+
+  get conditions() {
+    return this.conditionsTree.conditions;
+  }
+
+  get groups() {
+    return this.conditionsTree.groups;
+  }
+
+  get hasMultipleRows() {
+    return this.conditions.length > 1 || (this.groups && this.groups.length > 0);
+  }
+
+  addGroup() {
+    const newGroups = this.conditionsTree.groups || [];
+    newGroups.push({
+      operator: 'and',
+      // // Pass undefined values to force ConditionForm to use its default condition prop value
+      // conditions: [undefined, undefined],
+      conditions: [
+        { column: '', comparison: '', value: ''}
+        ,
+        { column: '', comparison: '', value: ''}
+      ],
+      groups: []
+    });
+
+    const newConditionsTree = {
+      ...this.conditionsTree,
+      groups: newGroups,
+    };
+    this.$emit('conditionsTreeUpdated', newConditionsTree);
+  }
+
+  addRow() {
+    const newConditionsTree = {
+      ...this.conditionsTree,
+      // Pass undefined value to force ConditionForm to use its default condition prop value
+      conditions: [...this.conditions, { column: '', comparison: '', value: ''}],
+    };
+    this.$emit('conditionsTreeUpdated', newConditionsTree);
+  }
+
+  deleteGroup(groupIndex: number) {
+    const newGroups = [...this.groups];
+    newGroups.splice(groupIndex, 1);
+
+    const newConditionsTree = {
+      ...this.conditionsTree,
+      groups: newGroups,
+    };
+
+    this.$emit('conditionsTreeUpdated', newConditionsTree);
+  }
+
+  deleteRow(rowIndex: number) {
+    const newConditions = [...this.conditions];
+    newConditions.splice(rowIndex, 1);
+
+    const newConditionsTree = {
+      ...this.conditionsTree,
+      conditions: newConditions,
+    };
+
+    this.$emit('conditionsTreeUpdated', newConditionsTree);
+  }
+
+  updateCondition(rowIndex: number) {
+    return (c: any) => {
+      const newConditions = [...this.conditions];
+      newConditions[rowIndex] = c;
+
+      const newConditionsTree = {
+        ...this.conditionsTree,
+        conditions: newConditions,
+      };
+
+      this.$emit('conditionsTreeUpdated', newConditionsTree);
+    };
+  }
+
+  updateGroup(groupIndex: number, g: any) {
+    const newGroups = [...this.groups];
+    newGroups[groupIndex] = g;
+
+    const newConditionsTree = {
+      ...this.conditionsTree,
+      groups: newGroups,
+    };
+
+    this.$emit('conditionsTreeUpdated', newConditionsTree);
+  }
+
+  switchOperator(newOperator: string) {
+    const newConditionsTree = {
+      ...this.conditionsTree,
+      operator: newOperator,
+    };
+    this.$emit('conditionsTreeUpdated', newConditionsTree);
+  }
+}
+</script>
+
+<style lang="scss">
+$blue: #2a66a1;
+$brown-grey: #888888;
+$brown-grey-two: #aaaaaa;
+$blue-extra-light: #f4f7fa;
+$grey-light-2: #eeeeee;
+
+.conditions-group {
+  background: $blue-extra-light;
+  border: 1px solid $grey-light-2;
+  border-radius: 3px;
+  margin-top: 20px;
+  position: relative;
+  padding: 30px 15px 15px 30px;
+}
+
+.conditions-group--root {
+  background: white;
+  border: none;
+
+  > .condition-row {
+    background-color: $blue-extra-light;
+  }
+}
+
+.conditions-group--with-switch {
+  padding-top: 40px;
+}
+
+.conditions-group__switch {
+  box-sizing: border-box;
+  display: inline-flex;
+  left: 10px;
+  position: absolute;
+  top: 10px;
+  z-index: 1;
+}
+
+.conditions-group__delete {
+  color: $brown-grey-two;
+  font-size: 16px;
+  position: absolute;
+  right: 15px;
+  top: 15px;
+
+  &:hover {
+    color: #000;
+    cursor: pointer;
+  }
+}
+
+.conditions-group__switch-button {
+  background-color: $grey-light-2;
+  border-radius: 4px 0 0 4px;
+  color: $brown-grey;
+  cursor: pointer;
+  display: flex;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 10px;
+  font-weight: bold;
+  justify-content: center;
+  padding: 6px 8px;
+  text-transform: uppercase;
+  width: 40px;
+
+  &:last-child {
+    border-radius: 0 4px 4px 0;
+  }
+
+  &:last-child.conditions-group__switch-button--active {
+    box-shadow: inset 10px 0px 10px -5px rgba(0, 0, 0, 0.3);
+  }
+}
+
+.conditions-group__switch-button--active {
+  background-color: $blue;
+  box-shadow: inset -10px 0px 10px -5px rgba(0, 0, 0, 0.3);
+  color: #fff;
+}
+
+.conditions-group__action-buttons {
+  display: flex;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 10px;
+  font-weight: bold;
+  position: relative;
+  text-transform: uppercase;
+}
+
+.conditions-group__link {
+  border-bottom: 1px solid $blue;
+  border-left: 1px solid $blue;
+  height: 209px;
+  left: -10px;
+  position: absolute;
+  top: -45px;
+  width: 5px;
+}
+
+.conditions-group__link--dashed {
+  border-bottom: 1px dashed $blue;
+  border-left: 1px dashed $blue;
+  height: 45px;
+  top: -32px;
+}
+
+.conditions-group__input {
+  height: 40px;
+  flex-grow: 1;
+  font-size: 14px;
+  margin: 3px;
+  padding: 8px 10px;
+}
+
+.conditions-group__add-button {
+  color: $blue;
+  margin: 5px;
+
+  &:hover {
+    color: black;
+    cursor: pointer;
+  }
+}
+
+.condition-row {
+  align-items: center;
+  background-color: darken($blue-extra-light, 5%);
+  border: 1px solid $grey-light-2;
+  border-radius: 3px;
+  display: flex;
+  margin: 10px 0;
+  position: relative;
+}
+
+.condition-row__link {
+  border-bottom: 1px solid $blue;
+  border-left: 1px solid $blue;
+  height: 60px;
+  left: -11px;
+  position: absolute;
+  top: -35px;
+  width: 10px;
+}
+
+.condition-row__delete {
+  color: $brown-grey-two;
+  font-size: 16px;
+  margin: 0 12px;
+
+  &:hover {
+    color: #000;
+    cursor: pointer;
+  }
+}
+</style>

--- a/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
@@ -66,7 +66,7 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 import { TempFilterStep } from '@/lib/steps';
 
 @Component({
-  name: 'conditionsGroup',
+  name: 'ConditionsGroup',
 })
 
 export default class ConditionsGroup extends Vue {

--- a/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
@@ -63,7 +63,7 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
-import { TempFilterStep } from '@/lib/steps';
+import { AbstractFilterTree, AbstractCondition, ConditionOperator } from '@/lib/steps';
 
 @Component({
   name: 'ConditionsGroup',
@@ -74,7 +74,7 @@ export default class ConditionsGroup extends Vue {
     type: Object,
     default: () => ({ operator: 'and', conditions: [], groups: []})
   })
-  conditionsTree!: TempFilterStep;
+  conditionsTree!: AbstractFilterTree;
 
   @Prop({
     type: Boolean,
@@ -102,12 +102,10 @@ export default class ConditionsGroup extends Vue {
     const newGroups = this.conditionsTree.groups || [];
     newGroups.push({
       operator: 'and',
-      // // Pass undefined values to force ConditionForm to use its default condition prop value
-      // conditions: [undefined, undefined],
+      // Pass undefined values to force ConditionForm to use its default condition prop value
       conditions: [
-        { column: '', comparison: '', value: ''}
-        ,
-        { column: '', comparison: '', value: ''}
+        undefined,
+        undefined,
       ],
       groups: []
     });
@@ -116,16 +114,16 @@ export default class ConditionsGroup extends Vue {
       ...this.conditionsTree,
       groups: newGroups,
     };
-    this.$emit('conditionsTreeUpdated', newConditionsTree);
+    this.emitUpdatedConditionTree(newConditionsTree);
   }
 
   addRow() {
     const newConditionsTree = {
       ...this.conditionsTree,
       // Pass undefined value to force ConditionForm to use its default condition prop value
-      conditions: [...this.conditions, { column: '', comparison: '', value: ''}],
+      conditions: [...this.conditions, undefined],
     };
-    this.$emit('conditionsTreeUpdated', newConditionsTree);
+    this.emitUpdatedConditionTree(newConditionsTree);
   }
 
   deleteGroup(groupIndex: number) {
@@ -137,7 +135,7 @@ export default class ConditionsGroup extends Vue {
       groups: newGroups,
     };
 
-    this.$emit('conditionsTreeUpdated', newConditionsTree);
+    this.emitUpdatedConditionTree(newConditionsTree);
   }
 
   deleteRow(rowIndex: number) {
@@ -149,11 +147,11 @@ export default class ConditionsGroup extends Vue {
       conditions: newConditions,
     };
 
-    this.$emit('conditionsTreeUpdated', newConditionsTree);
+    this.emitUpdatedConditionTree(newConditionsTree);
   }
 
   updateCondition(rowIndex: number) {
-    return (c: any) => {
+    return (c: AbstractCondition) => {
       const newConditions = [...this.conditions];
       newConditions[rowIndex] = c;
 
@@ -162,7 +160,7 @@ export default class ConditionsGroup extends Vue {
         conditions: newConditions,
       };
 
-      this.$emit('conditionsTreeUpdated', newConditionsTree);
+      this.emitUpdatedConditionTree(newConditionsTree);
     };
   }
 
@@ -175,14 +173,18 @@ export default class ConditionsGroup extends Vue {
       groups: newGroups,
     };
 
-    this.$emit('conditionsTreeUpdated', newConditionsTree);
+    this.emitUpdatedConditionTree(newConditionsTree);
   }
 
-  switchOperator(newOperator: string) {
+  switchOperator(newOperator: ConditionOperator) {
     const newConditionsTree = {
       ...this.conditionsTree,
       operator: newOperator,
     };
+    this.emitUpdatedConditionTree(newConditionsTree);
+  }
+
+  emitUpdatedConditionTree(newConditionsTree: AbstractFilterTree) {
     this.$emit('conditionsTreeUpdated', newConditionsTree);
   }
 }

--- a/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/stepforms/ConditionsEditor/ConditionsGroup.vue
@@ -9,16 +9,14 @@
       <div class="condition-group__switch-link" />
       <div class="conditions-group__switch-buttons">
         <div
-          id="switch-button-and"
-          class="conditions-group__switch-button"
+          class="conditions-group__switch-button conditions-group__switch-button--and"
           :class="{ 'conditions-group__switch-button--active': operator === 'and' }"
           @click="switchOperator('and')"
         >
           and
         </div>
         <div
-          id="switch-button-or"
-          class="conditions-group__switch-button"
+          class="conditions-group__switch-button conditions-group__switch-button--or"
           :class="{ 'conditions-group__switch-button--active': operator === 'or' }"
           @click="switchOperator('or')"
         >

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -138,19 +138,18 @@ export type FilterStep = {
   condition: FilterSimpleCondition | FilterComboAnd | FilterComboOr;
 };
 
-// Temporary
-export type TempFilterStep = {
-  conditions: TempFilterCondition[];
-  groups: (TempFilterStep)[];
-  operator: 'and' | 'or';
+// Any ConditionType can be used with this generic type
+export type GenericFilterTree<ConditionType extends AbstractCondition> = {
+  conditions: ConditionType[];
+  groups: GenericFilterTree<ConditionType>[];
+  operator: ConditionOperator;
 };
+export type ConditionOperator = 'and' | 'or';
+export type AbstractCondition = any;
+export type AbstractFilterTree = GenericFilterTree<AbstractCondition>;
 
-export type TempFilterCondition = {
-  column: string;
-  comparison: string;
-  value: string;
-};
-// End - Temporary
+// Concrete FilterTree:
+export type FilterTree = GenericFilterTree<FilterSimpleCondition>;
 
 export type FormulaStep = {
   name: 'formula';

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -138,6 +138,20 @@ export type FilterStep = {
   condition: FilterSimpleCondition | FilterComboAnd | FilterComboOr;
 };
 
+// Temporary
+export type TempFilterStep = {
+  conditions: TempFilterCondition[];
+  groups: (TempFilterStep)[];
+  operator: 'and' | 'or';
+};
+
+export type TempFilterCondition = {
+  column: string;
+  comparison: string;
+  value: string;
+};
+// End - Temporary
+
 export type FormulaStep = {
   name: 'formula';
   new_column: string;

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -138,19 +138,6 @@ export type FilterStep = {
   condition: FilterSimpleCondition | FilterComboAnd | FilterComboOr;
 };
 
-// Any ConditionType can be used with this generic type
-export type GenericFilterTree<ConditionType extends AbstractCondition> = {
-  conditions: ConditionType[];
-  groups: GenericFilterTree<ConditionType>[];
-  operator: ConditionOperator;
-};
-export type ConditionOperator = 'and' | 'or';
-export type AbstractCondition = any;
-export type AbstractFilterTree = GenericFilterTree<AbstractCondition>;
-
-// Concrete FilterTree:
-export type FilterTree = GenericFilterTree<FilterSimpleCondition>;
-
 export type FormulaStep = {
   name: 'formula';
   new_column: string;

--- a/stories/conditions-editor.js
+++ b/stories/conditions-editor.js
@@ -39,7 +39,7 @@ stories.add('default', () => ({
 
   computed: {
     conditionsStringify() {
-      return JSON.stringify(this.conditionsTree, null, '\t');
+      return JSON.stringify(this.conditionsTree, null, 2);
     }
   },
 
@@ -106,7 +106,7 @@ stories.add('data filtering', () => ({
 
   computed: {
     conditionsStringify() {
-      return JSON.stringify(this.conditionsTree, null, '\t');
+      return JSON.stringify(this.conditionsTree, null, 2);
     }
   },
 

--- a/stories/conditions-editor.js
+++ b/stories/conditions-editor.js
@@ -1,0 +1,120 @@
+import { ConditionsEditor, ConditionForm } from '../dist/storybook/components';
+import { storiesOf } from '@storybook/vue';
+
+const stories = storiesOf('ConditionsEditor', module);
+
+stories.add('default', () => ({
+  template: `\
+    <div style="margin: 30px; overflow: auto">
+      <ConditionsEditor :conditions-tree="conditionsTree" @conditionsUpdated="updateConditions"></ConditionsEditor>
+    </div>\
+  `,
+
+  components: {
+    ConditionsEditor,
+    ConditionForm
+  },
+
+  data() {
+    return {
+      conditionsTree: {
+        operator: 'and',
+        conditions: [
+          {
+            column: 'my_col',
+            comparison: 'equal',
+            value: 'my_value',
+          },
+          {
+            column: 'my_col',
+            comparison: 'equal',
+            value: 'my_value',
+          },
+        ],
+        groups: [
+          {
+            operator: 'or',
+            conditions: [
+              {
+                column: 'my_sub_col',
+                comparison: 'equal',
+                value: 'my_value',
+              },
+              {
+                column: 'my_sub_col',
+                comparison: 'equal',
+                value: 'my_value',
+              },
+            ],
+          },
+        ],
+      },
+    };
+  },
+
+  methods: {
+    updateConditions(newConditions) {
+      this.conditionsTree = newConditions;
+    },
+  },
+}));
+
+stories.add('data permission', () => ({
+  template: `\
+    <div style="margin: 30px; overflow: auto">
+      <ConditionsEditor :conditions-tree="conditionsTree" @conditionsTreeUpdated="updateConditionsTree">
+        <template v-slot:default="slotProps">
+          <ConditionForm :condition="slotProps.condition" @conditionUpdated="slotProps.updateCondition"></ConditionForm>
+        </template>
+      </ConditionsEditor>
+    </div>\
+  `,
+
+  components: {
+    ConditionForm,
+    ConditionsEditor,
+  },
+
+  data() {
+    return {
+      conditionsTree: {
+        operator: 'and',
+        conditions: [
+          {
+            column: 'my_col',
+            comparison: 'equal',
+            value: 'my_value',
+          },
+          {
+            column: 'my_col',
+            comparison: 'equal',
+            value: 'my_value',
+          },
+        ],
+        groups: [
+          {
+            operator: 'or',
+            conditions: [
+              {
+                column: 'my_sub_col',
+                comparison: 'equal',
+                value: 'my_value',
+              },
+              {
+                column: 'my_sub_col',
+                comparison: 'equal',
+                value: 'my_value',
+              },
+            ],
+          },
+        ],
+      },
+    };
+  },
+
+  methods: {
+    updateConditionsTree(newConditionsTree) {
+      this.conditionsTree = newConditionsTree;
+    },
+  },
+}));

--- a/stories/conditions-editor.js
+++ b/stories/conditions-editor.js
@@ -6,7 +6,7 @@ const stories = storiesOf('ConditionsEditor', module);
 stories.add('default', () => ({
   template: `
     <div style="margin: 30px; overflow: auto">
-      <ConditionsEditor :conditions-tree="conditionsTree" @conditionsUpdated="updateConditions"></ConditionsEditor>
+      <ConditionsEditor :conditions-tree="conditionsTree" @conditionsTreeUpdated="updateConditionsTree"></ConditionsEditor>
     </div>
   `,
 
@@ -37,13 +37,13 @@ stories.add('default', () => ({
   },
 
   methods: {
-    updateConditions(newConditions) {
-      this.conditionsTree = newConditions;
+    updateConditionsTree(newConditionsTree) {
+      this.conditionsTree = newConditionsTree;
     },
   },
 }));
 
-stories.add('data permission', () => ({
+stories.add('data filtering', () => ({
   template: `
     <div style="margin: 30px; overflow: auto">
       <ConditionsEditor :conditions-tree="conditionsTree" @conditionsTreeUpdated="updateConditionsTree">
@@ -66,12 +66,12 @@ stories.add('data permission', () => ({
         conditions: [
           {
             column: 'my_col',
-            comparison: 'equal',
+            operator: 'eq',
             value: 'my_value',
           },
           {
             column: 'my_col',
-            comparison: 'equal',
+            operator: 'eq',
             value: 'my_value',
           },
         ],
@@ -81,12 +81,12 @@ stories.add('data permission', () => ({
             conditions: [
               {
                 column: 'my_sub_col',
-                comparison: 'equal',
+                operator: 'eq',
                 value: 'my_value',
               },
               {
                 column: 'my_sub_col',
-                comparison: 'equal',
+                operator: 'eq',
                 value: 'my_value',
               },
             ],

--- a/stories/conditions-editor.js
+++ b/stories/conditions-editor.js
@@ -4,10 +4,10 @@ import { storiesOf } from '@storybook/vue';
 const stories = storiesOf('ConditionsEditor', module);
 
 stories.add('default', () => ({
-  template: `\
+  template: `
     <div style="margin: 30px; overflow: auto">
       <ConditionsEditor :conditions-tree="conditionsTree" @conditionsUpdated="updateConditions"></ConditionsEditor>
-    </div>\
+    </div>
   `,
 
   components: {
@@ -20,31 +20,15 @@ stories.add('default', () => ({
       conditionsTree: {
         operator: 'and',
         conditions: [
-          {
-            column: 'my_col',
-            comparison: 'equal',
-            value: 'my_value',
-          },
-          {
-            column: 'my_col',
-            comparison: 'equal',
-            value: 'my_value',
-          },
+          'you',
+          'me',
         ],
         groups: [
           {
             operator: 'or',
             conditions: [
-              {
-                column: 'my_sub_col',
-                comparison: 'equal',
-                value: 'my_value',
-              },
-              {
-                column: 'my_sub_col',
-                comparison: 'equal',
-                value: 'my_value',
-              },
+              'to be',
+              'not to be',
             ],
           },
         ],
@@ -60,14 +44,14 @@ stories.add('default', () => ({
 }));
 
 stories.add('data permission', () => ({
-  template: `\
+  template: `
     <div style="margin: 30px; overflow: auto">
       <ConditionsEditor :conditions-tree="conditionsTree" @conditionsTreeUpdated="updateConditionsTree">
         <template v-slot:default="slotProps">
           <ConditionForm :condition="slotProps.condition" @conditionUpdated="slotProps.updateCondition"></ConditionForm>
         </template>
       </ConditionsEditor>
-    </div>\
+    </div>
   `,
 
   components: {

--- a/stories/conditions-editor.js
+++ b/stories/conditions-editor.js
@@ -7,6 +7,7 @@ stories.add('default', () => ({
   template: `
     <div style="margin: 30px; overflow: auto">
       <ConditionsEditor :conditions-tree="conditionsTree" @conditionsTreeUpdated="updateConditionsTree"></ConditionsEditor>
+      <pre style="margin-top: 30px;">{{ conditionsStringify }}</pre>
     </div>
   `,
 
@@ -36,6 +37,12 @@ stories.add('default', () => ({
     };
   },
 
+  computed: {
+    conditionsStringify() {
+      return JSON.stringify(this.conditionsTree, null, '\t');
+    }
+  },
+
   methods: {
     updateConditionsTree(newConditionsTree) {
       this.conditionsTree = newConditionsTree;
@@ -51,6 +58,7 @@ stories.add('data filtering', () => ({
           <ConditionForm :condition="slotProps.condition" @conditionUpdated="slotProps.updateCondition"></ConditionForm>
         </template>
       </ConditionsEditor>
+      <pre style="margin-top: 30px;">{{ conditionsStringify }}</pre>
     </div>
   `,
 
@@ -94,6 +102,12 @@ stories.add('data filtering', () => ({
         ],
       },
     };
+  },
+
+  computed: {
+    conditionsStringify() {
+      return JSON.stringify(this.conditionsTree, null, '\t');
+    }
   },
 
   methods: {

--- a/stories/index.js
+++ b/stories/index.js
@@ -61,3 +61,4 @@ stories
 import './data-viewer';
 import './form-rename-step';
 import './resizable-panel';
+import './conditions-editor';

--- a/tests/unit/condition-form.spec.ts
+++ b/tests/unit/condition-form.spec.ts
@@ -13,14 +13,14 @@ describe('ConditionForm', () => {
   it.skip('should emit "conditionUpdated" event with the right args', async () => {
     const wrapper = shallowMount(ConditionForm, {
       propsData: {
-        condition: { column: '', operator: 'eq', value: ''}
+        condition: { column: '', operator: 'eq', value: '' },
       },
     });
     wrapper.find('.condition-form__input--column').setValue('my_col');
     jest.advanceTimersByTime(500); // flush debounce
     expect(wrapper.emitted().conditionUpdated).toBeDefined();
     expect(wrapper.emitted().conditionUpdated[0]).toEqual([
-      { column: 'my_col', operator: 'eq', value: ''},
+      { column: 'my_col', operator: 'eq', value: '' },
     ]);
   });
 });

--- a/tests/unit/condition-form.spec.ts
+++ b/tests/unit/condition-form.spec.ts
@@ -1,0 +1,26 @@
+import { shallowMount } from '@vue/test-utils';
+
+import ConditionForm from '@/components/stepforms/ConditionsEditor/ConditionForm.vue';
+
+describe('ConditionForm', () => {
+  jest.useFakeTimers();
+
+  it('should instantiate', () => {
+    const wrapper = shallowMount(ConditionForm);
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it.skip('should emit "conditionUpdated" event with the right args', async () => {
+    const wrapper = shallowMount(ConditionForm, {
+      propsData: {
+        condition: { column: '', comparison: 'eq', value: ''}
+      },
+    });
+    wrapper.find('.condition-form__input--column').setValue('my_col');
+    jest.advanceTimersByTime(5000);
+    expect(wrapper.emitted().conditionUpdated).toBeDefined();
+    // expect(wrapper.emitted().conditionUpdated[0]).toEqual([
+    //   { column: 'my_col', comparison: 'eq', value: ''},
+    // ]);
+  });
+});

--- a/tests/unit/condition-form.spec.ts
+++ b/tests/unit/condition-form.spec.ts
@@ -3,21 +3,18 @@ import { shallowMount } from '@vue/test-utils';
 import ConditionForm from '@/components/stepforms/ConditionsEditor/ConditionForm.vue';
 
 describe('ConditionForm', () => {
-  jest.useFakeTimers();
-
   it('should instantiate', () => {
     const wrapper = shallowMount(ConditionForm);
     expect(wrapper.exists()).toBeTruthy();
   });
 
-  it.skip('should emit "conditionUpdated" event with the right args', async () => {
+  it('should emit "conditionUpdated" event with the right args', async () => {
     const wrapper = shallowMount(ConditionForm, {
       propsData: {
         condition: { column: '', operator: 'eq', value: '' },
       },
     });
     wrapper.find('.condition-form__input--column').setValue('my_col');
-    jest.advanceTimersByTime(500); // flush debounce
     expect(wrapper.emitted().conditionUpdated).toBeDefined();
     expect(wrapper.emitted().conditionUpdated[0]).toEqual([
       { column: 'my_col', operator: 'eq', value: '' },

--- a/tests/unit/condition-form.spec.ts
+++ b/tests/unit/condition-form.spec.ts
@@ -13,14 +13,14 @@ describe('ConditionForm', () => {
   it.skip('should emit "conditionUpdated" event with the right args', async () => {
     const wrapper = shallowMount(ConditionForm, {
       propsData: {
-        condition: { column: '', comparison: 'eq', value: ''}
+        condition: { column: '', operator: 'eq', value: ''}
       },
     });
     wrapper.find('.condition-form__input--column').setValue('my_col');
-    jest.advanceTimersByTime(5000);
+    jest.advanceTimersByTime(500); // flush debounce
     expect(wrapper.emitted().conditionUpdated).toBeDefined();
-    // expect(wrapper.emitted().conditionUpdated[0]).toEqual([
-    //   { column: 'my_col', comparison: 'eq', value: ''},
-    // ]);
+    expect(wrapper.emitted().conditionUpdated[0]).toEqual([
+      { column: 'my_col', operator: 'eq', value: ''},
+    ]);
   });
 });

--- a/tests/unit/conditions-group.spec.ts
+++ b/tests/unit/conditions-group.spec.ts
@@ -1,0 +1,436 @@
+import { shallowMount, Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
+
+import ConditionsGroup from '@/components/stepforms/ConditionsEditor/ConditionsGroup.vue';
+
+let wrapper: Wrapper<Vue>;
+
+describe('ConditionsGroup', () => {
+  it('should instantiate', () => {
+    const wrapper = shallowMount(ConditionsGroup);
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('should not have the class "conditions-group--root"', () => {
+    const wrapper = shallowMount(ConditionsGroup);
+    expect(wrapper.find('.conditions-group').classes()).not.toContain('conditions-group--root');
+  });
+
+  it('should have the class "conditions-group__switch-button--active" on the right switch button', () => {
+    const wrapper = shallowMount(ConditionsGroup, {
+      propsData: {
+        conditionsTree: {
+          operator: 'or',
+          conditions: [
+            {
+              column: '',
+              comparison: '',
+              value: '',
+            },
+            {
+              column: '',
+              comparison: '',
+              value: '',
+            },
+          ],
+        },
+      }
+    });
+    expect(wrapper.find('#switch-button-or').classes()).toContain('conditions-group__switch-button--active');
+  });
+
+  describe('when the group is the root', () => {
+    beforeEach(() => {
+      wrapper = shallowMount(ConditionsGroup, {
+        propsData: {
+          isRootGroup: true,
+          conditionsTree: {
+            conditions: [
+              {
+                column: '',
+                comparison: '',
+                value: '',
+              },
+            ],
+          },
+        }
+      });
+    });
+
+    afterEach(() => {
+      wrapper.destroy();
+    });
+
+    it('should have the class "conditions-group--root"', () => {
+      expect(wrapper.find('.conditions-group').classes()).toContain('conditions-group--root');
+    });
+
+    it('should not display the trash button for the group', () => {
+      expect(wrapper.find('.conditions-group__delete').exists()).toBeFalsy();
+    });
+  });
+
+  describe('when the group has multiple rows', () => {
+    beforeEach(() => {
+      wrapper = shallowMount(ConditionsGroup, {
+        propsData: {
+          conditionsTree: {
+            conditions: [
+              {
+                column: '',
+                comparison: '',
+                value: '',
+              },
+              {
+                column: '',
+                comparison: '',
+                value: '',
+              }
+            ]
+          },
+        }
+      });
+    });
+
+    afterEach(() => {
+      wrapper.destroy();
+    });
+
+    it('should have the class "conditions-group--with-switch"', () => {
+      expect(wrapper.find('.conditions-group').classes()).toContain('conditions-group--with-switch');
+    });
+
+    it('should have the switch button', () => {
+      expect(wrapper.find('.conditions-group__switch').exists()).toBeTruthy();
+    });
+
+    it('should have the link', () => {
+      expect(wrapper.find('.condition-row__link').exists()).toBeTruthy();
+    });
+  });
+
+  describe('when the group has groups', () => {
+    beforeEach(() => {
+      wrapper = shallowMount(ConditionsGroup, {
+        propsData: {
+          conditionsTree: {
+            conditions: [
+              {
+                column: '',
+                comparison: '',
+                value: '',
+              },
+            ],
+            groups: [
+              {
+                conditions: [
+                  {
+                    column: '',
+                    comparison: '',
+                    value: '',
+                  },
+                ],
+              }
+            ]
+          },
+        }
+      });
+    });
+
+    afterEach(() => {
+      wrapper.destroy();
+    });
+
+    it('should have the class "conditions-group--with-switch"', () => {
+      expect(wrapper.find('.conditions-group').classes()).toContain('conditions-group--with-switch');
+    });
+
+    it('should have the switch button', () => {
+      expect(wrapper.find('.conditions-group__switch').exists()).toBeTruthy();
+    });
+
+    it('should have the link', () => {
+      expect(wrapper.find('.condition-row__link').exists()).toBeTruthy();
+    });
+
+    it('should display the trash button', () => {
+      const wrapper = shallowMount(ConditionsGroup);
+      expect(wrapper.find('.conditions-group__delete').exists()).toBeTruthy();
+    });
+  });
+
+  describe('click actions', () => {
+    beforeEach(() => {
+      wrapper = shallowMount(ConditionsGroup, {
+        propsData: {
+          isRootGroup: true,
+          conditionsTree: {
+            operator: 'and',
+            conditions: [
+              {
+                column: 'a',
+                comparison: 'eq',
+                value: 'toto',
+              },
+              {
+                column: 'b',
+                comparison: 'eq',
+                value: 'tata',
+              },
+            ],
+            groups: [
+              {
+                conditions: [
+                  {
+                    column: 'c',
+                    comparison: 'eq',
+                    value: 'tutu',
+                  },
+                ],
+              }
+            ]
+          },
+        }
+      });
+    });
+
+    afterEach(() => {
+      wrapper.destroy();
+    });
+
+    it('should emit "conditionsTreeUpdated" with the new conditionTree when clicking on "add condition" button', () => {
+      wrapper.find('#add-row-button').trigger('click');
+      expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
+        operator: 'and',
+        conditions: [
+          {
+            column: 'a',
+            comparison: 'eq',
+            value: 'toto',
+          },
+          {
+            column: 'b',
+            comparison: 'eq',
+            value: 'tata',
+          },
+          {
+            column: '',
+            comparison: '',
+            value: '',
+          },
+        ],
+        groups: [
+          {
+            conditions: [
+              {
+                column: 'c',
+                comparison: 'eq',
+                value: 'tutu',
+              },
+            ],
+          }
+        ]
+      }]);
+    });
+
+    it('should emit "conditionsTreeUpdated" with the new conditionTree when clicking on "add group" button', () => {
+      wrapper.find('#add-group-button').trigger('click');
+      expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
+        operator: 'and',
+        conditions: [
+          {
+            column: 'a',
+            comparison: 'eq',
+            value: 'toto',
+          },
+          {
+            column: 'b',
+            comparison: 'eq',
+            value: 'tata',
+          },
+        ],
+        groups: [
+          {
+            conditions: [
+              {
+                column: 'c',
+                comparison: 'eq',
+                value: 'tutu',
+              },
+            ],
+          },
+          {
+            operator: 'and',
+            conditions: [
+              {
+                column: '',
+                comparison: '',
+                value: '',
+              },
+              {
+                column: '',
+                comparison: '',
+                value: '',
+              },
+            ],
+            groups: [],
+          }
+        ]
+      }]);
+    });
+
+    it('should emit "conditionsTreeUpdated" with the new conditionTree when clicking on "delete row button"', () => {
+      wrapper.findAll('.condition-row__delete').at(0).trigger('click');
+      expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
+        operator: 'and',
+        conditions: [
+          {
+            column: 'b',
+            comparison: 'eq',
+            value: 'tata',
+          },
+        ],
+        groups: [
+          {
+            conditions: [
+              {
+                column: 'c',
+                comparison: 'eq',
+                value: 'tutu',
+              },
+            ],
+          }
+        ]
+      }]);
+    });
+
+    it('should emit "conditionsTreeUpdated" with the new conditionTree when its group emit "groupDeleted" event', () => {
+      wrapper.find('conditionsgroup-stub').vm.$emit('groupDeleted');
+      expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
+        operator: 'and',
+        conditions: [
+          {
+            column: 'a',
+            comparison: 'eq',
+            value: 'toto',
+          },
+          {
+            column: 'b',
+            comparison: 'eq',
+            value: 'tata',
+          },
+        ],
+        groups: [],
+      }]);
+    });
+
+    it('should emit "conditionsTreeUpdated" with the new conditionTree when its group emit "conditionsTreeUpdated" event', () => {
+      wrapper.find('conditionsgroup-stub').vm.$emit('conditionsTreeUpdated', {
+        conditions: [
+          {
+            column: 'd',
+            comparison: 'eq',
+            value: 'blublu',
+          },
+        ],
+      });
+      expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
+        operator: 'and',
+        conditions: [
+          {
+            column: 'a',
+            comparison: 'eq',
+            value: 'toto',
+          },
+          {
+            column: 'b',
+            comparison: 'eq',
+            value: 'tata',
+          },
+        ],
+        groups: [
+          {
+            conditions: [
+              {
+                column: 'd',
+                comparison: 'eq',
+                value: 'blublu',
+              },
+            ],
+          }
+        ]
+      }]);
+    });
+
+    it('should emit "conditionsTreeUpdated" with the new conditionTree when "or" operator button is click', () => {
+      wrapper.find('#switch-button-or').trigger('click');
+      expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
+        operator: 'or',
+        conditions: [
+          {
+            column: 'a',
+            comparison: 'eq',
+            value: 'toto',
+          },
+          {
+            column: 'b',
+            comparison: 'eq',
+            value: 'tata',
+          },
+        ],
+        groups: [
+          {
+            conditions: [
+              {
+                column: 'c',
+                comparison: 'eq',
+                value: 'tutu',
+              },
+            ],
+          }
+        ]
+      }]);
+    });
+
+    it('should emit "conditionsTreeUpdated" with the new conditionTree when the slot emit an event', () => {
+      (wrapper.vm as any).updateCondition(0)({
+        column: 'leader',
+        comparison: 'eq',
+        value: 'arthas',
+      });
+      expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
+        operator: 'and',
+        conditions: [
+          {
+            column: 'leader',
+            comparison: 'eq',
+            value: 'arthas',
+          },
+          {
+            column: 'b',
+            comparison: 'eq',
+            value: 'tata',
+          },
+        ],
+        groups: [
+          {
+            conditions: [
+              {
+                column: 'c',
+                comparison: 'eq',
+                value: 'tutu',
+              },
+            ],
+          }
+        ]
+      }]);
+    });
+  });
+});

--- a/tests/unit/conditions-group.spec.ts
+++ b/tests/unit/conditions-group.spec.ts
@@ -22,16 +22,8 @@ describe('ConditionsGroup', () => {
         conditionsTree: {
           operator: 'or',
           conditions: [
-            {
-              column: '',
-              comparison: '',
-              value: '',
-            },
-            {
-              column: '',
-              comparison: '',
-              value: '',
-            },
+            undefined,
+            undefined,
           ],
         },
       }
@@ -46,11 +38,7 @@ describe('ConditionsGroup', () => {
           isRootGroup: true,
           conditionsTree: {
             conditions: [
-              {
-                column: '',
-                comparison: '',
-                value: '',
-              },
+              'only condition',
             ],
           },
         }
@@ -76,16 +64,8 @@ describe('ConditionsGroup', () => {
         propsData: {
           conditionsTree: {
             conditions: [
-              {
-                column: '',
-                comparison: '',
-                value: '',
-              },
-              {
-                column: '',
-                comparison: '',
-                value: '',
-              }
+              'condition A',
+              'condition B'
             ]
           },
         }
@@ -115,20 +95,12 @@ describe('ConditionsGroup', () => {
         propsData: {
           conditionsTree: {
             conditions: [
-              {
-                column: '',
-                comparison: '',
-                value: '',
-              },
+              'condition A',
             ],
             groups: [
               {
                 conditions: [
-                  {
-                    column: '',
-                    comparison: '',
-                    value: '',
-                  },
+                  'condition B',
                 ],
               }
             ]
@@ -214,11 +186,7 @@ describe('ConditionsGroup', () => {
             comparison: 'eq',
             value: 'tata',
           },
-          {
-            column: '',
-            comparison: '',
-            value: '',
-          },
+          undefined,
         ],
         groups: [
           {
@@ -264,16 +232,8 @@ describe('ConditionsGroup', () => {
           {
             operator: 'and',
             conditions: [
-              {
-                column: '',
-                comparison: '',
-                value: '',
-              },
-              {
-                column: '',
-                comparison: '',
-                value: '',
-              },
+              undefined,
+              undefined,
             ],
             groups: [],
           }

--- a/tests/unit/conditions-group.spec.ts
+++ b/tests/unit/conditions-group.spec.ts
@@ -40,6 +40,7 @@ describe('ConditionsGroup', () => {
             conditions: [
               'only condition',
             ],
+            groups: [undefined]
           },
         }
       });
@@ -49,12 +50,14 @@ describe('ConditionsGroup', () => {
       wrapper.destroy();
     });
 
-    it('should have the class "conditions-group--root"', () => {
-      expect(wrapper.find('.conditions-group').classes()).toContain('conditions-group--root');
+    it('should be able to add sub groups', () => {
+      expect(wrapper.find('.conditions-group__add-button').exists()).toBeTruthy();
     });
+  });
 
-    it('should not display the trash button for the group', () => {
-      expect(wrapper.find('.conditions-group__delete').exists()).toBeFalsy();
+  describe('when the group is not the root', () => {
+    it('should not be able to add sub groups', () => {
+      expect(wrapper.find('.conditions-group__add-button').exists()).toBeFalsy();
     });
   });
 
@@ -76,20 +79,17 @@ describe('ConditionsGroup', () => {
       wrapper.destroy();
     });
 
-    it('should have the class "conditions-group--with-switch"', () => {
+    it('should have the switch button to choose an operator', () => {
       expect(wrapper.find('.conditions-group').classes()).toContain('conditions-group--with-switch');
-    });
-
-    it('should have the switch button', () => {
       expect(wrapper.find('.conditions-group__switch').exists()).toBeTruthy();
     });
 
-    it('should have the link', () => {
+    it('should display a link', () => {
       expect(wrapper.find('.condition-row__link').exists()).toBeTruthy();
     });
   });
 
-  describe('when the group has groups', () => {
+  describe('with child groups', () => {
     beforeEach(() => {
       wrapper = shallowMount(ConditionsGroup, {
         propsData: {
@@ -113,21 +113,17 @@ describe('ConditionsGroup', () => {
       wrapper.destroy();
     });
 
-    it('should have the class "conditions-group--with-switch"', () => {
-      expect(wrapper.find('.conditions-group').classes()).toContain('conditions-group--with-switch');
-    });
-
-    it('should have the switch button', () => {
+    it('should have the operator switch button', () => {
       expect(wrapper.find('.conditions-group__switch').exists()).toBeTruthy();
     });
 
-    it('should have the link', () => {
-      expect(wrapper.find('.condition-row__link').exists()).toBeTruthy();
+    it('should display a link', () => {
+      expect(wrapper.find('.conditions-group__link').exists()).toBeTruthy();
     });
 
-    it('should display the trash button', () => {
-      const wrapper = shallowMount(ConditionsGroup);
-      expect(wrapper.find('.conditions-group__delete').exists()).toBeTruthy();
+    it('should display the trash button for each group', () => {
+      const childGroupWrapper = wrapper.find('.conditions-group__child-group');
+      expect(childGroupWrapper.find('.conditions-group__delete').exists()).toBeTruthy();
     });
   });
 
@@ -267,8 +263,8 @@ describe('ConditionsGroup', () => {
       }]);
     });
 
-    it('should emit "conditionsTreeUpdated" with the new conditionTree when its group emit "groupDeleted" event', () => {
-      wrapper.find('conditionsgroup-stub').vm.$emit('groupDeleted');
+    it('should emit "conditionsTreeUpdated" with the new conditionTree when hitting the trash button for a group', () => {
+      wrapper.find('.conditions-group__child-group .conditions-group__delete').trigger('click');
       expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
       expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
         operator: 'and',
@@ -358,7 +354,7 @@ describe('ConditionsGroup', () => {
       }]);
     });
 
-    it('should emit "conditionsTreeUpdated" with the new conditionTree when the slot emit an event', () => {
+    it('should emit "conditionsTreeUpdated" with the new conditionTree when the slot emits an event', () => {
       (wrapper.vm as any).updateCondition(0)({
         column: 'leader',
         comparison: 'eq',

--- a/tests/unit/conditions-group.spec.ts
+++ b/tests/unit/conditions-group.spec.ts
@@ -96,8 +96,22 @@ describe('ConditionsGroup', () => {
       expect(wrapper.find('.conditions-group__switch').exists()).toBeTruthy();
     });
 
-    it('should display a link', () => {
-      expect(wrapper.find('.condition-row__link').exists()).toBeTruthy();
+    describe('links', () => {
+      it('should be plain links for all elements but the last condition', () => {
+        const conditionRowWrappers = wrapper.findAll('.condition-row');
+        expect(
+          conditionRowWrappers
+            .at(0)
+            .find('.condition-row__link')
+            .classes(),
+        ).not.toContain('condition-row__link--last');
+        expect(
+          conditionRowWrappers
+            .at(1)
+            .find('.condition-row__link')
+            .classes(),
+        ).toContain('condition-row__link--last');
+      });
     });
   });
 
@@ -106,10 +120,13 @@ describe('ConditionsGroup', () => {
       wrapper = shallowMount(ConditionsGroup, {
         propsData: {
           conditionsTree: {
-            conditions: ['condition A'],
+            conditions: ['condition A', 'condition A'],
             groups: [
               {
-                conditions: ['condition B'],
+                conditions: ['condition B', 'condition C'],
+              },
+              {
+                conditions: ['condition D', 'condition E'],
               },
             ],
           },
@@ -127,6 +144,38 @@ describe('ConditionsGroup', () => {
 
     it('should display a link', () => {
       expect(wrapper.find('.conditions-group__link').exists()).toBeTruthy();
+    });
+
+    describe('links', () => {
+      it('should be plain links for all elements but the last group', () => {
+        const conditionRowWrappers = wrapper.findAll('.condition-row');
+        expect(
+          conditionRowWrappers
+            .at(0)
+            .find('.condition-row__link')
+            .classes(),
+        ).not.toContain('condition-row__link--last');
+        expect(
+          conditionRowWrappers
+            .at(1)
+            .find('.condition-row__link')
+            .classes(),
+        ).not.toContain('condition-row__link--last');
+
+        const childGroupWrappers = wrapper.findAll('.conditions-group__child-group');
+        expect(
+          childGroupWrappers
+            .at(0)
+            .find('.conditions-group__link')
+            .classes(),
+        ).not.toContain('conditions-group__link--last');
+        expect(
+          childGroupWrappers
+            .at(1)
+            .find('.conditions-group__link')
+            .classes(),
+        ).toContain('conditions-group__link--last');
+      });
     });
 
     it('should display the trash button for each group', () => {

--- a/tests/unit/conditions-group.spec.ts
+++ b/tests/unit/conditions-group.spec.ts
@@ -28,7 +28,7 @@ describe('ConditionsGroup', () => {
         },
       }
     });
-    expect(wrapper.find('#switch-button-or').classes()).toContain('conditions-group__switch-button--active');
+    expect(wrapper.find('.conditions-group__switch-button--or').classes()).toContain('conditions-group__switch-button--active');
   });
 
   describe('when the group is the root', () => {
@@ -51,13 +51,31 @@ describe('ConditionsGroup', () => {
     });
 
     it('should be able to add sub groups', () => {
-      expect(wrapper.find('.conditions-group__add-button').exists()).toBeTruthy();
+      expect(wrapper.find('.conditions-group__add-button--group').exists()).toBeTruthy();
     });
   });
 
   describe('when the group is not the root', () => {
+    beforeEach(() => {
+      wrapper = shallowMount(ConditionsGroup, {
+        propsData: {
+          isRootGroup: false,
+          conditionsTree: {
+            conditions: [
+              'only condition',
+            ],
+            groups: [undefined]
+          },
+        }
+      });
+    });
+
+    afterEach(() => {
+      wrapper.destroy();
+    });
+
     it('should not be able to add sub groups', () => {
-      expect(wrapper.find('.conditions-group__add-button').exists()).toBeFalsy();
+      expect(wrapper.find('.conditions-group__add-button--group').exists()).toBeFalsy();
     });
   });
 
@@ -167,7 +185,7 @@ describe('ConditionsGroup', () => {
     });
 
     it('should emit "conditionsTreeUpdated" with the new conditionTree when clicking on "add condition" button', () => {
-      wrapper.find('#add-row-button').trigger('click');
+      wrapper.find('.conditions-group__add-button--condition').trigger('click');
       expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
       expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
         operator: 'and',
@@ -199,7 +217,7 @@ describe('ConditionsGroup', () => {
     });
 
     it('should emit "conditionsTreeUpdated" with the new conditionTree when clicking on "add group" button', () => {
-      wrapper.find('#add-group-button').trigger('click');
+      wrapper.find('.conditions-group__add-button--group').trigger('click');
       expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
       expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
         operator: 'and',
@@ -324,7 +342,7 @@ describe('ConditionsGroup', () => {
     });
 
     it('should emit "conditionsTreeUpdated" with the new conditionTree when "or" operator button is click', () => {
-      wrapper.find('#switch-button-or').trigger('click');
+      wrapper.find('.conditions-group__switch-button--or').trigger('click');
       expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
       expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
         operator: 'or',

--- a/tests/unit/conditions-group.spec.ts
+++ b/tests/unit/conditions-group.spec.ts
@@ -21,14 +21,13 @@ describe('ConditionsGroup', () => {
       propsData: {
         conditionsTree: {
           operator: 'or',
-          conditions: [
-            undefined,
-            undefined,
-          ],
+          conditions: [undefined, undefined],
         },
-      }
+      },
     });
-    expect(wrapper.find('.conditions-group__switch-button--or').classes()).toContain('conditions-group__switch-button--active');
+    expect(wrapper.find('.conditions-group__switch-button--or').classes()).toContain(
+      'conditions-group__switch-button--active',
+    );
   });
 
   describe('when the group is the root', () => {
@@ -37,12 +36,10 @@ describe('ConditionsGroup', () => {
         propsData: {
           isRootGroup: true,
           conditionsTree: {
-            conditions: [
-              'only condition',
-            ],
-            groups: [undefined]
+            conditions: ['only condition'],
+            groups: [undefined],
           },
-        }
+        },
       });
     });
 
@@ -61,12 +58,10 @@ describe('ConditionsGroup', () => {
         propsData: {
           isRootGroup: false,
           conditionsTree: {
-            conditions: [
-              'only condition',
-            ],
-            groups: [undefined]
+            conditions: ['only condition'],
+            groups: [undefined],
           },
-        }
+        },
       });
     });
 
@@ -84,12 +79,9 @@ describe('ConditionsGroup', () => {
       wrapper = shallowMount(ConditionsGroup, {
         propsData: {
           conditionsTree: {
-            conditions: [
-              'condition A',
-              'condition B'
-            ]
+            conditions: ['condition A', 'condition B'],
           },
-        }
+        },
       });
     });
 
@@ -98,7 +90,9 @@ describe('ConditionsGroup', () => {
     });
 
     it('should have the switch button to choose an operator', () => {
-      expect(wrapper.find('.conditions-group').classes()).toContain('conditions-group--with-switch');
+      expect(wrapper.find('.conditions-group').classes()).toContain(
+        'conditions-group--with-switch',
+      );
       expect(wrapper.find('.conditions-group__switch').exists()).toBeTruthy();
     });
 
@@ -112,18 +106,14 @@ describe('ConditionsGroup', () => {
       wrapper = shallowMount(ConditionsGroup, {
         propsData: {
           conditionsTree: {
-            conditions: [
-              'condition A',
-            ],
+            conditions: ['condition A'],
             groups: [
               {
-                conditions: [
-                  'condition B',
-                ],
-              }
-            ]
+                conditions: ['condition B'],
+              },
+            ],
           },
-        }
+        },
       });
     });
 
@@ -173,10 +163,10 @@ describe('ConditionsGroup', () => {
                     value: 'tutu',
                   },
                 ],
-              }
-            ]
+              },
+            ],
           },
-        }
+        },
       });
     });
 
@@ -187,119 +177,127 @@ describe('ConditionsGroup', () => {
     it('should emit "conditionsTreeUpdated" with the new conditionTree when clicking on "add condition" button', () => {
       wrapper.find('.conditions-group__add-button--condition').trigger('click');
       expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
-      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
-        operator: 'and',
-        conditions: [
-          {
-            column: 'a',
-            comparison: 'eq',
-            value: 'toto',
-          },
-          {
-            column: 'b',
-            comparison: 'eq',
-            value: 'tata',
-          },
-          undefined,
-        ],
-        groups: [
-          {
-            conditions: [
-              {
-                column: 'c',
-                comparison: 'eq',
-                value: 'tutu',
-              },
-            ],
-          }
-        ]
-      }]);
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([
+        {
+          operator: 'and',
+          conditions: [
+            {
+              column: 'a',
+              comparison: 'eq',
+              value: 'toto',
+            },
+            {
+              column: 'b',
+              comparison: 'eq',
+              value: 'tata',
+            },
+            undefined,
+          ],
+          groups: [
+            {
+              conditions: [
+                {
+                  column: 'c',
+                  comparison: 'eq',
+                  value: 'tutu',
+                },
+              ],
+            },
+          ],
+        },
+      ]);
     });
 
     it('should emit "conditionsTreeUpdated" with the new conditionTree when clicking on "add group" button', () => {
       wrapper.find('.conditions-group__add-button--group').trigger('click');
       expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
-      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
-        operator: 'and',
-        conditions: [
-          {
-            column: 'a',
-            comparison: 'eq',
-            value: 'toto',
-          },
-          {
-            column: 'b',
-            comparison: 'eq',
-            value: 'tata',
-          },
-        ],
-        groups: [
-          {
-            conditions: [
-              {
-                column: 'c',
-                comparison: 'eq',
-                value: 'tutu',
-              },
-            ],
-          },
-          {
-            operator: 'and',
-            conditions: [
-              undefined,
-              undefined,
-            ],
-            groups: [],
-          }
-        ]
-      }]);
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([
+        {
+          operator: 'and',
+          conditions: [
+            {
+              column: 'a',
+              comparison: 'eq',
+              value: 'toto',
+            },
+            {
+              column: 'b',
+              comparison: 'eq',
+              value: 'tata',
+            },
+          ],
+          groups: [
+            {
+              conditions: [
+                {
+                  column: 'c',
+                  comparison: 'eq',
+                  value: 'tutu',
+                },
+              ],
+            },
+            {
+              operator: 'and',
+              conditions: [undefined, undefined],
+              groups: [],
+            },
+          ],
+        },
+      ]);
     });
 
     it('should emit "conditionsTreeUpdated" with the new conditionTree when clicking on "delete row button"', () => {
-      wrapper.findAll('.condition-row__delete').at(0).trigger('click');
+      wrapper
+        .findAll('.condition-row__delete')
+        .at(0)
+        .trigger('click');
       expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
-      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
-        operator: 'and',
-        conditions: [
-          {
-            column: 'b',
-            comparison: 'eq',
-            value: 'tata',
-          },
-        ],
-        groups: [
-          {
-            conditions: [
-              {
-                column: 'c',
-                comparison: 'eq',
-                value: 'tutu',
-              },
-            ],
-          }
-        ]
-      }]);
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([
+        {
+          operator: 'and',
+          conditions: [
+            {
+              column: 'b',
+              comparison: 'eq',
+              value: 'tata',
+            },
+          ],
+          groups: [
+            {
+              conditions: [
+                {
+                  column: 'c',
+                  comparison: 'eq',
+                  value: 'tutu',
+                },
+              ],
+            },
+          ],
+        },
+      ]);
     });
 
     it('should emit "conditionsTreeUpdated" with the new conditionTree when hitting the trash button for a group', () => {
       wrapper.find('.conditions-group__child-group .conditions-group__delete').trigger('click');
       expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
-      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
-        operator: 'and',
-        conditions: [
-          {
-            column: 'a',
-            comparison: 'eq',
-            value: 'toto',
-          },
-          {
-            column: 'b',
-            comparison: 'eq',
-            value: 'tata',
-          },
-        ],
-        groups: [],
-      }]);
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([
+        {
+          operator: 'and',
+          conditions: [
+            {
+              column: 'a',
+              comparison: 'eq',
+              value: 'toto',
+            },
+            {
+              column: 'b',
+              comparison: 'eq',
+              value: 'tata',
+            },
+          ],
+          groups: [],
+        },
+      ]);
     });
 
     it('should emit "conditionsTreeUpdated" with the new conditionTree when its group emit "conditionsTreeUpdated" event', () => {
@@ -313,63 +311,67 @@ describe('ConditionsGroup', () => {
         ],
       });
       expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
-      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
-        operator: 'and',
-        conditions: [
-          {
-            column: 'a',
-            comparison: 'eq',
-            value: 'toto',
-          },
-          {
-            column: 'b',
-            comparison: 'eq',
-            value: 'tata',
-          },
-        ],
-        groups: [
-          {
-            conditions: [
-              {
-                column: 'd',
-                comparison: 'eq',
-                value: 'blublu',
-              },
-            ],
-          }
-        ]
-      }]);
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([
+        {
+          operator: 'and',
+          conditions: [
+            {
+              column: 'a',
+              comparison: 'eq',
+              value: 'toto',
+            },
+            {
+              column: 'b',
+              comparison: 'eq',
+              value: 'tata',
+            },
+          ],
+          groups: [
+            {
+              conditions: [
+                {
+                  column: 'd',
+                  comparison: 'eq',
+                  value: 'blublu',
+                },
+              ],
+            },
+          ],
+        },
+      ]);
     });
 
     it('should emit "conditionsTreeUpdated" with the new conditionTree when "or" operator button is click', () => {
       wrapper.find('.conditions-group__switch-button--or').trigger('click');
       expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
-      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
-        operator: 'or',
-        conditions: [
-          {
-            column: 'a',
-            comparison: 'eq',
-            value: 'toto',
-          },
-          {
-            column: 'b',
-            comparison: 'eq',
-            value: 'tata',
-          },
-        ],
-        groups: [
-          {
-            conditions: [
-              {
-                column: 'c',
-                comparison: 'eq',
-                value: 'tutu',
-              },
-            ],
-          }
-        ]
-      }]);
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([
+        {
+          operator: 'or',
+          conditions: [
+            {
+              column: 'a',
+              comparison: 'eq',
+              value: 'toto',
+            },
+            {
+              column: 'b',
+              comparison: 'eq',
+              value: 'tata',
+            },
+          ],
+          groups: [
+            {
+              conditions: [
+                {
+                  column: 'c',
+                  comparison: 'eq',
+                  value: 'tutu',
+                },
+              ],
+            },
+          ],
+        },
+      ]);
     });
 
     it('should emit "conditionsTreeUpdated" with the new conditionTree when the slot emits an event', () => {
@@ -379,32 +381,34 @@ describe('ConditionsGroup', () => {
         value: 'arthas',
       });
       expect(wrapper.emitted().conditionsTreeUpdated).toBeDefined();
-      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([{
-        operator: 'and',
-        conditions: [
-          {
-            column: 'leader',
-            comparison: 'eq',
-            value: 'arthas',
-          },
-          {
-            column: 'b',
-            comparison: 'eq',
-            value: 'tata',
-          },
-        ],
-        groups: [
-          {
-            conditions: [
-              {
-                column: 'c',
-                comparison: 'eq',
-                value: 'tutu',
-              },
-            ],
-          }
-        ]
-      }]);
+      expect(wrapper.emitted().conditionsTreeUpdated[0]).toEqual([
+        {
+          operator: 'and',
+          conditions: [
+            {
+              column: 'leader',
+              comparison: 'eq',
+              value: 'arthas',
+            },
+            {
+              column: 'b',
+              comparison: 'eq',
+              value: 'tata',
+            },
+          ],
+          groups: [
+            {
+              conditions: [
+                {
+                  column: 'c',
+                  comparison: 'eq',
+                  value: 'tutu',
+                },
+              ],
+            },
+          ],
+        },
+      ]);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5280,7 +5280,7 @@ find-babel-config@1.2.0, find-babel-config@^1.1.0:
     json5 "^0.5.1"
     path-exists "^3.0.0"
 
-find-cache-dir@^2.1.0:
+find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
@@ -5966,6 +5966,11 @@ html-minifier-terser@^5.0.1:
     param-case "^2.1.1"
     relateurl "^0.2.7"
     terser "^4.3.9"
+
+html-tags@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
+  integrity sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=
 
 html-webpack-plugin@^4.0.0-beta.2:
   version "4.0.0-beta.11"
@@ -11046,6 +11051,11 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+svg-tags@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
+  integrity sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=
 
 symbol-tree@^3.2.2:
   version "3.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2496,6 +2496,11 @@ babel-helper-to-multiple-sequence-expressions@^0.5.0:
   resolved "https://registry.yarnpkg.com/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz#a3f924e3561882d42fcf48907aa98f7979a4588d"
   integrity sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA==
 
+babel-helper-vue-jsx-merge-props@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-2.0.3.tgz#22aebd3b33902328e513293a8e4992b384f9f1b6"
+  integrity sha512-gsLiKK7Qrb7zYJNgiXKpXblxbV5ffSwR0f5whkPAaBAR4fhi6bwRZxX9wBlIc5M/v8CCkXUbXZL4N/nSE97cqg==
+
 babel-jest@^24.8.0, babel-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.9.0.tgz#3fc327cb8467b89d14d7bc70e315104a783ccd54"
@@ -2508,6 +2513,16 @@ babel-jest@^24.8.0, babel-jest@^24.9.0:
     babel-preset-jest "^24.9.0"
     chalk "^2.4.2"
     slash "^2.0.0"
+
+babel-loader@^8.0.6:
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.6.tgz#e33bdb6f362b03f4bb141a0c21ab87c501b70dfb"
+  integrity sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    loader-utils "^1.0.2"
+    mkdirp "^0.5.1"
+    pify "^4.0.1"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -2560,6 +2575,20 @@ babel-plugin-jest-hoist@^24.9.0:
   integrity sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==
   dependencies:
     "@types/babel__traverse" "^7.0.6"
+
+babel-plugin-jsx-event-modifiers@^2.0.2:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jsx-event-modifiers/-/babel-plugin-jsx-event-modifiers-2.0.5.tgz#93e6ebb5d7553bb08f9fedbf7a0bee3af09a0472"
+  integrity sha512-tWGnCk0whZ+nZcj9tYLw4+y08tPJXqaEjIxRJZS6DkUUae72Kz4BsoGpxt/Kow7mmgQJpvFCw8IPLSNh5rkZCg==
+
+babel-plugin-jsx-v-model@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jsx-v-model/-/babel-plugin-jsx-v-model-2.0.3.tgz#c396416b99cb1af782087315ae1d3e62e070f47d"
+  integrity sha512-SIx3Y3XxwGEz56Q1atwr5GaZsxJ2IRYmn5dl38LFkaTAvjnbNQxsZHO+ylJPsd+Hmv+ixJBYYFEekPBTHwiGfQ==
+  dependencies:
+    babel-plugin-syntax-jsx "^6.18.0"
+    html-tags "^2.0.0"
+    svg-tags "^1.0.0"
 
 babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.4.5:
   version "2.8.0"
@@ -2735,6 +2764,13 @@ babel-plugin-transform-undefined-to-void@^6.9.4:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz#be241ca81404030678b748717322b89d0c8fe280"
   integrity sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=
 
+babel-plugin-transform-vue-jsx@^3.5.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-vue-jsx/-/babel-plugin-transform-vue-jsx-3.7.0.tgz#d40492e6692a36b594f7e9a1928f43e969740960"
+  integrity sha512-W39X07/n3oJMQd8tALBO+440NraGSF//Lo1ydd/9Nme3+QiRGFBb1Q39T9iixh0jZPPbfv3so18tNoIgLatymw==
+  dependencies:
+    esutils "^2.0.2"
+
 babel-preset-jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz#192b521e2217fb1d1f67cf73f70c336650ad3cdc"
@@ -2771,6 +2807,17 @@ babel-preset-jest@^24.9.0:
     babel-plugin-transform-simplify-comparison-operators "^6.9.4"
     babel-plugin-transform-undefined-to-void "^6.9.4"
     lodash "^4.17.11"
+
+babel-preset-vue@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/babel-preset-vue/-/babel-preset-vue-2.0.2.tgz#cfadf1bd736125397481b5f8525ced0049a0c71f"
+  integrity sha1-z63xvXNhJTl0gbX4UlztAEmgxx8=
+  dependencies:
+    babel-helper-vue-jsx-merge-props "^2.0.2"
+    babel-plugin-jsx-event-modifiers "^2.0.2"
+    babel-plugin-jsx-v-model "^2.0.1"
+    babel-plugin-syntax-jsx "^6.18.0"
+    babel-plugin-transform-vue-jsx "^3.5.0"
 
 babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"


### PR DESCRIPTION
A new component to edit condition filter trees:
![Screenshot from 2020-02-07 16-39-07](https://user-images.githubusercontent.com/932583/74142539-6a43f580-4bf9-11ea-982f-f411d90ce4dc.png)

This recursive component accepts a slot to define the tree leave's form.

Here is the default case, with a simple input:
![Screenshot from 2020-02-07 19-01-31](https://user-images.githubusercontent.com/932583/74142538-69ab5f00-4bf9-11ea-9550-07f684caf223.png)

And a more advanced case with a three properties-object:
![Screenshot from 2020-02-07 19-01-37](https://user-images.githubusercontent.com/932583/74142534-6912c880-4bf9-11ea-82ef-a8a02bdfa1f2.png)

We intentionally removed the ability to create more than one level of nesting, to avoid unnecessary complexity. 

On the type-level, it defines a generic type: `AbstractConditionTree<T>` where T is the resulting type of the elements defined in the slot.

This component will then be used to enhance the FilterStep capabilities. 