### PR TITLE
remove "cancel" property from step-form-buttonbar

### DIFF
--- a/docs/_docs/tech/stepforms.md
+++ b/docs/_docs/tech/stepforms.md
@@ -27,7 +27,7 @@ you can leverage a few components and base classes provided:
   e.g.:
 
   ```typescript
-  <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+  <step-form-buttonbar :errors="errors" :submit="submit"></step-form-buttonbar>
   ```
 
 Between those two elements should lie the list on inputs (_text inputs_, _autocomplete_. etc.) that your form wil need.

--- a/src/components/stepforms/AddTextColumnStepForm.vue
+++ b/src/components/stepforms/AddTextColumnStepForm.vue
@@ -18,7 +18,7 @@
       :errors="errors"
       :warning="duplicateColumnName"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -22,7 +22,7 @@
       data-path=".aggregations"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/AppendStepForm.vue
+++ b/src/components/stepforms/AppendStepForm.vue
@@ -10,7 +10,7 @@
       data-path=".pipelines"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/ArgmaxStepForm.vue
+++ b/src/components/stepforms/ArgmaxStepForm.vue
@@ -18,7 +18,7 @@
       data-path=".groups"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/ArgminStepForm.vue
+++ b/src/components/stepforms/ArgminStepForm.vue
@@ -18,7 +18,7 @@
       data-path=".groups"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/ConcatenateStepForm.vue
+++ b/src/components/stepforms/ConcatenateStepForm.vue
@@ -29,7 +29,7 @@
       data-path=".new_column_name"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/ConvertStepForm.vue
+++ b/src/components/stepforms/ConvertStepForm.vue
@@ -20,7 +20,7 @@
       data-path=".data_type"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/CustomStepForm.vue
+++ b/src/components/stepforms/CustomStepForm.vue
@@ -8,7 +8,7 @@
       :errors="errors"
       data-path=".query"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/DateExtractStepForm.vue
+++ b/src/components/stepforms/DateExtractStepForm.vue
@@ -30,7 +30,7 @@
       data-path=".new_column_name"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/DeleteColumnStepForm.vue
+++ b/src/components/stepforms/DeleteColumnStepForm.vue
@@ -11,7 +11,7 @@
       data-path=".columns"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/DomainStepForm.vue
+++ b/src/components/stepforms/DomainStepForm.vue
@@ -8,7 +8,7 @@
       :options="domains"
       placeholder="Choose a domain"
     />
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :errors="errors" :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/DuplicateColumnStepForm.vue
+++ b/src/components/stepforms/DuplicateColumnStepForm.vue
@@ -17,7 +17,7 @@
       data-path=".new_column_name"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/FillnaStepForm.vue
+++ b/src/components/stepforms/FillnaStepForm.vue
@@ -17,7 +17,7 @@
       data-path=".value"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -16,7 +16,7 @@
       data-path=".condition.and"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/FormulaStepForm.vue
+++ b/src/components/stepforms/FormulaStepForm.vue
@@ -18,7 +18,7 @@
       :errors="errors"
       :warning="duplicateColumnName"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/FromDateStepForm.vue
+++ b/src/components/stepforms/FromDateStepForm.vue
@@ -18,7 +18,7 @@
       data-path=".format"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/JoinStepForm.vue
+++ b/src/components/stepforms/JoinStepForm.vue
@@ -31,7 +31,7 @@
       data-path=".on"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/PercentageStepForm.vue
+++ b/src/components/stepforms/PercentageStepForm.vue
@@ -18,7 +18,7 @@
       data-path=".group"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/PivotStepForm.vue
+++ b/src/components/stepforms/PivotStepForm.vue
@@ -36,7 +36,7 @@
       data-path=".agg_function"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 <script lang="ts">

--- a/src/components/stepforms/RenameStepForm.vue
+++ b/src/components/stepforms/RenameStepForm.vue
@@ -17,7 +17,7 @@
       data-path=".newname"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/ReplaceStepForm.vue
+++ b/src/components/stepforms/ReplaceStepForm.vue
@@ -20,7 +20,7 @@
       data-path=".to_replace"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/SelectColumnStepForm.vue
+++ b/src/components/stepforms/SelectColumnStepForm.vue
@@ -11,7 +11,7 @@
       data-path=".columns"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/SortStepForm.vue
+++ b/src/components/stepforms/SortStepForm.vue
@@ -12,7 +12,7 @@
       :errors="errors"
     />
 
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/SubstringStepForm.vue
+++ b/src/components/stepforms/SubstringStepForm.vue
@@ -27,7 +27,7 @@
       data-path=".end_index"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -19,7 +19,7 @@
       data-path=".format"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/ToLowerStepForm.vue
+++ b/src/components/stepforms/ToLowerStepForm.vue
@@ -9,7 +9,7 @@
       data-path=".column"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/ToUpperStepForm.vue
+++ b/src/components/stepforms/ToUpperStepForm.vue
@@ -9,7 +9,7 @@
       data-path=".column"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/TopStepForm.vue
+++ b/src/components/stepforms/TopStepForm.vue
@@ -38,7 +38,7 @@
       data-path=".groups"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/UniqueGroupsStepForm.vue
+++ b/src/components/stepforms/UniqueGroupsStepForm.vue
@@ -11,7 +11,7 @@
       data-path=".on"
       :errors="errors"
     />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/UnpivotStepForm.vue
+++ b/src/components/stepforms/UnpivotStepForm.vue
@@ -22,7 +22,7 @@
       :errors="errors"
     />
     <CheckboxWidget id="dropnaCheckbox" :label="checkboxLabel" v-model="editedStep.dropna" />
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
+    <step-form-buttonbar :submit="submit" />
   </div>
 </template>
 


### PR DESCRIPTION
This property doesn't exist anymore, it has been replaced by a cancel
property in the `step-form-header` component