### PR TITLE
Fix :: WidgetList item deletion

### DIFF
--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -2,7 +2,7 @@
   <div class="widget-list__container" :class="toggleClassErrorWarning">
     <label :for="id">{{ name }}</label>
     <div class="widget-list__body">
-      <div class="widget-list__child" v-for="(child, index) in children" :key="index">
+      <div class="widget-list__child" v-for="(child, index) in children" :key="child.uid">
         <span class="widget-list__component-sep" v-if="index > 0 && separatorLabel">{{
           separatorLabel
         }}</span>
@@ -96,6 +96,7 @@ export default class ListWidget extends Mixins(FormWidget) {
       valueCopy.push(this.defaultChildValue);
     }
     return valueCopy.map(value => ({
+      uid: this.getUniqueId(value),
       isRemovable: valueCopy.length !== 1,
       value,
     }));
@@ -114,6 +115,10 @@ export default class ListWidget extends Mixins(FormWidget) {
 
   addFieldSet() {
     this.updateValue([...this.value, _.cloneDeep(this.defaultChildValue)]);
+  }
+
+  getUniqueId(childValue: any) {
+    return Object.values(childValue).join('-');
   }
 
   removeChild(index: number) {

--- a/tests/unit/list-widget.spec.ts
+++ b/tests/unit/list-widget.spec.ts
@@ -66,6 +66,31 @@ describe('Widget List', () => {
       trashWrapper.trigger('click');
       expect(wrapper.emitted()['input']).toBeDefined();
     });
+
+    it('should remove the second input when clickng on trash', async () => {
+      const wrapper = shallowMount(ListWidget, {
+        propsData: {
+          value: [
+            { column: 'first', aggfunction: 'sum', newcolumn: 'first_bar' },
+            { column: 'second', aggfunction: 'sum', newcolumn: 'second_bar' },
+            { column: 'third', aggfunction: 'sum', newcolumn: 'third_bar' },
+          ],
+        },
+      });
+      const trashWrappers = wrapper.findAll('.widget-list__icon');
+      trashWrappers.at(1).trigger('click');
+      expect(wrapper.emitted()['input'][0][0].length).toEqual(2);
+      expect(wrapper.emitted()['input'][0][0][0]).toEqual({
+        column: 'first',
+        aggfunction: 'sum',
+        newcolumn: 'first_bar',
+      });
+      expect(wrapper.emitted()['input'][0][0][1]).toEqual({
+        column: 'third',
+        aggfunction: 'sum',
+        newcolumn: 'third_bar',
+      });
+    });
   });
 
   describe('not automatic new field', () => {


### PR DESCRIPTION
As we remove and update element by their index in v-for, values are well updated but the dom does not render the right elements.

To fix that, we add unique ids but they can't be random cause it could lead to call `updateChildValue`, reinstantiating items because `children` computed properties will compute a new id as values change.