### PR TITLE
Tidy the store to use pipelines library and currentPipelineName as references 

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -197,7 +197,7 @@ async function setupInitialData(store, domain = null) {
   } else {
     const response = await mongoservice.executePipeline(
       store,
-      store.state[VQB_MODULE_NAME].pipeline,
+      store.getters[VQBnamespace('pipeline')],
       store.state[VQB_MODULE_NAME].pagesize,
     );
     if (response.error) {
@@ -237,8 +237,26 @@ async function buildVueApp() {
     },
     created: function() {
       registerModule(this.$store, {
-        pipeline: initialPipeline,
+        currentPipelineName: 'pipeline',
         pipelines: {
+          pipeline: [
+            {
+              name: 'domain',
+              domain: 'test-collection',
+            },
+            {
+              name: 'filter',
+              condition: {
+                and: [
+                  {
+                    column: 'Groups',
+                    value: '<%= groupname %>',
+                    operator: 'eq',
+                  },
+                ],
+              },
+            },
+          ],
           pipeline1: [
             {
               name: 'domain',

--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -43,10 +43,9 @@ export default class ActionMenu extends Vue {
   })
   columnName!: string;
 
-  @VQBModule.State pipeline!: Pipeline;
-
   @VQBModule.Getter computedActiveStepIndex!: number;
   @VQBModule.Getter isEditingStep!: boolean;
+  @VQBModule.Getter pipeline!: Pipeline;
 
   @VQBModule.Mutation selectStep!: MutationCallbacks['selectStep'];
   @VQBModule.Mutation setPipeline!: MutationCallbacks['setPipeline'];

--- a/src/components/ActionToolbarButton.vue
+++ b/src/components/ActionToolbarButton.vue
@@ -59,10 +59,9 @@ export default class ActionToolbarButton extends Vue {
   })
   category!: string;
 
-  @VQBModule.State pipeline!: S.Pipeline;
-
   @VQBModule.Getter computedActiveStepIndex!: number;
   @VQBModule.Getter isEditingStep!: boolean;
+  @VQBModule.Getter pipeline!: S.Pipeline;
   @VQBModule.Getter selectedColumns!: string[];
 
   @VQBModule.Mutation selectStep!: MutationCallbacks['selectStep'];

--- a/src/components/DataTypesMenu.vue
+++ b/src/components/DataTypesMenu.vue
@@ -61,10 +61,9 @@ export default class DataTypesMenu extends Vue {
   })
   columnName!: string;
 
-  @VQBModule.State pipeline!: Pipeline;
-
   @VQBModule.Getter computedActiveStepIndex!: number;
   @VQBModule.Getter isEditingStep!: boolean;
+  @VQBModule.Getter pipeline!: Pipeline;
 
   @VQBModule.Mutation selectStep!: MutationCallbacks['selectStep'];
   @VQBModule.Mutation setPipeline!: MutationCallbacks['setPipeline'];

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -39,12 +39,11 @@ import Step from './Step.vue';
   },
 })
 export default class PipelineComponent extends Vue {
-  @VQBModule.State('pipeline') steps!: Pipeline;
   @VQBModule.State domains!: string[];
 
-  @VQBModule.Getter activePipeline!: Pipeline;
   @VQBModule.Getter('computedActiveStepIndex') activeStepIndex!: number;
   @VQBModule.Getter domainStep!: DomainStep;
+  @VQBModule.Getter('pipeline') steps!: Pipeline;
   @VQBModule.Getter('isPipelineEmpty') onlyDomainStepIsPresent!: boolean;
   @VQBModule.Getter('isStepDisabled') isDisabled!: (index: number) => boolean;
 

--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -49,12 +49,12 @@ import { STEPFORM_REGISTRY } from './formlib';
 })
 export default class QueryBuilder extends Vue {
   @VQBModule.State currentStepFormName!: PipelineStepName;
-  @VQBModule.State pipeline!: Pipeline;
   @VQBModule.State stepFormInitialValue!: object;
   @VQBModule.State stepFormDefaults!: object;
 
   @VQBModule.Getter computedActiveStepIndex!: number;
   @VQBModule.Getter isEditingStep!: boolean;
+  @VQBModule.Getter pipeline!: Pipeline;
 
   @VQBModule.Mutation closeStepForm!: () => void;
   @VQBModule.Mutation openStepForm!: (payload: {
@@ -64,7 +64,7 @@ export default class QueryBuilder extends Vue {
   @VQBModule.Mutation resetStepFormInitialValue!: () => void;
   @VQBModule.Mutation setCurrentDomain!: (payload: Pick<VQBState, 'currentDomain'>) => void;
   @VQBModule.Mutation selectStep!: (payload: { index: number }) => void;
-  @VQBModule.Mutation setPipeline!: (payload: Pick<VQBState, 'pipeline'>) => void;
+  @VQBModule.Mutation setPipeline!: (payload: { pipeline: Pipeline }) => void;
 
   get isStepCreation() {
     return this.stepFormInitialValue === undefined;

--- a/src/components/stepforms/StepForm.vue
+++ b/src/components/stepforms/StepForm.vue
@@ -48,8 +48,8 @@ function componentProxyBoundOn(self: Vue) {
  * default basic 'submit' / 'back' event callbacks and map some of the props /
  * getters / state and mutations from the store that you'll most of the time
  * need in your concrete step form implementation:
- * - `@VQBModule.State pipeline`
  * - `@VQBModule.State selectedStepIndex`
+ * - `@VQBModule.Getter pipeline`
  * - `@VQBModule.Mutation selectStep`
  * - `@VQBModule.Mutation setSelectedColumns`.
  *
@@ -91,7 +91,6 @@ export default class BaseStepForm<StepType> extends Vue {
   stepFormDefaults!: Partial<StepType>;
 
   @VQBModule.State interpolateFunc!: InterpolateFunction;
-  @VQBModule.State pipeline!: Pipeline;
   @VQBModule.State selectedStepIndex!: number;
   @VQBModule.State variables!: ScopeContext;
 
@@ -100,6 +99,7 @@ export default class BaseStepForm<StepType> extends Vue {
 
   @VQBModule.Getter columnNames!: string[];
   @VQBModule.Getter computedActiveStepIndex!: number;
+  @VQBModule.Getter pipeline!: Pipeline;
   @VQBModule.Getter selectedColumns!: string[];
 
   readonly selectedColumnAttrName: string | null = null;

--- a/src/store/backend-plugin.ts
+++ b/src/store/backend-plugin.ts
@@ -88,7 +88,7 @@ export function dereferencePipelines(
 }
 
 async function _updateDataset(store: Store<any>, service: BackendService, pipeline: Pipeline) {
-  if (!store.state[VQB_MODULE_NAME].pipeline.length) {
+  if (!store.getters[VQBnamespace('pipeline')].length) {
     return;
   }
   try {

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -3,7 +3,7 @@
  */
 import _ from 'lodash';
 
-import { activePipeline, inactivePipeline, VQBState } from './state';
+import { activePipeline, currentPipeline, inactivePipeline, VQBState } from './state';
 
 export default {
   /**
@@ -32,12 +32,12 @@ export default {
    * a direct "usable" index (i.e. convert "-1" to a positive one) of last active step.
    */
   computedActiveStepIndex: (state: VQBState) =>
-    state.selectedStepIndex === -1 ? state.pipeline.length - 1 : state.selectedStepIndex,
+    state.selectedStepIndex === -1 ? currentPipeline(state).length - 1 : state.selectedStepIndex,
   /**
    * the first step of the pipeline. Since it's handled differently in the UI,
    * it's useful to be able to access it directly.
    */
-  domainStep: (state: VQBState) => state.pipeline[0],
+  domainStep: (state: VQBState) => currentPipeline(state)[0],
   /**
    * the part of the pipeline that is currently disabled.
    */
@@ -53,7 +53,7 @@ export default {
   /**
    * helper that is True if pipeline is empty or only contain a domain step.
    */
-  isPipelineEmpty: (state: VQBState) => state.pipeline.length <= 1,
+  isPipelineEmpty: (state: VQBState) => currentPipeline(state).length <= 1,
   /**
    * helper that is True if this step is after the last currently active step.
    */
@@ -64,6 +64,10 @@ export default {
    */
   pageno: (state: VQBState) =>
     state.dataset.paginationContext ? state.dataset.paginationContext.pageno : 1,
+  /**
+   * Return current edited pipeline
+   */
+  pipeline: (state: VQBState) => currentPipeline(state),
   /**
    * Return pipelines save in store
    */
@@ -79,7 +83,7 @@ export default {
   /**
    * Get the step config of the pipeline based on its index
    */
-  stepConfig: (state: VQBState) => (index: number) => state.pipeline[index],
+  stepConfig: (state: VQBState) => (index: number) => currentPipeline(state)[index],
   /**
    * Return the app translator name
    */

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -2,10 +2,11 @@
  * exports the list of store getters.
  */
 import _ from 'lodash';
+import { GetterTree } from 'vuex';
 
 import { activePipeline, currentPipeline, inactivePipeline, VQBState } from './state';
 
-export default {
+const getters: GetterTree<VQBState, any> = {
   /**
    * the part of the pipeline that is currently selected.
    */
@@ -89,3 +90,5 @@ export default {
    */
   translator: (state: VQBState) => state.translator,
 };
+
+export default getters;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,13 +5,13 @@
  * e.g. `registerModule(hostStore, initialState)` to register a VQB store
  * and `unregisterModule()` for the dual operation.
  *
- * A `vuex-class`'s namesapce is exported as the '`VQBModule` symbol. It can therefore
+ * A `vuex-class`'s namespace is exported as the '`VQBModule` symbol. It can therefore
  * be used as a decorator inside a `Vue` component, .e.g.:
  *
  * ```typescript
  * @Component
  * class MyComponent extends Vue {
- *    @VQBModule.State pipeline!: Pipeline;
+ *    @VQBModule.Getter pipeline!: Pipeline;
  *    // ...
  * }
  * ```

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -42,7 +42,7 @@ export const VQBModule = namespace(VQB_MODULE_NAME);
 export function buildStoreModule(initialState: Partial<VQBState> = {}) {
   const store = {
     namespaced: true,
-    state: { ...emptyState, ...initialState },
+    state: { ...emptyState(), ...initialState },
     getters,
     mutations,
   };
@@ -81,7 +81,7 @@ export function setupStore(
     Vue.use(Vuex);
   }
   const store: StoreOptions<VQBState> = {
-    state: { ...emptyState, ...initialState },
+    state: { ...emptyState(), ...initialState },
     getters,
     mutations,
     plugins,

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -89,36 +89,38 @@ export interface VQBState {
 }
 
 /**
- * default empty state, useful to update just some parts of it
+ * generate the default empty state, useful to update just some parts of it
  * when creating the initial version of store.
  */
-export const emptyState: VQBState = {
-  dataset: {
-    headers: [],
-    data: [],
-    paginationContext: {
-      pagesize: 50,
-      pageno: 1,
-      totalCount: 0,
+export function emptyState(): VQBState {
+  return {
+    dataset: {
+      headers: [],
+      data: [],
+      paginationContext: {
+        pagesize: 50,
+        pageno: 1,
+        totalCount: 0,
+      },
     },
-  },
-  domains: [],
-  currentStepFormName: undefined,
-  stepFormInitialValue: undefined,
-  stepFormDefaults: undefined,
-  selectedStepIndex: -1,
-  currentPipelineName: 'my_pipeline',
-  pipelines: {
-    my_pipeline: [],
-  },
-  selectedColumns: [],
-  pagesize: 50,
-  backendErrors: [],
-  isLoading: false,
-  variables: {},
-  translator: 'mongo40',
-  interpolateFunc: (x: string, _context: ScopeContext) => x,
-};
+    domains: [],
+    currentStepFormName: undefined,
+    stepFormInitialValue: undefined,
+    stepFormDefaults: undefined,
+    selectedStepIndex: -1,
+    currentPipelineName: 'my_pipeline',
+    pipelines: {
+      my_pipeline: [],
+    },
+    selectedColumns: [],
+    pagesize: 50,
+    backendErrors: [],
+    isLoading: false,
+    variables: {},
+    translator: 'mongo40',
+    interpolateFunc: (x: string, _context: ScopeContext) => x,
+  };
+}
 
 /**
  * @param state current application state

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -39,7 +39,7 @@ export interface VQBState {
   /**
    * saved pipelines, with unique name as key and pipeline as value
    */
-  pipelines: { [k: string]: Pipeline };
+  pipelines: { [name: string]: Pipeline };
 
   /**
    * object used to fill an edit step form

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -108,9 +108,9 @@ export function emptyState(): VQBState {
     stepFormInitialValue: undefined,
     stepFormDefaults: undefined,
     selectedStepIndex: -1,
-    currentPipelineName: 'my_pipeline',
+    currentPipelineName: 'default_pipeline',
     pipelines: {
-      my_pipeline: [],
+      default_pipeline: [],
     },
     selectedColumns: [],
     pagesize: 50,

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -23,7 +23,7 @@ export interface VQBState {
   /**
    * the current pipeline (being edited) name
    */
-  currentPipelineName?: string;
+  currentPipelineName: string;
   /**
    * the current step form displayed
    */
@@ -32,11 +32,6 @@ export interface VQBState {
    * the last step currently active.
    */
   selectedStepIndex: number;
-  /**
-   * FIXME should be a getter from pipelines + current selected pipeline
-   * the current pipeline (including inactive steps).
-   */
-  pipeline: Pipeline;
 
   /**
    * saved pipelines, with unique name as key and pipeline as value
@@ -112,9 +107,10 @@ export const emptyState: VQBState = {
   stepFormInitialValue: undefined,
   stepFormDefaults: undefined,
   selectedStepIndex: -1,
-  pipeline: [],
-  currentPipelineName: undefined,
-  pipelines: {},
+  currentPipelineName: 'my_pipeline',
+  pipelines: {
+    my_pipeline: [],
+  },
   selectedColumns: [],
   pagesize: 50,
   backendErrors: [],
@@ -126,13 +122,21 @@ export const emptyState: VQBState = {
 
 /**
  * @param state current application state
+ * @return the pipeline currently edited
+ */
+export function currentPipeline(state: VQBState) {
+  return state.pipelines[state.currentPipelineName];
+}
+
+/**
+ * @param state current application state
  * @return the index of the first inactive step. Return first out of bound index
  * if all steps are active.
  */
 function firstNonSelectedIndex(state: VQBState) {
-  const { pipeline, selectedStepIndex } = state;
+  const { selectedStepIndex } = state;
   if (selectedStepIndex < 0) {
-    return pipeline.length;
+    return currentPipeline(state).length;
   }
   return selectedStepIndex + 1;
 }
@@ -142,7 +146,7 @@ function firstNonSelectedIndex(state: VQBState) {
  * @return the subpart of the pipeline that is currently active.
  */
 export function activePipeline(state: VQBState) {
-  return state.pipeline.slice(0, firstNonSelectedIndex(state));
+  return currentPipeline(state).slice(0, firstNonSelectedIndex(state));
 }
 
 /**
@@ -150,5 +154,5 @@ export function activePipeline(state: VQBState) {
  * @return the subpart of the pipeline that is currently inactive.
  */
 export function inactivePipeline(state: VQBState) {
-  return state.pipeline.slice(firstNonSelectedIndex(state));
+  return currentPipeline(state).slice(firstNonSelectedIndex(state));
 }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -93,7 +93,7 @@ export interface VQBState {
 
 /**
  * default empty state, useful to update just some parts of it
- * when creating the intiial version of store.
+ * when creating the initial version of store.
  */
 export const emptyState: VQBState = {
   dataset: {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -16,6 +16,7 @@ export interface VQBState {
    */
   domains: string[];
   /**
+   * FIXME should be a getter from the current pipeline
    * the domain currently selected.
    */
   currentDomain?: string;
@@ -32,6 +33,7 @@ export interface VQBState {
    */
   selectedStepIndex: number;
   /**
+   * FIXME should be a getter from pipelines + current selected pipeline
    * the current pipeline (including inactive steps).
    */
   pipeline: Pipeline;

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -85,7 +85,7 @@ describe('Action Menu', () => {
   });
 
   describe('when clicking on "Delete column"', () => {
-    it('should add a valide delete step in the pipeline', async () => {
+    it('should add a valid delete step in the pipeline', async () => {
       const store = setupMockStore();
       const wrapper = shallowMount(ActionMenu, {
         store,
@@ -97,7 +97,9 @@ describe('Action Menu', () => {
       const actionsWrapper = wrapper.findAll('.action-menu__option');
       actionsWrapper.at(2).trigger('click');
       await localVue.nextTick();
-      expect(store.state.vqb.pipeline).toEqual([{ name: 'delete', columns: ['columnA'] }]);
+      expect(store.getters[VQBnamespace('pipeline')]).toEqual([
+        { name: 'delete', columns: ['columnA'] },
+      ]);
     });
 
     it('should emit a close event', () => {
@@ -219,7 +221,9 @@ describe('Action Menu', () => {
       const actionsWrapper = wrapper.findAll('.action-menu__option');
       actionsWrapper.at(7).trigger('click');
       await localVue.nextTick();
-      expect(store.state.vqb.pipeline).toEqual([{ name: 'uniquegroups', on: ['columnA'] }]);
+      expect(store.getters[VQBnamespace('pipeline')]).toEqual([
+        { name: 'uniquegroups', on: ['columnA'] },
+      ]);
     });
 
     it('should emit a close event', () => {

--- a/tests/unit/action-toolbar-button.spec.ts
+++ b/tests/unit/action-toolbar-button.spec.ts
@@ -2,8 +2,9 @@ import { createLocalVue, mount } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import ActionToolbarButton from '@/components/ActionToolbarButton.vue';
+import { VQBnamespace } from '@/store';
 
-import { setupMockStore } from './utils';
+import { buildState, buildStateWithOnePipeline, setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -149,10 +150,11 @@ describe('ActionToolbarButton', () => {
 
   describe('When clicking on the "To lowercase" operation', () => {
     it('should close any open step form', async () => {
-      const store = setupMockStore({
-        pipeline: [{ name: 'domain', domain: 'myDomain' }],
-        selectedColumns: ['foo'],
-      });
+      const store = setupMockStore(
+        buildStateWithOnePipeline([{ name: 'domain', domain: 'myDomain' }], {
+          selectedColumns: ['foo'],
+        }),
+      );
       const wrapper = mount(ActionToolbarButton, {
         propsData: { category: 'text' },
         store,
@@ -164,10 +166,11 @@ describe('ActionToolbarButton', () => {
     });
 
     it('should insert a lowercase step in pipeline', async () => {
-      const store = setupMockStore({
-        pipeline: [{ name: 'domain', domain: 'myDomain' }],
-        selectedColumns: ['foo'],
-      });
+      const store = setupMockStore(
+        buildStateWithOnePipeline([{ name: 'domain', domain: 'myDomain' }], {
+          selectedColumns: ['foo'],
+        }),
+      );
       const wrapper = mount(ActionToolbarButton, {
         propsData: { category: 'text' },
         store,
@@ -175,7 +178,7 @@ describe('ActionToolbarButton', () => {
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
       await actionsWrappers.at(4).trigger('click');
-      expect(store.state.vqb.pipeline).toEqual([
+      expect(store.getters[VQBnamespace('pipeline')]).toEqual([
         { name: 'domain', domain: 'myDomain' },
         { name: 'lowercase', column: 'foo' },
       ]);
@@ -183,10 +186,11 @@ describe('ActionToolbarButton', () => {
     });
 
     it('should emit a close event', async () => {
-      const store = setupMockStore({
-        pipeline: [{ name: 'domain', domain: 'myDomain' }],
-        selectedColumns: ['foo'],
-      });
+      const store = setupMockStore(
+        buildStateWithOnePipeline([{ name: 'domain', domain: 'myDomain' }], {
+          selectedColumns: ['foo'],
+        }),
+      );
       const wrapper = mount(ActionToolbarButton, {
         propsData: { category: 'text' },
         store,
@@ -200,10 +204,11 @@ describe('ActionToolbarButton', () => {
 
   describe('When clicking on the "To uppercase" operation', () => {
     it('should close any open step form', async () => {
-      const store = setupMockStore({
-        pipeline: [{ name: 'domain', domain: 'myDomain' }],
-        selectedColumns: ['foo'],
-      });
+      const store = setupMockStore(
+        buildStateWithOnePipeline([{ name: 'domain', domain: 'myDomain' }], {
+          selectedColumns: ['foo'],
+        }),
+      );
       const wrapper = mount(ActionToolbarButton, {
         propsData: { category: 'text' },
         store,
@@ -215,10 +220,11 @@ describe('ActionToolbarButton', () => {
     });
 
     it('should insert a lowercase step in pipeline', async () => {
-      const store = setupMockStore({
-        pipeline: [{ name: 'domain', domain: 'myDomain' }],
-        selectedColumns: ['foo'],
-      });
+      const store = setupMockStore(
+        buildStateWithOnePipeline([{ name: 'domain', domain: 'myDomain' }], {
+          selectedColumns: ['foo'],
+        }),
+      );
       const wrapper = mount(ActionToolbarButton, {
         propsData: { category: 'text' },
         store,
@@ -226,7 +232,7 @@ describe('ActionToolbarButton', () => {
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
       await actionsWrappers.at(5).trigger('click');
-      expect(store.state.vqb.pipeline).toEqual([
+      expect(store.getters[VQBnamespace('pipeline')]).toEqual([
         { name: 'domain', domain: 'myDomain' },
         { name: 'uppercase', column: 'foo' },
       ]);
@@ -234,10 +240,11 @@ describe('ActionToolbarButton', () => {
     });
 
     it('should emit a close event', async () => {
-      const store = setupMockStore({
-        pipeline: [{ name: 'domain', domain: 'myDomain' }],
-        selectedColumns: ['foo'],
-      });
+      const store = setupMockStore(
+        buildStateWithOnePipeline([{ name: 'domain', domain: 'myDomain' }], {
+          selectedColumns: ['foo'],
+        }),
+      );
       const wrapper = mount(ActionToolbarButton, {
         propsData: { category: 'text' },
         store,
@@ -251,10 +258,11 @@ describe('ActionToolbarButton', () => {
 
   describe('When clicking on the "Convert from text to date" operation', () => {
     it('should close any open step form', async () => {
-      const store = setupMockStore({
-        pipeline: [{ name: 'domain', domain: 'myDomain' }],
-        selectedColumns: ['foo'],
-      });
+      const store = setupMockStore(
+        buildStateWithOnePipeline([{ name: 'domain', domain: 'myDomain' }], {
+          selectedColumns: ['foo'],
+        }),
+      );
       const wrapper = mount(ActionToolbarButton, {
         propsData: { category: 'date' },
         store,
@@ -266,10 +274,11 @@ describe('ActionToolbarButton', () => {
     });
 
     it('should insert a todate step in pipeline', async () => {
-      const store = setupMockStore({
-        pipeline: [{ name: 'domain', domain: 'myDomain' }],
-        selectedColumns: ['foo'],
-      });
+      const store = setupMockStore(
+        buildStateWithOnePipeline([{ name: 'domain', domain: 'myDomain' }], {
+          selectedColumns: ['foo'],
+        }),
+      );
       const wrapper = mount(ActionToolbarButton, {
         propsData: { category: 'date' },
         store,
@@ -277,7 +286,7 @@ describe('ActionToolbarButton', () => {
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
       await actionsWrappers.at(0).trigger('click');
-      expect(store.state.vqb.pipeline).toEqual([
+      expect(store.getters[VQBnamespace('pipeline')]).toEqual([
         { name: 'domain', domain: 'myDomain' },
         { name: 'todate', column: 'foo' },
       ]);
@@ -285,10 +294,11 @@ describe('ActionToolbarButton', () => {
     });
 
     it('should emit a close event', async () => {
-      const store = setupMockStore({
-        pipeline: [{ name: 'domain', domain: 'myDomain' }],
-        selectedColumns: ['foo'],
-      });
+      const store = setupMockStore(
+        buildStateWithOnePipeline([{ name: 'domain', domain: 'myDomain' }], {
+          selectedColumns: ['foo'],
+        }),
+      );
       const wrapper = mount(ActionToolbarButton, {
         propsData: { category: 'date' },
         store,
@@ -303,10 +313,11 @@ describe('ActionToolbarButton', () => {
   for (const [idx, operation] of Object.entries(['year', 'month', 'day', 'week'])) {
     describe(`When clicking on the "Extract ${operation} from" operation`, () => {
       it('should insert a todate step in pipeline', async () => {
-        const store = setupMockStore({
-          pipeline: [{ name: 'domain', domain: 'myDomain' }],
-          selectedColumns: ['foo'],
-        });
+        const store = setupMockStore(
+          buildStateWithOnePipeline([{ name: 'domain', domain: 'myDomain' }], {
+            selectedColumns: ['foo'],
+          }),
+        );
         const wrapper = mount(ActionToolbarButton, {
           propsData: { category: 'date' },
           store,
@@ -314,7 +325,7 @@ describe('ActionToolbarButton', () => {
         });
         const actionsWrappers = wrapper.findAll('.action-menu__option');
         await actionsWrappers.at(Number(idx) + 2).trigger('click');
-        expect(store.state.vqb.pipeline).toEqual([
+        expect(store.getters[VQBnamespace('pipeline')]).toEqual([
           { name: 'domain', domain: 'myDomain' },
           { name: 'dateextract', column: 'foo', operation },
         ]);
@@ -322,10 +333,11 @@ describe('ActionToolbarButton', () => {
       });
 
       it('should emit a close event', async () => {
-        const store = setupMockStore({
-          pipeline: [{ name: 'domain', domain: 'myDomain' }],
-          selectedColumns: ['foo'],
-        });
+        const store = setupMockStore(
+          buildStateWithOnePipeline([{ name: 'domain', domain: 'myDomain' }], {
+            selectedColumns: ['foo'],
+          }),
+        );
         const wrapper = mount(ActionToolbarButton, {
           propsData: { category: 'date' },
           store,

--- a/tests/unit/action-toolbar-button.spec.ts
+++ b/tests/unit/action-toolbar-button.spec.ts
@@ -4,7 +4,7 @@ import Vuex from 'vuex';
 import ActionToolbarButton from '@/components/ActionToolbarButton.vue';
 import { VQBnamespace } from '@/store';
 
-import { buildState, buildStateWithOnePipeline, setupMockStore } from './utils';
+import { buildStateWithOnePipeline, setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/append-step-form.spec.ts
+++ b/tests/unit/append-step-form.spec.ts
@@ -23,10 +23,13 @@ describe('Append Step Form', () => {
   });
 
   runner.testCancel({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-    ],
+    currentPipelineName: 'default_pipeline',
+    pipelines: {
+      default_pipeline: [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', oldname: 'foo', newname: 'bar' },
+      ],
+    },
     selectedStepIndex: 1,
   });
 

--- a/tests/unit/argmax-step-form.spec.ts
+++ b/tests/unit/argmax-step-form.spec.ts
@@ -26,12 +26,15 @@ describe('Argmax Step Form', () => {
 
   runner.testCancel();
   runner.testResetSelectedIndex({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
+    currentPipelineName: 'default_pipeline',
+    pipelines: {
+      default_pipeline: [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', oldname: 'foo', newname: 'bar' },
+        { name: 'rename', oldname: 'baz', newname: 'spam' },
+        { name: 'rename', oldname: 'tic', newname: 'tac' },
+      ],
+    },
     selectedStepIndex: 2,
   });
 

--- a/tests/unit/concatenate-step-form.spec.ts
+++ b/tests/unit/concatenate-step-form.spec.ts
@@ -48,12 +48,15 @@ describe('Concatenate Step Form', () => {
   });
 
   runner.testCancel({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
+    currentPipelineName: 'default_pipeline',
+    pipelines: {
+      default_pipeline: [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', oldname: 'foo', newname: 'bar' },
+        { name: 'rename', oldname: 'baz', newname: 'spam' },
+        { name: 'rename', oldname: 'tic', newname: 'tac' },
+      ],
+    },
     selectedStepIndex: 2,
   });
 

--- a/tests/unit/data-types-menu.spec.ts
+++ b/tests/unit/data-types-menu.spec.ts
@@ -2,8 +2,9 @@ import { createLocalVue, mount, shallowMount } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import DataTypesMenu from '@/components/DataTypesMenu.vue';
+import { VQBnamespace } from '@/store';
 
-import { setupMockStore } from './utils';
+import { buildStateWithOnePipeline, setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -36,14 +37,18 @@ describe('Data Types Menu', () => {
   });
 
   describe('when clicking on a data type', () => {
-    it('should add a valide convert step in the pipeline and select it', async () => {
-      const store = setupMockStore({
-        pipeline: [
-          { name: 'domain', domain: 'test' },
-          { name: 'delete', columns: ['test'] },
-        ],
-        selectedStepIndex: 0,
-      });
+    it('should add a valid convert step in the pipeline and select it', async () => {
+      const store = setupMockStore(
+        buildStateWithOnePipeline(
+          [
+            { name: 'domain', domain: 'test' },
+            { name: 'delete', columns: ['test'] },
+          ],
+          {
+            selectedStepIndex: 0,
+          },
+        ),
+      );
       const wrapper = shallowMount(DataTypesMenu, {
         store,
         localVue,
@@ -54,7 +59,7 @@ describe('Data Types Menu', () => {
       const actionsWrapper = wrapper.findAll('.data-types-menu__option');
       actionsWrapper.at(0).trigger('click');
       await localVue.nextTick();
-      expect(store.state.vqb.pipeline).toEqual([
+      expect(store.getters[VQBnamespace('pipeline')]).toEqual([
         { name: 'domain', domain: 'test' },
         { name: 'convert', columns: ['columnA'], data_type: 'integer' },
         { name: 'delete', columns: ['test'] },

--- a/tests/unit/dateextract-step-form.spec.ts
+++ b/tests/unit/dateextract-step-form.spec.ts
@@ -85,12 +85,15 @@ describe('DateExtract Step Form', () => {
   );
 
   runner.testCancel({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
+    currentPipelineName: 'default_pipeline',
+    pipelines: {
+      default_pipeline: [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', oldname: 'foo', newname: 'bar' },
+        { name: 'rename', oldname: 'baz', newname: 'spam' },
+        { name: 'rename', oldname: 'tic', newname: 'tac' },
+      ],
+    },
     selectedStepIndex: 2,
   });
 

--- a/tests/unit/delete-column-step-form.spec.ts
+++ b/tests/unit/delete-column-step-form.spec.ts
@@ -24,10 +24,13 @@ describe('Delete Column Step Form', () => {
   });
 
   runner.testCancel({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-    ],
+    currentPipelineName: 'default_pipeline',
+    pipelines: {
+      default_pipeline: [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', oldname: 'foo', newname: 'bar' },
+      ],
+    },
     selectedStepIndex: 1,
   });
 

--- a/tests/unit/duplicate-column-step-form.spec.ts
+++ b/tests/unit/duplicate-column-step-form.spec.ts
@@ -38,10 +38,13 @@ describe('Duplicate Column Step Form', () => {
   });
 
   runner.testCancel({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-    ],
+    currentPipelineName: 'default_pipeline',
+    pipelines: {
+      default_pipeline: [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', oldname: 'foo', newname: 'bar' },
+      ],
+    },
     selectedStepIndex: 1,
   });
 

--- a/tests/unit/pagination-component.spec.ts
+++ b/tests/unit/pagination-component.spec.ts
@@ -5,7 +5,7 @@ import Pagination from '@/components/Pagination.vue';
 import { Pipeline } from '@/lib/steps';
 import { BackendService, servicePluginFactory } from '@/store/backend-plugin';
 
-import { setupMockStore } from './utils';
+import { buildStateWithOnePipeline, setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -63,8 +63,7 @@ describe('Pagination Component', () => {
   it('should call executePipeline with limit / offset on backend service', () => {
     const pagesize = 2;
     const store = setupMockStore(
-      {
-        pipeline: [{ name: 'domain', domain: 'foo' }],
+      buildStateWithOnePipeline([{ name: 'domain', domain: 'foo' }], {
         dataset: {
           headers: [{ name: 'city' }, { name: 'population' }, { name: 'isCapitalCity' }],
           data: [
@@ -78,7 +77,7 @@ describe('Pagination Component', () => {
           },
         },
         pagesize,
-      },
+      }),
       [servicePluginFactory(new DummyService())],
     );
     const wrapper = mount(Pagination, { localVue, store });

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -4,7 +4,7 @@ import Vuex from 'vuex';
 import PipelineComponent from '@/components/Pipeline.vue';
 import { Pipeline } from '@/lib/steps';
 
-import { setupMockStore } from './utils';
+import { setupMockStore, buildStateWithOnePipeline } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -16,7 +16,7 @@ describe('Pipeline.vue', () => {
       { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
       { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
     ];
-    const store = setupMockStore({ pipeline });
+    const store = setupMockStore(buildStateWithOnePipeline(pipeline));
     const wrapper = shallowMount(PipelineComponent, { store, localVue });
     const steps = wrapper.findAll('step-stub');
     expect(steps.length).toEqual(3);

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -4,7 +4,7 @@ import Vuex from 'vuex';
 import PipelineComponent from '@/components/Pipeline.vue';
 import { Pipeline } from '@/lib/steps';
 
-import { setupMockStore, buildStateWithOnePipeline } from './utils';
+import { buildStateWithOnePipeline, setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/plugins.spec.ts
+++ b/tests/unit/plugins.spec.ts
@@ -10,7 +10,7 @@ import { VQBnamespace } from '@/store';
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 import { BackendService, servicePluginFactory } from '@/store/backend-plugin';
 
-import { setupMockStore, buildStateWithOnePipeline } from './utils';
+import { buildStateWithOnePipeline, setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);

--- a/tests/unit/rename-step-form.spec.ts
+++ b/tests/unit/rename-step-form.spec.ts
@@ -37,12 +37,15 @@ describe('Rename Step Form', () => {
   });
 
   runner.testCancel({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
+    currentPipelineName: 'default_pipeline',
+    pipelines: {
+      default_pipeline: [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', oldname: 'foo', newname: 'bar' },
+        { name: 'rename', oldname: 'baz', newname: 'spam' },
+        { name: 'rename', oldname: 'tic', newname: 'tac' },
+      ],
+    },
     selectedStepIndex: 2,
   });
 
@@ -75,12 +78,15 @@ describe('Rename Step Form', () => {
 
   it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
     const initialState = {
-      pipeline: [
-        { name: 'domain', domain: 'foo' },
-        { name: 'rename', oldname: 'foo', newname: 'bar' },
-        { name: 'rename', oldname: 'baz', newname: 'spam' },
-        { name: 'rename', oldname: 'tic', newname: 'tac' },
-      ],
+      currentPipelineName: 'default_pipeline',
+      pipelines: {
+        default_pipeline: [
+          { name: 'domain', domain: 'foo' },
+          { name: 'rename', oldname: 'foo', newname: 'bar' },
+          { name: 'rename', oldname: 'baz', newname: 'spam' },
+          { name: 'rename', oldname: 'tic', newname: 'tac' },
+        ],
+      },
       selectedStepIndex: 2,
     };
     const wrapper = runner.mount(initialState, { propsData: { isStepCreation: true } });

--- a/tests/unit/sort-step-form.spec.ts
+++ b/tests/unit/sort-step-form.spec.ts
@@ -37,12 +37,15 @@ describe('Sort Step Form', () => {
   );
 
   runner.testCancel({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
+    currentPipelineName: 'default_pipeline',
+    pipelines: {
+      default_pipeline: [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', oldname: 'foo', newname: 'bar' },
+        { name: 'rename', oldname: 'baz', newname: 'spam' },
+        { name: 'rename', oldname: 'tic', newname: 'tac' },
+      ],
+    },
     selectedStepIndex: 2,
   });
 

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -5,8 +5,9 @@ import DeleteConfirmationModal from '@/components/DeleteConfirmationModal.vue';
 import PipelineComponent from '@/components/Pipeline.vue';
 import Step from '@/components/Step.vue';
 import { Pipeline } from '@/lib/steps';
+import { VQBnamespace } from '@/store';
 
-import { setupMockStore } from './utils';
+import { setupMockStore, buildStateWithOnePipeline } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -124,7 +125,7 @@ describe('Step.vue', () => {
         { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
         { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
       ];
-      const store = setupMockStore({ pipeline });
+      const store = setupMockStore(buildStateWithOnePipeline(pipeline));
       const wrapper = mount(PipelineComponent, { store, localVue });
       const step = wrapper.findAll(Step).at(1);
 
@@ -134,7 +135,7 @@ describe('Step.vue', () => {
       const modal = step.find(DeleteConfirmationModal);
       modal.find('.fa-times').trigger('click');
       await localVue.nextTick();
-      expect(store.state.vqb.pipeline.length).toEqual(3);
+      expect(store.getters[VQBnamespace('pipeline')].length).toEqual(3);
       expect(step.find(DeleteConfirmationModal).exists()).toBeFalsy();
 
       // Test for clicking on the bottom-left cancel button
@@ -143,7 +144,7 @@ describe('Step.vue', () => {
       const modalBis = step.find(DeleteConfirmationModal);
       modalBis.find('.vqb-modal__action--secondary').trigger('click');
       await localVue.nextTick();
-      expect(store.state.vqb.pipeline.length).toEqual(3);
+      expect(store.getters[VQBnamespace('pipeline')].length).toEqual(3);
       expect(step.find(DeleteConfirmationModal).exists()).toBeFalsy();
     });
 
@@ -153,7 +154,7 @@ describe('Step.vue', () => {
         { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
         { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
       ];
-      const store = setupMockStore({ pipeline });
+      const store = setupMockStore(buildStateWithOnePipeline(pipeline));
       const wrapper = mount(PipelineComponent, { store, localVue });
       const step = wrapper.findAll(Step).at(1);
       step.find('.fa-trash-alt').trigger('click');
@@ -161,7 +162,7 @@ describe('Step.vue', () => {
       const modal = step.find(DeleteConfirmationModal);
       modal.find('.vqb-modal__action--primary').trigger('click');
       await localVue.nextTick();
-      expect(store.state.vqb.pipeline.length).toEqual(2);
+      expect(store.getters[VQBnamespace('pipeline')].length).toEqual(2);
       expect(step.find(DeleteConfirmationModal).exists()).toBeFalsy();
     });
   });
@@ -173,7 +174,7 @@ describe('Step.vue', () => {
       { name: 'rename', oldname: 'region', newname: 'kingdom' },
       { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
     ];
-    const store = setupMockStore({ pipeline });
+    const store = setupMockStore(buildStateWithOnePipeline(pipeline));
     const wrapper = mount(PipelineComponent, { store, localVue });
     const stepsArray = wrapper.findAll(Step);
     const renameStep = stepsArray.at(2);
@@ -191,7 +192,7 @@ describe('Step.vue', () => {
       { name: 'rename', oldname: 'region', newname: 'kingdom' },
       { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
     ];
-    const store = setupMockStore({ pipeline, isEditingStep: false });
+    const store = setupMockStore(buildStateWithOnePipeline(pipeline, { isEditingStep: false }));
     const wrapper = mount(PipelineComponent, { store, localVue });
     const stepsArray = wrapper.findAll(Step);
     const renameStep = stepsArray.at(2);

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -7,7 +7,7 @@ import Step from '@/components/Step.vue';
 import { Pipeline } from '@/lib/steps';
 import { VQBnamespace } from '@/store';
 
-import { setupMockStore, buildStateWithOnePipeline } from './utils';
+import { buildStateWithOnePipeline, setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -192,7 +192,9 @@ describe('Step.vue', () => {
       { name: 'rename', oldname: 'region', newname: 'kingdom' },
       { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
     ];
-    const store = setupMockStore(buildStateWithOnePipeline(pipeline, { isEditingStep: false }));
+    const store = setupMockStore(
+      buildStateWithOnePipeline(pipeline, { currentStepFormName: 'rename' }),
+    );
     const wrapper = mount(PipelineComponent, { store, localVue });
     const stepsArray = wrapper.findAll(Step);
     const renameStep = stepsArray.at(2);

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -1,23 +1,9 @@
 import { Pipeline } from '@/lib/steps';
 import getters from '@/store/getters';
 import mutations from '@/store/mutations';
-import { emptyState, VQBState } from '@/store/state';
+import { emptyState } from '@/store/state';
 
-function stateWithOnePipeline(pipeline: Pipeline) {
-  return {
-    currentPipelineName: 'my_pipeline',
-    pipelines: {
-      my_pipeline: pipeline,
-    },
-  };
-}
-
-function buildState(customState: Partial<VQBState>) {
-  return {
-    ...emptyState(),
-    ...customState,
-  };
-}
+import { buildState, buildStateWithOnePipeline } from './utils';
 
 describe('getter tests', () => {
   describe('(in)active pipeline steps', () => {
@@ -27,7 +13,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState(stateWithOnePipeline(pipeline));
+      const state = buildState(buildStateWithOnePipeline(pipeline));
       expect(getters.activePipeline(state, {}, {}, {})).toEqual(pipeline);
     });
 
@@ -37,7 +23,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ ...stateWithOnePipeline(pipeline), selectedStepIndex: 1 });
+      const state = buildState(buildStateWithOnePipeline(pipeline, { selectedStepIndex: 1 }));
       expect(getters.activePipeline(state, {}, {}, {})).toEqual(pipeline.slice(0, 2));
     });
 
@@ -47,7 +33,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ ...stateWithOnePipeline(pipeline) });
+      const state = buildState(buildStateWithOnePipeline(pipeline));
       expect(getters.inactivePipeline(state, {}, {}, {})).toEqual([]);
     });
 
@@ -57,7 +43,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ ...stateWithOnePipeline(pipeline), selectedStepIndex: 1 });
+      const state = buildState(buildStateWithOnePipeline(pipeline, { selectedStepIndex: 1 }));
       expect(getters.inactivePipeline(state, {}, {}, {})).toEqual(pipeline.slice(2));
     });
   });
@@ -69,7 +55,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ ...stateWithOnePipeline(pipeline) });
+      const state = buildState(buildStateWithOnePipeline(pipeline));
       expect(getters.computedActiveStepIndex(state, {}, {}, {})).toEqual(2);
     });
 
@@ -79,7 +65,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ ...stateWithOnePipeline(pipeline), selectedStepIndex: 1 });
+      const state = buildState(buildStateWithOnePipeline(pipeline, { selectedStepIndex: 1 }));
       expect(getters.computedActiveStepIndex(state, {}, {}, {})).toEqual(1);
     });
   });
@@ -134,7 +120,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ ...stateWithOnePipeline(pipeline) });
+      const state = buildState(buildStateWithOnePipeline(pipeline));
       expect(getters.domainStep(state, {}, {}, {})).toEqual(pipeline[0]);
     });
   });
@@ -164,7 +150,7 @@ describe('getter tests', () => {
   describe('pipeline empty tests', () => {
     it('should return true if pipeline is empty', () => {
       const pipeline: Pipeline = [];
-      const state = buildState({ ...stateWithOnePipeline(pipeline) });
+      const state = buildState(buildStateWithOnePipeline(pipeline));
       expect(getters.isPipelineEmpty(state, {}, {}, {})).toBeTruthy();
     });
 
@@ -174,7 +160,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ ...stateWithOnePipeline(pipeline) });
+      const state = buildState(buildStateWithOnePipeline(pipeline));
       expect(getters.isPipelineEmpty(state, {}, {}, {})).toBeFalsy();
     });
   });
@@ -229,7 +215,7 @@ describe('mutation tests', () => {
       { name: 'rename', oldname: 'foo', newname: 'bar' },
       { name: 'rename', oldname: 'baz', newname: 'spam' },
     ];
-    const state = buildState({ ...stateWithOnePipeline(pipeline) });
+    const state = buildState(buildStateWithOnePipeline(pipeline));
     expect(state.selectedStepIndex).toEqual(-1);
     mutations.selectStep(state, { index: 2 });
     expect(state.selectedStepIndex).toEqual(2);
@@ -255,7 +241,7 @@ describe('mutation tests', () => {
       { name: 'rename', oldname: 'foo', newname: 'bar' },
       { name: 'rename', oldname: 'baz', newname: 'spam' },
     ];
-    const state = buildState({ currentDomain: 'foo', ...stateWithOnePipeline(pipeline) });
+    const state = buildState({ currentDomain: 'foo', ...buildStateWithOnePipeline(pipeline) });
     expect(state.currentDomain).toEqual('foo');
     mutations.setCurrentDomain(state, { currentDomain: 'bar' });
     expect(state.currentDomain).toEqual('bar');
@@ -313,10 +299,11 @@ describe('mutation tests', () => {
       { name: 'domain', domain: 'foo' },
       { name: 'rename', oldname: 'foo', newname: 'bar' },
     ];
-    const state = buildState({
-      currentDomain: 'babar',
-      ...stateWithOnePipeline([{ name: 'domain', domain: 'babar' }]),
-    });
+    const state = buildState(
+      buildStateWithOnePipeline([{ name: 'domain', domain: 'babar' }], {
+        currentDomain: 'babar',
+      }),
+    );
     expect(getters.pipeline(state, {}, {}, {})).toEqual([{ name: 'domain', domain: 'babar' }]);
     expect(state.currentDomain).toEqual('babar');
     mutations.setPipeline(state, { pipeline });
@@ -329,10 +316,11 @@ describe('mutation tests', () => {
       { name: 'domain', domain: 'foo' },
       { name: 'rename', oldname: 'foo', newname: 'bar' },
     ];
-    const state = buildState({
-      currentDomain: 'foo',
-      ...stateWithOnePipeline([{ name: 'rename', oldname: 'foo', newname: 'bar' }]),
-    });
+    const state = buildState(
+      buildStateWithOnePipeline([{ name: 'rename', oldname: 'foo', newname: 'bar' }], {
+        currentDomain: 'foo',
+      }),
+    );
     mutations.setPipeline(state, { pipeline });
     expect(getters.pipeline(state, {}, {}, {})).toEqual(pipeline);
     expect(state.currentDomain).toEqual('foo');

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -3,9 +3,18 @@ import getters from '@/store/getters';
 import mutations from '@/store/mutations';
 import { emptyState, VQBState } from '@/store/state';
 
+function stateWithOnePipeline(pipeline: Pipeline) {
+  return {
+    currentPipelineName: 'my_pipeline',
+    pipelines: {
+      my_pipeline: pipeline,
+    },
+  };
+}
+
 function buildState(customState: Partial<VQBState>) {
   return {
-    ...emptyState,
+    ...emptyState(),
     ...customState,
   };
 }
@@ -18,7 +27,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ pipeline });
+      const state = buildState(stateWithOnePipeline(pipeline));
       expect(getters.activePipeline(state)).toEqual(pipeline);
     });
 
@@ -28,7 +37,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ pipeline, selectedStepIndex: 1 });
+      const state = buildState({ ...stateWithOnePipeline(pipeline), selectedStepIndex: 1 });
       expect(getters.activePipeline(state)).toEqual(pipeline.slice(0, 2));
     });
 
@@ -38,7 +47,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ pipeline });
+      const state = buildState({ ...stateWithOnePipeline(pipeline) });
       expect(getters.inactivePipeline(state)).toEqual([]);
     });
 
@@ -48,7 +57,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ pipeline, selectedStepIndex: 1 });
+      const state = buildState({ ...stateWithOnePipeline(pipeline), selectedStepIndex: 1 });
       expect(getters.inactivePipeline(state)).toEqual(pipeline.slice(2));
     });
   });
@@ -60,7 +69,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ pipeline });
+      const state = buildState({ ...stateWithOnePipeline(pipeline) });
       expect(getters.computedActiveStepIndex(state)).toEqual(2);
     });
 
@@ -70,7 +79,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ pipeline, selectedStepIndex: 1 });
+      const state = buildState({ ...stateWithOnePipeline(pipeline), selectedStepIndex: 1 });
       expect(getters.computedActiveStepIndex(state)).toEqual(1);
     });
   });
@@ -125,7 +134,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ pipeline });
+      const state = buildState({ ...stateWithOnePipeline(pipeline) });
       expect(getters.domainStep(state)).toEqual(pipeline[0]);
     });
   });
@@ -155,7 +164,7 @@ describe('getter tests', () => {
   describe('pipeline empty tests', () => {
     it('should return true if pipeline is empty', () => {
       const pipeline: Pipeline = [];
-      const state = buildState({ pipeline });
+      const state = buildState({ ...stateWithOnePipeline(pipeline) });
       expect(getters.isPipelineEmpty(state)).toBeTruthy();
     });
 
@@ -165,7 +174,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState({ pipeline });
+      const state = buildState({ ...stateWithOnePipeline(pipeline) });
       expect(getters.isPipelineEmpty(state)).toBeFalsy();
     });
   });
@@ -220,7 +229,7 @@ describe('mutation tests', () => {
       { name: 'rename', oldname: 'foo', newname: 'bar' },
       { name: 'rename', oldname: 'baz', newname: 'spam' },
     ];
-    const state = buildState({ pipeline });
+    const state = buildState({ ...stateWithOnePipeline(pipeline) });
     expect(state.selectedStepIndex).toEqual(-1);
     mutations.selectStep(state, { index: 2 });
     expect(state.selectedStepIndex).toEqual(2);
@@ -237,7 +246,7 @@ describe('mutation tests', () => {
     expect(state.currentDomain).toEqual('foo');
     mutations.setCurrentDomain(state, { currentDomain: 'bar' });
     expect(state.currentDomain).toEqual('bar');
-    expect(state.pipeline).toEqual([{ name: 'domain', domain: 'bar' }]);
+    expect(getters.pipeline(state)).toEqual([{ name: 'domain', domain: 'bar' }]);
   });
 
   it('sets current domain on non empty pipeline', () => {
@@ -246,11 +255,11 @@ describe('mutation tests', () => {
       { name: 'rename', oldname: 'foo', newname: 'bar' },
       { name: 'rename', oldname: 'baz', newname: 'spam' },
     ];
-    const state = buildState({ currentDomain: 'foo', pipeline });
+    const state = buildState({ currentDomain: 'foo', ...stateWithOnePipeline(pipeline) });
     expect(state.currentDomain).toEqual('foo');
     mutations.setCurrentDomain(state, { currentDomain: 'bar' });
     expect(state.currentDomain).toEqual('bar');
-    expect(state.pipeline).toEqual([
+    expect(getters.pipeline(state)).toEqual([
       { name: 'domain', domain: 'bar' },
       { name: 'rename', oldname: 'foo', newname: 'bar' },
       { name: 'rename', oldname: 'baz', newname: 'spam' },
@@ -294,9 +303,9 @@ describe('mutation tests', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
     ];
     const state = buildState({});
-    expect(state.pipeline).toEqual([]);
+    expect(getters.pipeline(state)).toEqual([]);
     mutations.setPipeline(state, { pipeline });
-    expect(state.pipeline).toEqual(pipeline);
+    expect(getters.pipeline(state)).toEqual(pipeline);
   });
 
   it('should set current domain when updating pipeline with domain', () => {
@@ -306,12 +315,12 @@ describe('mutation tests', () => {
     ];
     const state = buildState({
       currentDomain: 'babar',
-      pipeline: [{ name: 'domain', domain: 'babar' }],
+      ...stateWithOnePipeline([{ name: 'domain', domain: 'babar' }]),
     });
-    expect(state.pipeline).toEqual([{ name: 'domain', domain: 'babar' }]);
+    expect(getters.pipeline(state)).toEqual([{ name: 'domain', domain: 'babar' }]);
     expect(state.currentDomain).toEqual('babar');
     mutations.setPipeline(state, { pipeline });
-    expect(state.pipeline).toEqual(pipeline);
+    expect(getters.pipeline(state)).toEqual(pipeline);
     expect(state.currentDomain).toEqual('foo');
   });
 
@@ -322,10 +331,10 @@ describe('mutation tests', () => {
     ];
     const state = buildState({
       currentDomain: 'foo',
-      pipeline: [{ name: 'rename', oldname: 'foo', newname: 'bar' }],
+      ...stateWithOnePipeline([{ name: 'rename', oldname: 'foo', newname: 'bar' }]),
     });
     mutations.setPipeline(state, { pipeline });
-    expect(state.pipeline).toEqual(pipeline);
+    expect(getters.pipeline(state)).toEqual(pipeline);
     expect(state.currentDomain).toEqual('foo');
   });
 
@@ -349,7 +358,7 @@ describe('mutation tests', () => {
     expect(state.dataset).toEqual({
       headers: [],
       data: [],
-      paginationContext: emptyState.dataset.paginationContext,
+      paginationContext: emptyState().dataset.paginationContext,
     });
     mutations.setDataset(state, { dataset });
     expect(state.dataset).toEqual(dataset);

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -28,7 +28,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
       const state = buildState(stateWithOnePipeline(pipeline));
-      expect(getters.activePipeline(state)).toEqual(pipeline);
+      expect(getters.activePipeline(state, {}, {}, {})).toEqual(pipeline);
     });
 
     it('should return a partial pipeline if selectedIndex is specified', () => {
@@ -38,7 +38,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
       const state = buildState({ ...stateWithOnePipeline(pipeline), selectedStepIndex: 1 });
-      expect(getters.activePipeline(state)).toEqual(pipeline.slice(0, 2));
+      expect(getters.activePipeline(state, {}, {}, {})).toEqual(pipeline.slice(0, 2));
     });
 
     it('should return an empty pipeline if selectedIndex is -1', () => {
@@ -48,7 +48,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
       const state = buildState({ ...stateWithOnePipeline(pipeline) });
-      expect(getters.inactivePipeline(state)).toEqual([]);
+      expect(getters.inactivePipeline(state, {}, {}, {})).toEqual([]);
     });
 
     it('should return the rest of the pipeline if selectedIndex is specified', () => {
@@ -58,7 +58,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
       const state = buildState({ ...stateWithOnePipeline(pipeline), selectedStepIndex: 1 });
-      expect(getters.inactivePipeline(state)).toEqual(pipeline.slice(2));
+      expect(getters.inactivePipeline(state, {}, {}, {})).toEqual(pipeline.slice(2));
     });
   });
 
@@ -70,7 +70,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
       const state = buildState({ ...stateWithOnePipeline(pipeline) });
-      expect(getters.computedActiveStepIndex(state)).toEqual(2);
+      expect(getters.computedActiveStepIndex(state, {}, {}, {})).toEqual(2);
     });
 
     it('should compute active step index if selectedIndex is specified', () => {
@@ -80,7 +80,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
       const state = buildState({ ...stateWithOnePipeline(pipeline), selectedStepIndex: 1 });
-      expect(getters.computedActiveStepIndex(state)).toEqual(1);
+      expect(getters.computedActiveStepIndex(state, {}, {}, {})).toEqual(1);
     });
   });
 
@@ -92,7 +92,7 @@ describe('getter tests', () => {
           data: [],
         },
       });
-      expect(getters.columnNames(state)).toEqual(['col1', 'col2']);
+      expect(getters.columnNames(state, {}, {}, {})).toEqual(['col1', 'col2']);
     });
 
     it('should be able to handle empty headers', () => {
@@ -102,7 +102,7 @@ describe('getter tests', () => {
           data: [],
         },
       });
-      expect(getters.columnNames(state)).toEqual([]);
+      expect(getters.columnNames(state, {}, {}, {})).toEqual([]);
     });
   });
 
@@ -118,7 +118,7 @@ describe('getter tests', () => {
           data: [],
         },
       });
-      const columnTypes = getters.columnTypes(state);
+      const columnTypes = getters.columnTypes(state, {}, {}, {});
       expect(columnTypes).toEqual({
         col1: 'integer',
         col2: 'boolean',
@@ -135,7 +135,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
       const state = buildState({ ...stateWithOnePipeline(pipeline) });
-      expect(getters.domainStep(state)).toEqual(pipeline[0]);
+      expect(getters.domainStep(state, {}, {}, {})).toEqual(pipeline[0]);
     });
   });
 
@@ -147,7 +147,7 @@ describe('getter tests', () => {
           data: [],
         },
       });
-      expect(getters.isDatasetEmpty(state)).toBeTruthy();
+      expect(getters.isDatasetEmpty(state, {}, {}, {})).toBeTruthy();
     });
 
     it('should return false if dataset is not empty', () => {
@@ -157,7 +157,7 @@ describe('getter tests', () => {
           data: [[0, 0]],
         },
       });
-      expect(getters.isDatasetEmpty(state)).toBeFalsy();
+      expect(getters.isDatasetEmpty(state, {}, {}, {})).toBeFalsy();
     });
   });
 
@@ -165,7 +165,7 @@ describe('getter tests', () => {
     it('should return true if pipeline is empty', () => {
       const pipeline: Pipeline = [];
       const state = buildState({ ...stateWithOnePipeline(pipeline) });
-      expect(getters.isPipelineEmpty(state)).toBeTruthy();
+      expect(getters.isPipelineEmpty(state, {}, {}, {})).toBeTruthy();
     });
 
     it('should return false if pipeline is not empty', () => {
@@ -175,49 +175,49 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
       const state = buildState({ ...stateWithOnePipeline(pipeline) });
-      expect(getters.isPipelineEmpty(state)).toBeFalsy();
+      expect(getters.isPipelineEmpty(state, {}, {}, {})).toBeFalsy();
     });
   });
 
   describe('step disabled tests', () => {
     it('should return false if selected step is not specified or -1', () => {
       let state = buildState({});
-      expect(getters.isStepDisabled(state)(0)).toBeFalsy();
-      expect(getters.isStepDisabled(state)(1)).toBeFalsy();
+      expect(getters.isStepDisabled(state, {}, {}, {})(0)).toBeFalsy();
+      expect(getters.isStepDisabled(state, {}, {}, {})(1)).toBeFalsy();
       state = buildState({ selectedStepIndex: -1 });
-      expect(getters.isStepDisabled(state)(0)).toBeFalsy();
-      expect(getters.isStepDisabled(state)(1)).toBeFalsy();
+      expect(getters.isStepDisabled(state, {}, {}, {})(0)).toBeFalsy();
+      expect(getters.isStepDisabled(state, {}, {}, {})(1)).toBeFalsy();
     });
 
     it('should return false if selected step index is greater than index', () => {
       const state = buildState({ selectedStepIndex: 1 });
-      expect(getters.isStepDisabled(state)(0)).toBeFalsy();
-      expect(getters.isStepDisabled(state)(1)).toBeFalsy();
+      expect(getters.isStepDisabled(state, {}, {}, {})(0)).toBeFalsy();
+      expect(getters.isStepDisabled(state, {}, {}, {})(1)).toBeFalsy();
     });
 
     it('should return true if selected step index is lower than index', () => {
       const state = buildState({ selectedStepIndex: 1 });
-      expect(getters.isStepDisabled(state)(2)).toBeTruthy();
-      expect(getters.isStepDisabled(state)(3)).toBeTruthy();
+      expect(getters.isStepDisabled(state, {}, {}, {})(2)).toBeTruthy();
+      expect(getters.isStepDisabled(state, {}, {}, {})(3)).toBeTruthy();
     });
   });
 
   describe('message error related test', () => {
     it('should return false if backendError is undefined', () => {
       const state = buildState({ backendErrors: [] });
-      expect(getters.thereIsABackendError(state)).toBeFalsy();
+      expect(getters.thereIsABackendError(state, {}, {}, {})).toBeFalsy();
     });
 
     it('should return true if backendError is not undefined', () => {
       const state = buildState({ backendErrors: [{ type: 'error', message: 'error msg' }] });
-      expect(getters.thereIsABackendError(state)).toBeTruthy();
+      expect(getters.thereIsABackendError(state, {}, {}, {})).toBeTruthy();
     });
   });
 
   describe('translator', () => {
     it('should return the app translator', () => {
       const state = buildState({ translator: 'mongo40' });
-      expect(getters.translator(state)).toEqual('mongo40');
+      expect(getters.translator(state, {}, {}, {})).toEqual('mongo40');
     });
   });
 });
@@ -246,7 +246,7 @@ describe('mutation tests', () => {
     expect(state.currentDomain).toEqual('foo');
     mutations.setCurrentDomain(state, { currentDomain: 'bar' });
     expect(state.currentDomain).toEqual('bar');
-    expect(getters.pipeline(state)).toEqual([{ name: 'domain', domain: 'bar' }]);
+    expect(getters.pipeline(state, {}, {}, {})).toEqual([{ name: 'domain', domain: 'bar' }]);
   });
 
   it('sets current domain on non empty pipeline', () => {
@@ -259,7 +259,7 @@ describe('mutation tests', () => {
     expect(state.currentDomain).toEqual('foo');
     mutations.setCurrentDomain(state, { currentDomain: 'bar' });
     expect(state.currentDomain).toEqual('bar');
-    expect(getters.pipeline(state)).toEqual([
+    expect(getters.pipeline(state, {}, {}, {})).toEqual([
       { name: 'domain', domain: 'bar' },
       { name: 'rename', oldname: 'foo', newname: 'bar' },
       { name: 'rename', oldname: 'baz', newname: 'spam' },
@@ -303,9 +303,9 @@ describe('mutation tests', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
     ];
     const state = buildState({});
-    expect(getters.pipeline(state)).toEqual([]);
+    expect(getters.pipeline(state, {}, {}, {})).toEqual([]);
     mutations.setPipeline(state, { pipeline });
-    expect(getters.pipeline(state)).toEqual(pipeline);
+    expect(getters.pipeline(state, {}, {}, {})).toEqual(pipeline);
   });
 
   it('should set current domain when updating pipeline with domain', () => {
@@ -317,10 +317,10 @@ describe('mutation tests', () => {
       currentDomain: 'babar',
       ...stateWithOnePipeline([{ name: 'domain', domain: 'babar' }]),
     });
-    expect(getters.pipeline(state)).toEqual([{ name: 'domain', domain: 'babar' }]);
+    expect(getters.pipeline(state, {}, {}, {})).toEqual([{ name: 'domain', domain: 'babar' }]);
     expect(state.currentDomain).toEqual('babar');
     mutations.setPipeline(state, { pipeline });
-    expect(getters.pipeline(state)).toEqual(pipeline);
+    expect(getters.pipeline(state, {}, {}, {})).toEqual(pipeline);
     expect(state.currentDomain).toEqual('foo');
   });
 
@@ -334,7 +334,7 @@ describe('mutation tests', () => {
       ...stateWithOnePipeline([{ name: 'rename', oldname: 'foo', newname: 'bar' }]),
     });
     mutations.setPipeline(state, { pipeline });
-    expect(getters.pipeline(state)).toEqual(pipeline);
+    expect(getters.pipeline(state, {}, {}, {})).toEqual(pipeline);
     expect(state.currentDomain).toEqual('foo');
   });
 
@@ -367,7 +367,7 @@ describe('mutation tests', () => {
   it('should create a step form', () => {
     const state = buildState({});
     mutations.createStepForm(state, { stepName: 'filter' });
-    expect(getters.isEditingStep(state)).toBeTruthy();
+    expect(getters.isEditingStep(state, {}, {}, {})).toBeTruthy();
     expect(state.currentStepFormName).toEqual('filter');
     expect(state.stepFormInitialValue).toBeUndefined();
   });
@@ -378,7 +378,7 @@ describe('mutation tests', () => {
       stepName: 'rename',
       initialValue: { oldname: 'oldcolumn', newname: 'newcolumn' },
     });
-    expect(getters.isEditingStep(state)).toBeTruthy();
+    expect(getters.isEditingStep(state, {}, {}, {})).toBeTruthy();
     expect(state.currentStepFormName).toEqual('rename');
     expect(state.stepFormInitialValue).toEqual({ oldname: 'oldcolumn', newname: 'newcolumn' });
   });
@@ -386,7 +386,7 @@ describe('mutation tests', () => {
   it('should close an opened form', () => {
     const state = buildState({ currentStepFormName: 'rename' });
     mutations.closeStepForm(state);
-    expect(getters.isEditingStep(state)).toBeFalsy();
+    expect(getters.isEditingStep(state, {}, {}, {})).toBeFalsy();
     expect(state.currentStepFormName).toBeUndefined();
   });
 

--- a/tests/unit/unpivot-step-form.spec.ts
+++ b/tests/unit/unpivot-step-form.spec.ts
@@ -44,12 +44,15 @@ describe('Unpivot Step Form', () => {
   );
 
   runner.testCancel({
-    pipeline: [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', oldname: 'foo', newname: 'bar' },
-      { name: 'rename', oldname: 'baz', newname: 'spam' },
-      { name: 'rename', oldname: 'tic', newname: 'tac' },
-    ],
+    currentPipelineName: 'default_pipeline',
+    pipelines: {
+      default_pipeline: [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', oldname: 'foo', newname: 'bar' },
+        { name: 'rename', oldname: 'baz', newname: 'spam' },
+        { name: 'rename', oldname: 'tic', newname: 'tac' },
+      ],
+    },
     selectedStepIndex: 2,
   });
 

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -200,7 +200,7 @@ export class BasicStepFormTestRunner {
 
   testCancel(initialState: Partial<VQBState> = {}) {
     const store = setupMockStore(initialState);
-    const initialPipeline = [...store.state.vqb.pipeline];
+    const initialPipeline = [...store.getters.vqb.pipeline];
     const initialStepIndex = store.state.vqb.selectedStepIndex;
 
     it('should emit "back" event when back button is clicked', () => {
@@ -208,7 +208,7 @@ export class BasicStepFormTestRunner {
       wrapper.find('.step-edit-form__back-button').trigger('click');
       expect(wrapper.emitted()).toEqual({ back: [[]] });
       expect(store.state.vqb.selectedStepIndex).toEqual(initialStepIndex);
-      expect(store.state.vqb.pipeline).toEqual(initialPipeline);
+      expect(store.getters.vqb.pipeline).toEqual(initialPipeline);
     });
 
     it('should overwrite cancelEdition function', () => {


### PR DESCRIPTION
The state had two separate properties: `pipelines` and `pipeline`. This can lead to a confusing situation where pipelines are not set but pipeline is, and therefore the dereferencing can't happen correctly.
Now, `pipeline` is a getter depending on `pipelines` and `currentPipelineName`.
The action `setPipeline` is still available, and updates `pipelines[currentPipelineName]`, so big API change.

I took the opportunity to try a few typings improvements along the way.