### PR TITLE
Multiselect tags overflow issue

### DIFF
--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -156,9 +156,11 @@ export default class ListWidget extends Mixins(FormWidget) {
 }
 
 .widget-list__body {
+  background: none;
   width: 100%;
   display: flex;
   flex-direction: column;
+  padding: 0;
 }
 
 .widget-list__child {

--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -138,6 +138,7 @@ export default class MultiInputTextWidget extends Vue {
   display: block;
   padding-right: 30px;
   height: 40px;
+  overflow: hidden;
   & > input {
     background: transparent;
     margin-bottom: 0;
@@ -145,6 +146,11 @@ export default class MultiInputTextWidget extends Vue {
       color: $grey-dark;
     }
   }
+}
+
+.multiselect--active .multiselect__tags {
+  overflow: visible;
+  height: auto;
 }
 
 .widget-multiinputtext__container {


### PR DESCRIPTION
This PR fix an overflow issue when there is more than one row of tag into multiselect.

before : 
![image](https://user-images.githubusercontent.com/4438175/75170321-3654ee00-572a-11ea-867d-f36a5605b403.png)

Now it's cropped to display only one line and we show everything on click:
![image](https://user-images.githubusercontent.com/4438175/75171794-7d43e300-572c-11ea-9140-8e6ca55f7ed0.png)

This PR fix also another css visual issue a background color on filter step :
![image](https://user-images.githubusercontent.com/4438175/75171895-ad8b8180-572c-11ea-9da5-7e91c8e97f46.png)

Now : 
![image](https://user-images.githubusercontent.com/4438175/75172082-fba08500-572c-11ea-865a-8692f5fa7e32.png)
