### PR TITLE
Pipeline selector and no pipeline state

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -166,24 +166,6 @@ class MongoService {
 
 const mongoservice = new MongoService();
 const mongoBackendPlugin = servicePluginFactory(mongoservice);
-const initialPipeline = [
-  {
-    name: 'domain',
-    domain: 'test-collection',
-  },
-  {
-    name: 'filter',
-    condition: {
-      and: [
-        {
-          column: 'Groups',
-          value: '<%= groupname %>',
-          operator: 'eq',
-        },
-      ],
-    },
-  },
-];
 
 async function setupInitialData(store, domain = null) {
   const collections = await mongoservice.listCollections();

--- a/playground/app.js
+++ b/playground/app.js
@@ -328,6 +328,9 @@ async function buildVueApp() {
     computed: {
       code: function() {
         let activePipeline = this.$store.getters[VQBnamespace('activePipeline')];
+        if (!activePipeline) {
+          return '';
+        }
         const pipelines = this.$store.getters[VQBnamespace('pipelines')];
         if (pipelines) {
           activePipeline = dereferencePipelines(activePipeline, pipelines);

--- a/src/components/DataTypesMenu.vue
+++ b/src/components/DataTypesMenu.vue
@@ -63,7 +63,7 @@ export default class DataTypesMenu extends Vue {
 
   @VQBModule.Getter computedActiveStepIndex!: number;
   @VQBModule.Getter isEditingStep!: boolean;
-  @VQBModule.Getter pipeline!: Pipeline;
+  @VQBModule.Getter pipeline?: Pipeline;
 
   @VQBModule.Mutation selectStep!: MutationCallbacks['selectStep'];
   @VQBModule.Mutation setPipeline!: MutationCallbacks['setPipeline'];

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="data-viewer">
+  <div class="data-viewer" v-if="pipeline">
     <ActionToolbar :buttons="buttons" @actionClicked="openStepForm" />
     <div v-if="isLoading" class="data-viewer-loader-spinner" />
     <div v-if="!isEmpty && !isLoading" class="data-viewer-container">
@@ -53,6 +53,7 @@
     </div>
     <div v-else-if="isEmpty">No data available</div>
   </div>
+  <div class="data-viewer data-viewer--no-pipeline" v-else />
 </template>
 <script lang="ts">
 import Vue from 'vue';
@@ -60,7 +61,7 @@ import { Component } from 'vue-property-decorator';
 
 import Pagination from '@/components/Pagination.vue';
 import { DataSet, DataSetColumn, DataSetColumnType } from '@/lib/dataset';
-import { PipelineStepName } from '@/lib/steps';
+import { Pipeline, PipelineStepName } from '@/lib/steps';
 import { getTranslator } from '@/lib/translators';
 import { VQBModule } from '@/store';
 
@@ -94,6 +95,7 @@ export default class DataViewer extends Vue {
   @VQBModule.Getter('isDatasetEmpty') isEmpty!: boolean;
   @VQBModule.Getter columnHeaders!: DataSetColumn[];
   @VQBModule.Getter translator!: string;
+  @VQBModule.Getter pipeline?: Pipeline;
 
   @VQBModule.Mutation createStepForm!: ({
     stepName,

--- a/src/components/PipelineSelector.vue
+++ b/src/components/PipelineSelector.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="pipeline-selector">
+    Pipelines:
+    <select :value="currentPipelineName" @input="selectPipelineByName($event.target.value)">
+      <option v-for="pipelineName in pipelinesNames" :key="pipelineName" :value="pipelineName">
+        {{ pipelineName }}
+      </option>
+    </select>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+
+import { VQBModule } from '@/store';
+import { MutationCallbacks } from '@/store/mutations';
+
+@Component({
+  name: 'PipelineSelector',
+})
+export default class Vqb extends Vue {
+  @VQBModule.State currentPipelineName?: string;
+  @VQBModule.Getter pipelinesNames!: string[];
+
+  @VQBModule.Mutation setCurrentPipelineName!: MutationCallbacks['setCurrentPipelineName'];
+
+  selectPipelineByName(pipelineName: string) {
+    this.setCurrentPipelineName({ name: pipelineName });
+  }
+}
+</script>

--- a/src/components/PipelineSelector.vue
+++ b/src/components/PipelineSelector.vue
@@ -14,7 +14,6 @@ import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 
 import { VQBModule } from '@/store';
-import { MutationCallbacks } from '@/store/mutations';
 
 @Component({
   name: 'PipelineSelector',
@@ -23,10 +22,10 @@ export default class Vqb extends Vue {
   @VQBModule.State currentPipelineName?: string;
   @VQBModule.Getter pipelinesNames!: string[];
 
-  @VQBModule.Mutation setCurrentPipelineName!: MutationCallbacks['setCurrentPipelineName'];
+  @VQBModule.Action selectPipeline!: (payload: { name: string }) => void;
 
   selectPipelineByName(pipelineName: string) {
-    this.setCurrentPipelineName({ name: pipelineName });
+    this.selectPipeline({ name: pipelineName });
   }
 }
 </script>

--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="query-builder">
+  <div class="query-builder" v-if="pipeline">
     <transition v-if="isEditingStep" name="slide-right" mode="out-in">
       <component
         key="stepForm"
@@ -26,6 +26,9 @@
         <Pipeline key="pipeline" @editStep="editStep" />
       </div>
     </transition>
+  </div>
+  <div class="query-builder query-builder--no-pipeline" v-else>
+    Select a pipeline...
   </div>
 </template>
 <script lang="ts">

--- a/src/components/Vqb.vue
+++ b/src/components/Vqb.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="weaverbird">
+    <PipelineSelector class="weaverbird__pipeline-selector" />
     <ResizablePanels>
       <QueryBuilder slot="left-panel" />
       <DataViewer slot="right-panel" />
@@ -12,6 +13,7 @@ import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 
 import DataViewer from '@/components/DataViewer.vue';
+import PipelineSelector from '@/components/PipelineSelector.vue';
 import QueryBuilder from '@/components/QueryBuilder.vue';
 import ResizablePanels from '@/components/ResizablePanels.vue';
 
@@ -19,16 +21,30 @@ import ResizablePanels from '@/components/ResizablePanels.vue';
   name: 'vqb',
   components: {
     DataViewer,
+    PipelineSelector,
     QueryBuilder,
     ResizablePanels,
   },
 })
 export default class Vqb extends Vue {}
 </script>
+
 <style lang="scss" scoped>
 .weaverbird {
   flex: 1;
   height: 100%;
   background-color: white;
+  position: relative;
+}
+
+.weaverbird__pipeline-selector {
+  position: absolute;
+  background-color: white;
+  border-top-left-radius: 0.5em;
+  border-top-right-radius: 0.5em;
+  transform: translateY(-100%);
+  padding: 5px 10px;
+  top: 0;
+  left: 20px;
 }
 </style>

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,0 +1,14 @@
+import { ActionTree } from 'vuex';
+
+import { VQBState } from './state';
+
+const actions: ActionTree<VQBState, any> = {
+  selectPipeline({ commit }, { name }: { name: string }) {
+    commit('setCurrentPipelineName', { name: name });
+
+    // Reset selected step to last one
+    commit('selectStep', { index: -1 });
+  },
+};
+
+export default actions;

--- a/src/store/backend-plugin.ts
+++ b/src/store/backend-plugin.ts
@@ -139,7 +139,10 @@ export function servicePluginFactory(service: BackendService) {
         mutation.type === VQBnamespace('deleteStep') ||
         mutation.type === VQBnamespace('setCurrentPage')
       ) {
-        _updateDataset(store, service, activePipeline(state[VQB_MODULE_NAME]));
+        const pipeline = activePipeline(state[VQB_MODULE_NAME]);
+        if (pipeline) {
+          _updateDataset(store, service, pipeline);
+        }
       }
     });
   };

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -32,13 +32,24 @@ const getters: GetterTree<VQBState, any> = {
   /**
    * a direct "usable" index (i.e. convert "-1" to a positive one) of last active step.
    */
-  computedActiveStepIndex: (state: VQBState) =>
-    state.selectedStepIndex === -1 ? currentPipeline(state).length - 1 : state.selectedStepIndex,
+  computedActiveStepIndex(state: VQBState) {
+    const pipeline = currentPipeline(state);
+    if (!pipeline) {
+      return;
+    }
+    return state.selectedStepIndex === -1 ? pipeline.length - 1 : state.selectedStepIndex;
+  },
   /**
    * the first step of the pipeline. Since it's handled differently in the UI,
    * it's useful to be able to access it directly.
    */
-  domainStep: (state: VQBState) => currentPipeline(state)[0],
+  domainStep(state: VQBState) {
+    const pipeline = currentPipeline(state);
+    if (!pipeline) {
+      return;
+    }
+    return pipeline?.[0];
+  },
   /**
    * the part of the pipeline that is currently disabled.
    */
@@ -54,7 +65,13 @@ const getters: GetterTree<VQBState, any> = {
   /**
    * helper that is True if pipeline is empty or only contain a domain step.
    */
-  isPipelineEmpty: (state: VQBState) => currentPipeline(state).length <= 1,
+  isPipelineEmpty(state: VQBState) {
+    const pipeline = currentPipeline(state);
+    if (!pipeline) {
+      return;
+    }
+    return pipeline.length <= 1;
+  },
   /**
    * helper that is True if this step is after the last currently active step.
    */
@@ -84,7 +101,10 @@ const getters: GetterTree<VQBState, any> = {
   /**
    * Get the step config of the pipeline based on its index
    */
-  stepConfig: (state: VQBState) => (index: number) => currentPipeline(state)[index],
+  stepConfig: (state: VQBState) => (index: number) => {
+    const pipeline = currentPipeline(state);
+    return pipeline?.[index];
+  },
   /**
    * Return the app translator name
    */

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -91,6 +91,10 @@ const getters: GetterTree<VQBState, any> = {
    */
   pipelines: (state: VQBState) => state.pipelines,
   /**
+   * Return the array of pipeline names
+   */
+  pipelinesNames: (state: VQBState) => Object.keys(state.pipelines),
+  /**
    * Return true if an error occured in the backend
    */
   thereIsABackendError: (state: VQBState) => state.backendErrors.length > 0,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -20,6 +20,7 @@ import Vue from 'vue';
 import Vuex, { Store, StoreOptions } from 'vuex';
 import { namespace } from 'vuex-class';
 
+import actions from './actions';
 import getters from './getters';
 import mutations from './mutations';
 import { emptyState, VQBState } from './state';
@@ -45,6 +46,7 @@ export function buildStoreModule(initialState: Partial<VQBState> = {}) {
     state: { ...emptyState(), ...initialState },
     getters,
     mutations,
+    actions,
   };
   return store;
 }
@@ -81,6 +83,7 @@ export function setupStore(
     Vue.use(Vuex);
   }
   const store: StoreOptions<VQBState> = {
+    actions,
     state: { ...emptyState(), ...initialState },
     getters,
     mutations,

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -175,7 +175,7 @@ export default {
     }
   },
   /**
-   * update currentPipelineName.
+   * update currentPipelineName
    */
   setCurrentPipelineName(state: VQBState, { name }: { name: string }) {
     state.currentPipelineName = name;

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -2,6 +2,8 @@
  * exports the list of store mutations.
  */
 
+import Vue from 'vue';
+
 import { BackendError } from '@/lib/backend-response';
 import { DomainStep, Pipeline, PipelineStepName } from '@/lib/steps';
 
@@ -202,7 +204,7 @@ export default {
     if (state.currentPipelineName === undefined) {
       return;
     }
-    state.pipelines[state.currentPipelineName] = pipeline;
+    Vue.set(state.pipelines, state.currentPipelineName, pipeline);
     if (pipeline.length) {
       const firstStep = pipeline[0];
       if (firstStep.name === 'domain') {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -23,7 +23,7 @@ export interface VQBState {
   /**
    * the current pipeline (being edited) name
    */
-  currentPipelineName: string;
+  currentPipelineName?: string;
   /**
    * the current step form displayed
    */
@@ -108,10 +108,8 @@ export function emptyState(): VQBState {
     stepFormInitialValue: undefined,
     stepFormDefaults: undefined,
     selectedStepIndex: -1,
-    currentPipelineName: 'default_pipeline',
-    pipelines: {
-      default_pipeline: [],
-    },
+    currentPipelineName: undefined,
+    pipelines: {},
     selectedColumns: [],
     pagesize: 50,
     backendErrors: [],
@@ -127,18 +125,21 @@ export function emptyState(): VQBState {
  * @return the pipeline currently edited
  */
 export function currentPipeline(state: VQBState) {
+  if (!state.currentPipelineName) {
+    return;
+  }
   return state.pipelines[state.currentPipelineName];
 }
 
 /**
- * @param state current application state
+ * @param pipeline the current pipeline
+ * @param selectedStepIndex
  * @return the index of the first inactive step. Return first out of bound index
  * if all steps are active.
  */
-function firstNonSelectedIndex(state: VQBState) {
-  const { selectedStepIndex } = state;
+function firstNonSelectedIndex(pipeline: Pipeline, selectedStepIndex: number) {
   if (selectedStepIndex < 0) {
-    return currentPipeline(state).length;
+    return pipeline.length;
   }
   return selectedStepIndex + 1;
 }
@@ -148,7 +149,8 @@ function firstNonSelectedIndex(state: VQBState) {
  * @return the subpart of the pipeline that is currently active.
  */
 export function activePipeline(state: VQBState) {
-  return currentPipeline(state).slice(0, firstNonSelectedIndex(state));
+  const pipeline = currentPipeline(state);
+  return pipeline?.slice(0, firstNonSelectedIndex(pipeline, state.selectedStepIndex));
 }
 
 /**
@@ -156,5 +158,6 @@ export function activePipeline(state: VQBState) {
  * @return the subpart of the pipeline that is currently inactive.
  */
 export function inactivePipeline(state: VQBState) {
-  return currentPipeline(state).slice(firstNonSelectedIndex(state));
+  const pipeline = currentPipeline(state);
+  return pipeline?.slice(firstNonSelectedIndex(pipeline, state.selectedStepIndex));
 }

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -4,7 +4,7 @@ import Vuex from 'vuex';
 import ActionMenu from '@/components/ActionMenu.vue';
 import { VQBnamespace } from '@/store';
 
-import { setupMockStore } from './utils';
+import { buildStateWithOnePipeline, setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -112,7 +112,9 @@ describe('Action Menu', () => {
     });
 
     it('should close any open step form to show the addition of the delete step in the pipeline', () => {
-      const store = setupMockStore({ currentStepFormName: 'fillna' });
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], { currentStepFormName: 'fillna' }),
+      );
       const wrapper = shallowMount(ActionMenu, { store, localVue });
       const actionsWrapper = wrapper.findAll('.action-menu__option');
       actionsWrapper.at(2).trigger('click');

--- a/tests/unit/action-toolbar-button.spec.ts
+++ b/tests/unit/action-toolbar-button.spec.ts
@@ -85,7 +85,7 @@ describe('ActionToolbarButton', () => {
   it('should instantiate a Text button with the right list of actions', () => {
     // instantiate a store with at least one column selected so that steps
     // such as 'lowercase' can be triggered without creating a form.
-    const store = setupMockStore({ selectedColumns: ['foo'] });
+    const store = setupMockStore(buildStateWithOnePipeline([], { selectedColumns: ['foo'] }));
     const wrapper = mount(ActionToolbarButton, {
       propsData: { category: 'text' },
       localVue,

--- a/tests/unit/data-viewer.spec.ts
+++ b/tests/unit/data-viewer.spec.ts
@@ -3,7 +3,7 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 
 import DataViewer from '../../src/components/DataViewer.vue';
-import { setupMockStore } from './utils';
+import { buildStateWithOnePipeline, setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -15,6 +15,12 @@ describe('Data Viewer', () => {
     expect(wrapper.exists()).toBeTruthy();
   });
 
+  it('should display an empty state is no pipeline is selected', () => {
+    const wrapper = shallowMount(DataViewer, { store: setupMockStore({}), localVue });
+    expect(wrapper.find('.data-viewer--no-pipeline').exists()).toBeTruthy();
+    expect(wrapper.find('ActionToolbar-stub').exists()).toBeFalsy();
+  });
+
   it('should display a message when no data', () => {
     const wrapper = shallowMount(DataViewer, { store: setupMockStore(), localVue });
 
@@ -23,9 +29,11 @@ describe('Data Viewer', () => {
 
   it('should display a loader spinner when data is loading and hide data viewer container', () => {
     const wrapper = shallowMount(DataViewer, {
-      store: setupMockStore({
-        isLoading: true,
-      }),
+      store: setupMockStore(
+        buildStateWithOnePipeline([], {
+          isLoading: true,
+        }),
+      ),
       localVue,
     });
     const wrapperLoaderSpinner = wrapper.find('.data-viewer-loader-spinner');
@@ -36,21 +44,25 @@ describe('Data Viewer', () => {
 
   describe('header', () => {
     it('should have one row', () => {
-      const store = setupMockStore({
-        dataset: {
-          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-          data: [
-            ['value1', 'value2', 'value3'],
-            ['value4', 'value5', 'value6'],
-            ['value7', 'value8', 'value9'],
-            ['value10', 'value11', 'value12'],
-            ['value13', 'value14', 'value15'],
-          ],
-          paginationContext: {
-            totalCount: 5,
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          dataset: {
+            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+            data: [
+              ['value1', 'value2', 'value3'],
+              ['value4', 'value5', 'value6'],
+              ['value7', 'value8', 'value9'],
+              ['value10', 'value11', 'value12'],
+              ['value13', 'value14', 'value15'],
+            ],
+            paginationContext: {
+              totalCount: 5,
+              pagesize: 10,
+              pageno: 1,
+            },
           },
-        },
-      });
+        }),
+      );
       const wrapper = shallowMount(DataViewer, { store, localVue });
 
       const headerWrapper = wrapper.find('.data-viewer__header');
@@ -58,21 +70,25 @@ describe('Data Viewer', () => {
     });
 
     it('should have three cells', () => {
-      const store = setupMockStore({
-        dataset: {
-          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-          data: [
-            ['value1', 'value2', 'value3'],
-            ['value4', 'value5', 'value6'],
-            ['value7', 'value8', 'value9'],
-            ['value10', 'value11', 'value12'],
-            ['value13', 'value14', 'value15'],
-          ],
-          paginationContext: {
-            totalCount: 5,
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          dataset: {
+            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+            data: [
+              ['value1', 'value2', 'value3'],
+              ['value4', 'value5', 'value6'],
+              ['value7', 'value8', 'value9'],
+              ['value10', 'value11', 'value12'],
+              ['value13', 'value14', 'value15'],
+            ],
+            paginationContext: {
+              totalCount: 5,
+              pagesize: 10,
+              pageno: 1,
+            },
           },
-        },
-      });
+        }),
+      );
       const wrapper = shallowMount(DataViewer, { store, localVue });
 
       const headerCellsWrapper = wrapper.findAll('.data-viewer__header-cell');
@@ -80,21 +96,25 @@ describe('Data Viewer', () => {
     });
 
     it("should contains column's names", () => {
-      const store = setupMockStore({
-        dataset: {
-          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-          data: [
-            ['value1', 'value2', 'value3'],
-            ['value4', 'value5', 'value6'],
-            ['value7', 'value8', 'value9'],
-            ['value10', 'value11', 'value12'],
-            ['value13', 'value14', 'value15'],
-          ],
-          paginationContext: {
-            totalCount: 5,
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          dataset: {
+            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+            data: [
+              ['value1', 'value2', 'value3'],
+              ['value4', 'value5', 'value6'],
+              ['value7', 'value8', 'value9'],
+              ['value10', 'value11', 'value12'],
+              ['value13', 'value14', 'value15'],
+            ],
+            paginationContext: {
+              totalCount: 5,
+              pagesize: 10,
+              pageno: 1,
+            },
           },
-        },
-      });
+        }),
+      );
       const wrapper = shallowMount(DataViewer, { store, localVue });
 
       const headerCellsWrapper = wrapper.findAll('.data-viewer__header-cell');
@@ -104,26 +124,30 @@ describe('Data Viewer', () => {
     });
 
     it("should contains column's names even if not on every rows", () => {
-      const store = setupMockStore({
-        dataset: {
-          headers: [
-            { name: 'columnA' },
-            { name: 'columnB' },
-            { name: 'columnC' },
-            { name: 'columnD' },
-          ],
-          data: [
-            ['value1', 'value2', 'value3'],
-            ['value4', 'value5', 'value6'],
-            ['value7', 'value8', 'value9'],
-            ['value10', 'value11', 'value12'],
-            ['value13', 'value14', 'value15', 'value16'],
-          ],
-          paginationContext: {
-            totalCount: 5,
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          dataset: {
+            headers: [
+              { name: 'columnA' },
+              { name: 'columnB' },
+              { name: 'columnC' },
+              { name: 'columnD' },
+            ],
+            data: [
+              ['value1', 'value2', 'value3'],
+              ['value4', 'value5', 'value6'],
+              ['value7', 'value8', 'value9'],
+              ['value10', 'value11', 'value12'],
+              ['value13', 'value14', 'value15', 'value16'],
+            ],
+            paginationContext: {
+              totalCount: 5,
+              pagesize: 10,
+              pageno: 1,
+            },
           },
-        },
-      });
+        }),
+      );
       const wrapper = shallowMount(DataViewer, { store, localVue });
 
       const headerCellsWrapper = wrapper.findAll('.data-viewer__header-cell');
@@ -135,23 +159,27 @@ describe('Data Viewer', () => {
 
     it('should display the right icon for each types', () => {
       const date = new Date();
-      const store = setupMockStore({
-        dataset: {
-          headers: [
-            { name: 'columnA', type: 'string' },
-            { name: 'columnB', type: 'integer' },
-            { name: 'columnC', type: 'float' },
-            { name: 'columnD', type: 'date' },
-            { name: 'columnE', type: 'object' },
-            { name: 'columnF', type: 'boolean' },
-            { name: 'columnG', type: 'undefined' },
-          ],
-          data: [['value1', 42, 3.14, date, { obj: 'value' }, true]],
-          paginationContext: {
-            totalCount: 1,
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          dataset: {
+            headers: [
+              { name: 'columnA', type: 'string' },
+              { name: 'columnB', type: 'integer' },
+              { name: 'columnC', type: 'float' },
+              { name: 'columnD', type: 'date' },
+              { name: 'columnE', type: 'object' },
+              { name: 'columnF', type: 'boolean' },
+              { name: 'columnG', type: undefined },
+            ],
+            data: [['value1', 42, 3.14, date, { obj: 'value' }, true]],
+            paginationContext: {
+              totalCount: 1,
+              pagesize: 10,
+              pageno: 1,
+            },
           },
-        },
-      });
+        }),
+      );
       const wrapper = shallowMount(DataViewer, { store, localVue });
 
       const headerIconsWrapper = wrapper.findAll('.data-viewer__header-icon');
@@ -175,16 +203,20 @@ describe('Data Viewer', () => {
     });
 
     it('should have a data type menu for supported backends', async () => {
-      const store = setupMockStore({
-        translator: 'mongo40',
-        dataset: {
-          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-          data: [['value1', 'value2', 'value3']],
-          paginationContext: {
-            totalCount: 1,
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          translator: 'mongo40',
+          dataset: {
+            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+            data: [['value1', 'value2', 'value3']],
+            paginationContext: {
+              totalCount: 1,
+              pagesize: 10,
+              pageno: 1,
+            },
           },
-        },
-      });
+        }),
+      );
       const wrapper = shallowMount(DataViewer, { store, localVue });
       expect(wrapper.find('datatypesmenu-stub').exists()).toBeTruthy();
       expect(wrapper.find('.data-viewer__header-icon--active').exists()).toBeTruthy();
@@ -196,16 +228,20 @@ describe('Data Viewer', () => {
     });
 
     it('should have a data type menu for not supported backends', () => {
-      const store = setupMockStore({
-        translator: 'mongo36',
-        dataset: {
-          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-          data: [['value1', 'value2', 'value3']],
-          paginationContext: {
-            totalCount: 1,
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          translator: 'mongo36',
+          dataset: {
+            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+            data: [['value1', 'value2', 'value3']],
+            paginationContext: {
+              totalCount: 1,
+              pagesize: 10,
+              pageno: 1,
+            },
           },
-        },
-      });
+        }),
+      );
       const wrapper = shallowMount(DataViewer, { store, localVue });
       expect(wrapper.find('datatypesmenu-stub').exists()).toBeFalsy();
       expect(wrapper.find('.data-viewer__header-icon--active').exists()).toBeFalsy();
@@ -213,21 +249,25 @@ describe('Data Viewer', () => {
 
     describe('selection', () => {
       it('should add an active class on the cell', async () => {
-        const store = setupMockStore({
-          dataset: {
-            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-            data: [
-              ['value1', 'value2', 'value3'],
-              ['value4', 'value5', 'value6'],
-              ['value7', 'value8', 'value9'],
-              ['value10', 'value11', 'value12'],
-              ['value13', 'value14', 'value15'],
-            ],
-            paginationContext: {
-              totalCount: 5,
+        const store = setupMockStore(
+          buildStateWithOnePipeline([], {
+            dataset: {
+              headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+              data: [
+                ['value1', 'value2', 'value3'],
+                ['value4', 'value5', 'value6'],
+                ['value7', 'value8', 'value9'],
+                ['value10', 'value11', 'value12'],
+                ['value13', 'value14', 'value15'],
+              ],
+              paginationContext: {
+                totalCount: 5,
+                pagesize: 10,
+                pageno: 1,
+              },
             },
-          },
-        });
+          }),
+        );
         const wrapper = shallowMount(DataViewer, { store, localVue });
 
         const firstHeaderCellWrapper = wrapper.find('.data-viewer__header-cell');
@@ -240,21 +280,25 @@ describe('Data Viewer', () => {
 
   describe('body', () => {
     it('should have 5 rows', () => {
-      const store = setupMockStore({
-        dataset: {
-          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-          data: [
-            ['value1', 'value2', 'value3'],
-            ['value4', 'value5', 'value6'],
-            ['value7', 'value8', 'value9'],
-            ['value10', 'value11', 'value12'],
-            ['value13', 'value14', 'value15'],
-          ],
-          paginationContext: {
-            totalCount: 5,
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          dataset: {
+            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+            data: [
+              ['value1', 'value2', 'value3'],
+              ['value4', 'value5', 'value6'],
+              ['value7', 'value8', 'value9'],
+              ['value10', 'value11', 'value12'],
+              ['value13', 'value14', 'value15'],
+            ],
+            paginationContext: {
+              totalCount: 5,
+              pagesize: 10,
+              pageno: 1,
+            },
           },
-        },
-      });
+        }),
+      );
       const wrapper = shallowMount(DataViewer, { store, localVue });
 
       const rowsWrapper = wrapper.findAll('.data-viewer__row');
@@ -262,21 +306,25 @@ describe('Data Viewer', () => {
     });
 
     it('should pass down the right value to DataViewerCell', () => {
-      const store = setupMockStore({
-        dataset: {
-          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-          data: [
-            ['value1', 'value2', 'value3'],
-            ['value4', 'value5', 'value6'],
-            ['value7', 'value8', 'value9'],
-            ['value10', 'value11', 'value12'],
-            ['value13', 'value14', 'value15'],
-          ],
-          paginationContext: {
-            totalCount: 5,
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          dataset: {
+            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+            data: [
+              ['value1', 'value2', 'value3'],
+              ['value4', 'value5', 'value6'],
+              ['value7', 'value8', 'value9'],
+              ['value10', 'value11', 'value12'],
+              ['value13', 'value14', 'value15'],
+            ],
+            paginationContext: {
+              totalCount: 5,
+              pagesize: 10,
+              pageno: 1,
+            },
           },
-        },
-      });
+        }),
+      );
       const wrapper = shallowMount(DataViewer, { store, localVue });
 
       const firstRowWrapper = wrapper.find('.data-viewer__row');
@@ -298,9 +346,11 @@ describe('Data Viewer', () => {
         ],
         paginationContext: {
           totalCount: 5,
+          pagesize: 10,
+          pageno: 1,
         },
       };
-      const store = setupMockStore({ dataset });
+      const store = setupMockStore(buildStateWithOnePipeline([], { dataset }));
       const wrapper = shallowMount(DataViewer, { store, localVue });
       const firstHeadCellWrapper = wrapper.find('.data-viewer__header-cell');
       firstHeadCellWrapper.trigger('click');
@@ -322,21 +372,25 @@ describe('Data Viewer', () => {
     const openStepFormStub = jest.fn();
 
     beforeEach(() => {
-      const store = setupMockStore({
-        dataset: {
-          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-          data: [
-            ['value1', 'value2', 'value3'],
-            ['value4', 'value5', 'value6'],
-            ['value7', 'value8', 'value9'],
-            ['value10', 'value11', 'value12'],
-            ['value13', 'value14', 'value15'],
-          ],
-          paginationContext: {
-            totalCount: 5,
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          dataset: {
+            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+            data: [
+              ['value1', 'value2', 'value3'],
+              ['value4', 'value5', 'value6'],
+              ['value7', 'value8', 'value9'],
+              ['value10', 'value11', 'value12'],
+              ['value13', 'value14', 'value15'],
+            ],
+            paginationContext: {
+              totalCount: 5,
+              pagesize: 10,
+              pageno: 1,
+            },
           },
-        },
-      });
+        }),
+      );
       wrapper = shallowMount(DataViewer, { store, localVue });
       wrapper.setMethods({ openStepForm: openStepFormStub });
     });

--- a/tests/unit/pipeline-selector.spec.ts
+++ b/tests/unit/pipeline-selector.spec.ts
@@ -1,0 +1,76 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import Vuex from 'vuex';
+
+import PipelineSelector from '@/components/PipelineSelector.vue';
+
+import { setupMockStore } from './utils';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('PipelineSelector', () => {
+  it('should instantiate', () => {
+    const wrapper = shallowMount(PipelineSelector, { store: setupMockStore(), localVue });
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('should display all pipeline names in a select', () => {
+    const store = setupMockStore({
+      pipelines: {
+        pipeline1: [],
+        pipeline2: [],
+        pipeline3: [],
+      },
+    });
+    const wrapper = shallowMount(PipelineSelector, {
+      store,
+      localVue,
+    });
+    const select = wrapper.find('select');
+    expect(select.exists()).toBeTruthy();
+    const options = select.findAll('option');
+    expect(options).toHaveLength(3);
+    const optionsValues = options.wrappers.map(o => o.text());
+    expect(optionsValues).toEqual(['pipeline1', 'pipeline2', 'pipeline3']);
+  });
+
+  it('should display the selected pipeline if any', () => {
+    const store = setupMockStore({
+      currentPipelineName: 'pipeline2',
+      pipelines: {
+        pipeline1: [],
+        pipeline2: [],
+        pipeline3: [],
+      },
+    });
+    const wrapper = shallowMount(PipelineSelector, {
+      store,
+      localVue,
+    });
+    const select = wrapper.find('select');
+    expect((select.findAll('option').at(1).element as HTMLOptionElement).selected).toBeTruthy();
+  });
+
+  it('should update the currentPipelineName when a pipeline is selected', () => {
+    const store = setupMockStore({
+      currentPipelineName: 'pipeline2',
+      pipelines: {
+        pipeline1: [],
+        pipeline2: [],
+        pipeline3: [],
+      },
+    });
+    const wrapper = shallowMount(PipelineSelector, {
+      store,
+      localVue,
+    });
+    const select = wrapper.find('select');
+    select
+      .findAll('option')
+      .at(2)
+      .setSelected();
+    select.trigger('input');
+    expect(store.state.vqb.currentPipelineName).toEqual('pipeline3');
+    expect((select.findAll('option').at(2).element as HTMLOptionElement).selected).toBeTruthy();
+  });
+});

--- a/tests/unit/plugins.spec.ts
+++ b/tests/unit/plugins.spec.ts
@@ -90,7 +90,9 @@ describe('backend service plugin tests', () => {
   });
 
   it('should call execute pipeline when a setCurrentDomain mutation is committed', async () => {
-    const store = setupMockStore({}, [servicePluginFactory(new DummyService())]);
+    const store = setupMockStore(buildStateWithOnePipeline([]), [
+      servicePluginFactory(new DummyService()),
+    ]);
     store.commit(VQBnamespace('setCurrentDomain'), { currentDomain: 'GoT' });
     await flushPromises();
     expect(store.state.vqb.dataset).toEqual({
@@ -123,7 +125,9 @@ describe('backend service plugin tests', () => {
   });
 
   it('should call execute pipeline with correct pagesize', async () => {
-    const store = setupMockStore({ pagesize: 1 }, [servicePluginFactory(new DummyService())]);
+    const store = setupMockStore(buildStateWithOnePipeline([], { pagesize: 1 }), [
+      servicePluginFactory(new DummyService()),
+    ]);
     store.commit(VQBnamespace('setCurrentDomain'), { currentDomain: 'GoT' });
     await flushPromises();
     expect(store.state.vqb.dataset).toEqual({

--- a/tests/unit/query-builder.spec.ts
+++ b/tests/unit/query-builder.spec.ts
@@ -17,8 +17,16 @@ describe('Query Builder', () => {
     expect(wrapper.vm.$store.state.isEditingStep).toBeFalsy();
   });
 
+  it('should display an empty state is no pipeline is selected', () => {
+    const wrapper = shallowMount(QueryBuilder, { store: setupMockStore({}), localVue });
+    expect(wrapper.find('.query-builder--no-pipeline').exists()).toBeTruthy();
+    expect(wrapper.find('Pipeline-stub').exists()).toBeFalsy();
+  });
+
   it('should instantiate a AggregateStepForm component', () => {
-    const store = setupMockStore({ currentStepFormName: 'aggregate' });
+    const store = setupMockStore(
+      buildStateWithOnePipeline([], { currentStepFormName: 'aggregate' }),
+    );
     const wrapper = shallowMount(QueryBuilder, {
       store,
       localVue,
@@ -28,7 +36,7 @@ describe('Query Builder', () => {
   });
 
   it('should instantiate a FormRenameStep component', () => {
-    const store = setupMockStore({ currentStepFormName: 'rename' });
+    const store = setupMockStore(buildStateWithOnePipeline([], { currentStepFormName: 'rename' }));
     const wrapper = shallowMount(QueryBuilder, {
       store,
       localVue,
@@ -38,7 +46,7 @@ describe('Query Builder', () => {
   });
 
   it('should instantiate a DeleteColumnStep component', () => {
-    const store = setupMockStore({ currentStepFormName: 'delete' });
+    const store = setupMockStore(buildStateWithOnePipeline([], { currentStepFormName: 'delete' }));
     const wrapper = shallowMount(QueryBuilder, {
       store,
       localVue,
@@ -48,7 +56,7 @@ describe('Query Builder', () => {
   });
 
   it('should instantiate a FillnaStep component', () => {
-    const store = setupMockStore({ currentStepFormName: 'fillna' });
+    const store = setupMockStore(buildStateWithOnePipeline([], { currentStepFormName: 'fillna' }));
     const wrapper = shallowMount(QueryBuilder, {
       store,
       localVue,
@@ -58,7 +66,7 @@ describe('Query Builder', () => {
   });
 
   it('should instantiate a DomainStep component', () => {
-    const store = setupMockStore({ currentStepFormName: 'domain' });
+    const store = setupMockStore(buildStateWithOnePipeline([], { currentStepFormName: 'domain' }));
     const wrapper = shallowMount(QueryBuilder, {
       store,
       localVue,

--- a/tests/unit/query-builder.spec.ts
+++ b/tests/unit/query-builder.spec.ts
@@ -73,10 +73,11 @@ describe('Query Builder', () => {
 
     describe('when editing domain step', () => {
       beforeEach(async () => {
-        store = setupMockStore({
-          pipeline: [{ name: 'domain', domain: 'foo' }],
-          currentStepFormName: 'domain',
-        });
+        store = setupMockStore(
+          buildStateWithOnePipeline([{ name: 'domain', domain: 'foo' }], {
+            currentStepFormName: 'domain',
+          }),
+        );
         wrapper = shallowMount(QueryBuilder, {
           store,
           localVue,

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -228,7 +228,7 @@ describe('mutation tests', () => {
   });
 
   it('sets current domain on empty pipeline', () => {
-    const state = buildState({ currentDomain: 'foo' });
+    const state = buildState(buildStateWithOnePipeline([], { currentDomain: 'foo' }));
     expect(state.currentDomain).toEqual('foo');
     mutations.setCurrentDomain(state, { currentDomain: 'bar' });
     expect(state.currentDomain).toEqual('bar');
@@ -288,7 +288,7 @@ describe('mutation tests', () => {
       { name: 'rename', oldname: 'foo', newname: 'bar' },
       { name: 'rename', oldname: 'baz', newname: 'spam' },
     ];
-    const state = buildState({});
+    const state = buildStateWithOnePipeline([]);
     expect(getters.pipeline(state, {}, {}, {})).toEqual([]);
     mutations.setPipeline(state, { pipeline });
     expect(getters.pipeline(state, {}, {}, {})).toEqual(pipeline);

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -19,7 +19,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState(buildStateWithOnePipeline(pipeline));
+      const state = buildStateWithOnePipeline(pipeline);
       expect(getters.activePipeline(state, {}, {}, {})).toEqual(pipeline);
     });
 
@@ -29,7 +29,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState(buildStateWithOnePipeline(pipeline, { selectedStepIndex: 1 }));
+      const state = buildStateWithOnePipeline(pipeline, { selectedStepIndex: 1 });
       expect(getters.activePipeline(state, {}, {}, {})).toEqual(pipeline.slice(0, 2));
     });
 
@@ -39,7 +39,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState(buildStateWithOnePipeline(pipeline));
+      const state = buildStateWithOnePipeline(pipeline);
       expect(getters.inactivePipeline(state, {}, {}, {})).toEqual([]);
     });
 
@@ -49,7 +49,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState(buildStateWithOnePipeline(pipeline, { selectedStepIndex: 1 }));
+      const state = buildStateWithOnePipeline(pipeline, { selectedStepIndex: 1 });
       expect(getters.inactivePipeline(state, {}, {}, {})).toEqual(pipeline.slice(2));
     });
   });
@@ -66,7 +66,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState(buildStateWithOnePipeline(pipeline));
+      const state = buildStateWithOnePipeline(pipeline);
       expect(getters.computedActiveStepIndex(state, {}, {}, {})).toEqual(2);
     });
 
@@ -76,7 +76,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState(buildStateWithOnePipeline(pipeline, { selectedStepIndex: 1 }));
+      const state = buildStateWithOnePipeline(pipeline, { selectedStepIndex: 1 });
       expect(getters.computedActiveStepIndex(state, {}, {}, {})).toEqual(1);
     });
   });
@@ -136,7 +136,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState(buildStateWithOnePipeline(pipeline));
+      const state = buildStateWithOnePipeline(pipeline);
       expect(getters.domainStep(state, {}, {}, {})).toEqual(pipeline[0]);
     });
   });
@@ -171,7 +171,7 @@ describe('getter tests', () => {
 
     it('should return true if pipeline is empty', () => {
       const pipeline: Pipeline = [];
-      const state = buildState(buildStateWithOnePipeline(pipeline));
+      const state = buildStateWithOnePipeline(pipeline);
       expect(getters.isPipelineEmpty(state, {}, {}, {})).toBeTruthy();
     });
 
@@ -181,7 +181,7 @@ describe('getter tests', () => {
         { name: 'rename', oldname: 'foo', newname: 'bar' },
         { name: 'rename', oldname: 'baz', newname: 'spam' },
       ];
-      const state = buildState(buildStateWithOnePipeline(pipeline));
+      const state = buildStateWithOnePipeline(pipeline);
       expect(getters.isPipelineEmpty(state, {}, {}, {})).toBeFalsy();
     });
   });
@@ -253,7 +253,7 @@ describe('mutation tests', () => {
       { name: 'rename', oldname: 'foo', newname: 'bar' },
       { name: 'rename', oldname: 'baz', newname: 'spam' },
     ];
-    const state = buildState(buildStateWithOnePipeline(pipeline));
+    const state = buildStateWithOnePipeline(pipeline);
     expect(state.selectedStepIndex).toEqual(-1);
     mutations.selectStep(state, { index: 2 });
     expect(state.selectedStepIndex).toEqual(2);
@@ -266,7 +266,7 @@ describe('mutation tests', () => {
   });
 
   it('sets current domain on empty pipeline', () => {
-    const state = buildState(buildStateWithOnePipeline([], { currentDomain: 'foo' }));
+    const state = buildStateWithOnePipeline([], { currentDomain: 'foo' });
     expect(state.currentDomain).toEqual('foo');
     mutations.setCurrentDomain(state, { currentDomain: 'bar' });
     expect(state.currentDomain).toEqual('bar');

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -7,6 +7,12 @@ import { buildState, buildStateWithOnePipeline } from './utils';
 
 describe('getter tests', () => {
   describe('(in)active pipeline steps', () => {
+    it('should not return anything without any selected pipeline', () => {
+      const state = buildState({});
+      expect(getters.activePipeline(state, {}, {}, {})).toBeUndefined();
+      expect(getters.inactivePipeline(state, {}, {}, {})).toBeUndefined();
+    });
+
     it('should return the whole pipeline if selectedIndex is -1', () => {
       const pipeline: Pipeline = [
         { name: 'domain', domain: 'foo' },
@@ -49,6 +55,11 @@ describe('getter tests', () => {
   });
 
   describe('active step index tests', () => {
+    it('should not return anything if no pipeline is selected', () => {
+      const state = buildState({});
+      expect(getters.computedActiveStepIndex(state, {}, {}, {})).toBeUndefined();
+    });
+
     it('should compute active step index if selectedIndex is -1', () => {
       const pipeline: Pipeline = [
         { name: 'domain', domain: 'foo' },
@@ -114,6 +125,11 @@ describe('getter tests', () => {
   });
 
   describe('domain extraction tests', () => {
+    it('should not return anything if no pipeline is selected', function() {
+      const state = buildState({});
+      expect(getters.domainStep(state, {}, {}, {})).toBeUndefined;
+    });
+
     it('should return the domain step', () => {
       const pipeline: Pipeline = [
         { name: 'domain', domain: 'foo' },
@@ -148,6 +164,11 @@ describe('getter tests', () => {
   });
 
   describe('pipeline empty tests', () => {
+    it('should not return anything if no pipeline is selected', function() {
+      const state = buildState({});
+      expect(getters.isPipelineEmpty(state, {}, {}, {})).toBeUndefined;
+    });
+
     it('should return true if pipeline is empty', () => {
       const pipeline: Pipeline = [];
       const state = buildState(buildStateWithOnePipeline(pipeline));
@@ -185,6 +206,23 @@ describe('getter tests', () => {
       const state = buildState({ selectedStepIndex: 1 });
       expect(getters.isStepDisabled(state, {}, {}, {})(2)).toBeTruthy();
       expect(getters.isStepDisabled(state, {}, {}, {})(3)).toBeTruthy();
+    });
+  });
+
+  describe('step configuration', () => {
+    it('should retrieve the configuration of a step using its index', function() {
+      const pipeline: Pipeline = [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', oldname: 'foo', newname: 'bar' },
+        { name: 'rename', oldname: 'baz', newname: 'spam' },
+      ];
+      const state = buildStateWithOnePipeline(pipeline);
+      expect(getters.stepConfig(state, {}, {}, {})(1)).toEqual(pipeline[1]);
+    });
+
+    it('should not return anything if there is no selected pipeline', function() {
+      const state = buildState({});
+      expect(getters.stepConfig(state, {}, {}, {})(0)).toBeUndefined();
     });
   });
 
@@ -252,6 +290,12 @@ describe('mutation tests', () => {
     ]);
   });
 
+  it('do nothing without any current pipeline', () => {
+    const state = buildState({});
+    mutations.setCurrentDomain(state, { currentDomain: 'bar' });
+    expect(state.currentDomain).toBeUndefined();
+  });
+
   it('sets domain list', () => {
     const state = buildState({});
     expect(state.domains).toEqual([]);
@@ -283,13 +327,16 @@ describe('mutation tests', () => {
   });
 
   it('sets pipeline', () => {
+    expect(getters.pipeline(buildState({}), {}, {}, {})).toBeUndefined();
+
+    const state = buildStateWithOnePipeline([]);
+    expect(getters.pipeline(state, {}, {}, {})).toEqual([]);
+
     const pipeline: Pipeline = [
       { name: 'domain', domain: 'foo' },
       { name: 'rename', oldname: 'foo', newname: 'bar' },
       { name: 'rename', oldname: 'baz', newname: 'spam' },
     ];
-    const state = buildStateWithOnePipeline([]);
-    expect(getters.pipeline(state, {}, {}, {})).toEqual([]);
     mutations.setPipeline(state, { pipeline });
     expect(getters.pipeline(state, {}, {}, {})).toEqual(pipeline);
   });

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -37,7 +37,10 @@ export function buildStateWithOnePipeline(pipeline: Pipeline, customState?: Part
   });
 }
 
-export function setupMockStore(initialState: object = {}, plugins: any[] = []) {
+export function setupMockStore(
+  initialState: object = buildStateWithOnePipeline([]),
+  plugins: any[] = [],
+) {
   const store: Store<RootState> = new Vuex.Store({ plugins });
   registerModule(store, initialState);
 
@@ -216,7 +219,7 @@ export class BasicStepFormTestRunner {
     });
   }
 
-  testCancel(initialState: Partial<VQBState> = {}) {
+  testCancel(initialState: Partial<VQBState> = buildStateWithOnePipeline([])) {
     const store = setupMockStore(initialState);
     const initialPipeline = [...store.getters[VQBnamespace('pipeline')]];
     const initialStepIndex = store.state.vqb.selectedStepIndex;


### PR DESCRIPTION
Add a component to choose which pipeline is currently displayed.
Introduce the possibility that no pipeline can be selected.

![Screenshot from 2020-02-20 21-03-09](https://user-images.githubusercontent.com/932583/74973897-97c44680-5424-11ea-8429-bc0761d1e819.png)

All the available pipelines are listed:
![Screenshot from 2020-02-20 21-03-20](https://user-images.githubusercontent.com/932583/74973937-a7438f80-5424-11ea-9384-dc8e2239bd46.png)

And changing the selected pipeline displays the newly selected pipeline at its last step:
![Screenshot from 2020-02-20 21-03-26](https://user-images.githubusercontent.com/932583/74973993-bd515000-5424-11ea-9696-f1676c8b6e37.png)

Update: empty state when no pipeline is selected:
![Screenshot from 2020-02-21 18-21-38](https://user-images.githubusercontent.com/932583/75057944-60b06c80-54da-11ea-9508-158504d8f992.png)
(To reproduce it, change the initial `currentPipelineName` in the playground's to `undefined`)