### PR TITLE
[mongo translator] :: allow to escape column name in FormulaStep with "[" and "]"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - expose `setCodeEditor` to set a custom code editor component for custom steps
 - custom step which allows users to edit manually a step
 - uniquegroups step to get unique groups/values" from columns
+- escape column name between `[ ]` in formula step in mongo translator
 
 ## [0.10.0] - 2020-02-06
 

--- a/src/components/stepforms/FormulaStepForm.vue
+++ b/src/components/stepforms/FormulaStepForm.vue
@@ -65,7 +65,7 @@ export default class FormulaStepForm extends BaseStepForm<FormulaStep> {
     let ret = this.validator({ ...this.editedStep });
     let errors: ErrorObject[] = [];
     try {
-      parse(this.editedStep.formula);
+      parse(this.editedStep.formula.replace(/\[.*?\]/g, 'var'));
     } catch {
       ret = false;
       errors.push({

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -408,13 +408,47 @@ function getOperator(op: string) {
 }
 
 /**
+  Transform a formula expression into a MathNode
+  1. Replace in formula all column name between `[]` by a "pseudo"
+  2. Parse the formula into a MathNode
+  3. Replace all pseudo into MathNode by there original name
+*/
+function buildFormulaTree(formula: string): MathNode {
+  const ESCAPE_OPEN = '[';
+  const ESCAPE_CLOSE = ']';
+
+  // 1. Replace in formula all column name between `[]` by a "pseudo"
+  let formulaPseudotised = formula;
+  const pseudo: Record<string, string> = {};
+  let index = 0;
+  const regex = new RegExp(`\\${ESCAPE_OPEN}(.*?)\\${ESCAPE_CLOSE}`, 'g');
+  for (const match of formula.match(regex) || []) {
+    pseudo[`__vqb_col_${index}__`] = match;
+    formulaPseudotised = formulaPseudotised.replace(match, `__vqb_col_${index}__`);
+    index++;
+  }
+
+  // 2. Parse the formula into a MathNode
+  const mathjsTree: MathNode = math.parse(formulaPseudotised);
+
+  // 3. Replace all pseudo into MathNode by there original name
+  mathjsTree.traverse(function(node: MathNode): MathNode {
+    if (node.type === 'SymbolNode') {
+      if (pseudo[node.name]) {
+        node.name = pseudo[node.name].replace(ESCAPE_OPEN, '').replace(ESCAPE_CLOSE, '');
+      }
+    }
+    return node;
+  });
+  return mathjsTree;
+}
+
+/**
  * Translate a mathjs logical tree describing a formula into a Mongo step
  * @param node a mathjs node object (usually received after parsing an string expression)
  * This node is the root node of the logical tree describing the formula
  */
 function buildMongoFormulaTree(node: MathNode): MongoStep | string | number {
-  // For type checking in `case: 'OperatorNode'` in the`switch`clause below,
-  // do not let`args` and `op` be potentially`undefined`
   switch (node.type) {
     case 'OperatorNode':
       if (node.args.length === 1) {
@@ -424,9 +458,10 @@ function buildMongoFormulaTree(node: MathNode): MongoStep | string | number {
         };
       }
       return {
-        [getOperator(node.op)]: node.args.map(buildMongoFormulaTree),
+        [getOperator(node.op)]: node.args.map(e => buildMongoFormulaTree(e)),
       };
     case 'SymbolNode':
+      // Re-put the name back
       return $$(node.name);
     case 'ConstantNode':
       return node.value;
@@ -545,11 +580,13 @@ const mapper: Partial<StepMatcher<MongoStep>> = {
     },
   }),
   filter: filterstepToMatchstep,
-  formula: (step: Readonly<S.FormulaStep>) => ({
-    $addFields: {
-      [step.new_column]: buildMongoFormulaTree(math.parse(step.formula)),
-    },
-  }),
+  formula: (step: Readonly<S.FormulaStep>) => {
+    return {
+      $addFields: {
+        [step.new_column]: buildMongoFormulaTree(buildFormulaTree(step.formula)),
+      },
+    };
+  },
   fromdate: (step: Readonly<S.FromDateStep>) => ({
     $addFields: {
       [step.column]: { $dateToString: { date: $$(step.column), format: `${step.format}` } },

--- a/src/typings/mathjs/index.d.ts
+++ b/src/typings/mathjs/index.d.ts
@@ -16,21 +16,25 @@ declare namespace mathjs {
     fn: string;
     op: string;
     args: MathNode[];
+    traverse: function;
   }
 
   interface ConstantNode {
     type: 'ConstantNode';
     value: number;
+    traverse: function;
   }
 
   interface SymbolNode {
     type: 'SymbolNode';
     name: string;
+    traverse: function;
   }
 
   interface ParenthesisNode {
     type: 'ParenthesisNode';
     content: MathNode;
+    traverse: function;
   }
 
   type MathNode = OperatorNode | ConstantNode | SymbolNode | ParenthesisNode;

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -1096,6 +1096,48 @@ describe('Pipeline to mongo translator', () => {
     ]);
   });
 
+  it('can generate a formula step with special column name', () => {
+    const pipeline: Pipeline = [
+      {
+        name: 'formula',
+        new_column: 'test',
+        formula: '[column with space and + and, oh a - and_also *] + [an other ^column]',
+      },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      {
+        $addFields: {
+          test: {
+            $add: ['$column with space and + and, oh a - and_also *', '$an other ^column'],
+          },
+        },
+      },
+      { $project: { _id: 0 } },
+    ]);
+  });
+
+  it('can generate a formula step with a special column name and a normal column name', () => {
+    const pipeline: Pipeline = [
+      {
+        name: 'formula',
+        new_column: 'test',
+        formula: '[column with space and + and, oh a - and_also *] + A',
+      },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      {
+        $addFields: {
+          test: {
+            $add: ['$column with space and + and, oh a - and_also *', '$A'],
+          },
+        },
+      },
+      { $project: { _id: 0 } },
+    ]);
+  });
+
   it('can generate a pivot step', () => {
     const pipeline: Pipeline = [
       {


### PR DESCRIPTION
[mongo translator] :: allow to escape column name in FormulaStep with "[" and "]"

Before parsing the formula into a tree by mathjs, we replace all "[...]" by valid pseudo ("valid" for mathjs) and then re-put it back after building the mongo formula.

closes #295