### PR TITLE
Fix :: remove css cursor pointer on data viewer cells / add fallback fontAwesome declaration

### DIFF
--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -211,7 +211,7 @@ export default class MultiInputTextWidget extends Vue {
 .multiselect__select:before {
   border: 0;
   content: '\f078';
-  font-family: 'Font Awesome 5 Free';
+  font-family: 'Font Awesome 5 Pro', 'Font Awesome 5 Free';
   font-weight: 900;
   line-height: 1;
   top: 8px;

--- a/src/styles/DataViewer.scss
+++ b/src/styles/DataViewer.scss
@@ -31,7 +31,6 @@
   position: relative;
   padding: 8px;
   background-color: white;
-  cursor: pointer;
   border: 1px solid $data-viewer-border-color;
   font-size: 13px;
   text-align: left;
@@ -63,6 +62,7 @@
 }
 
 .data-viewer__header-cell {
+  cursor: pointer;
   font-weight: bold;
   padding: 6px 8px;
 }


### PR DESCRIPTION
everything is explained in this F**** long title  ⬆️ 

Before in tucana :
![image](https://user-images.githubusercontent.com/4438175/74172795-22d95b80-4c31-11ea-966a-0bdab90b4fda.png)

Now you get the right font icon arrow:
![image](https://user-images.githubusercontent.com/4438175/74172822-3389d180-4c31-11ea-84bd-9d07836da7d3.png)
