### PR TITLE
Escape mongo fieldnames

### DIFF
--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -588,9 +588,13 @@ const mapper: Partial<StepMatcher<MongoStep>> = {
       },
     },
   }),
-  delete: (step: Readonly<S.DeleteStep>) => ({
-    $project: _.fromPairs(step.columns.map(col => [col, 0])),
-  }),
+
+  delete(this: Mongo36Translator, step: Readonly<S.DeleteStep>) {
+    return {
+      $project: _.fromPairs(step.columns.map(col => [this.escapeFieldName(col), 0])),
+    };
+  },
+
   domain: (step: Readonly<S.DomainStep>) => ({ $match: { domain: step.domain } }),
   duplicate: (step: Readonly<S.DuplicateColumnStep>) => ({
     $addFields: { [step.new_column_name]: $$(step.column) },

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -622,10 +622,18 @@ const mapper: Partial<StepMatcher<MongoStep>> = {
   }),
   percentage: transformPercentage,
   pivot: transformPivot,
-  rename: (step: Readonly<S.RenameStep>) => [
-    { $addFields: { [step.newname]: $$(step.oldname) } },
-    { $project: { [step.oldname]: 0 } },
-  ],
+
+  rename(this: Mongo36Translator, step: Readonly<S.RenameStep>) {
+    return [
+      {
+        $addFields: {
+          [this.escapeFieldName(step.newname)]: $$(this.escapeFieldName(step.oldname)),
+        },
+      },
+      { $project: { [this.escapeFieldName(step.oldname)]: 0 } },
+    ];
+  },
+
   replace: transformReplace,
   rollup: transformRollup,
 

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -624,9 +624,13 @@ const mapper: Partial<StepMatcher<MongoStep>> = {
   ],
   replace: transformReplace,
   rollup: transformRollup,
-  select: (step: Readonly<S.SelectStep>) => ({
-    $project: _.fromPairs(step.columns.map(col => [col, 1])),
-  }),
+
+  select(this: Mongo36Translator, step: Readonly<S.SelectStep>) {
+    return {
+      $project: _.fromPairs(step.columns.map(col => [this.escapeFieldName(col), 1])),
+    };
+  },
+
   split: transformSplit,
   sort: transformSort,
   substring: transformSubstring,
@@ -646,10 +650,17 @@ export class Mongo36Translator extends BaseTranslator {
   static label = 'Mongo 3.6';
 
   domainCollectionMap: { [k: string]: string };
+  escapeFieldName = function(fieldName: string): string {
+    return fieldName;
+  };
 
   constructor() {
     super();
     this.domainCollectionMap = {};
+  }
+
+  setFieldNamesEscapingFunction(escapeFieldName: (fieldName: string) => string) {
+    this.escapeFieldName = escapeFieldName;
   }
 
   setDomainCollectionMap(domColMap: { [k: string]: string }) {

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -122,6 +122,28 @@ describe('Pipeline to mongo translator', () => {
     ]);
   });
 
+  it('can generate rename steps with escaped characters', () => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'test_cube' },
+      { name: 'rename', oldname: 'Reg$ion', newname: 'zone$' },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      { $match: { domain: 'test_cube' } },
+      {
+        $addFields: {
+          zone__DOLLAR_SIGN__: '$Reg__DOLLAR_SIGN__ion',
+        },
+      },
+      {
+        $project: {
+          Reg__DOLLAR_SIGN__ion: 0,
+          _id: 0,
+        },
+      },
+    ]);
+  });
+
   it('can simplify "and" block', () => {
     const andBlock = {
       $and: [

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -82,6 +82,24 @@ describe('Pipeline to mongo translator', () => {
     ]);
   });
 
+  it('can generate delete steps with escaped characters', () => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'test_cube' },
+      { name: 'delete', columns: ['Man$', 'Re$$gion'] },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      { $match: { domain: 'test_cube' } },
+      {
+        $project: {
+          Man__DOLLAR_SIGN__: 0,
+          Re__DOLLAR_SIGN____DOLLAR_SIGN__gion: 0,
+          _id: 0,
+        },
+      },
+    ]);
+  });
+
   it('can generate rename steps', () => {
     const pipeline: Pipeline = [
       { name: 'domain', domain: 'test_cube' },

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -18,10 +18,6 @@ describe('Mongo translator support tests', () => {
 describe('Pipeline to mongo translator', () => {
   const mongo36translator = getTranslator('mongo36') as Mongo36Translator;
 
-  mongo36translator.setFieldNamesEscapingFunction(fieldName =>
-    fieldName.replace(/\$/g, '__DOLLAR_SIGN__'),
-  );
-
   it('can generate domain steps', () => {
     const pipeline: Pipeline = [{ name: 'domain', domain: 'test_cube' }];
     const querySteps = mongo36translator.translate(pipeline);
@@ -46,24 +42,6 @@ describe('Pipeline to mongo translator', () => {
     ]);
   });
 
-  it('can generate select steps with escaped characters', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'test_cube' },
-      { name: 'select', columns: ['Man$', 'Re$$gion'] },
-    ];
-    const querySteps = mongo36translator.translate(pipeline);
-    expect(querySteps).toEqual([
-      { $match: { domain: 'test_cube' } },
-      {
-        $project: {
-          Man__DOLLAR_SIGN__: 1,
-          Re__DOLLAR_SIGN____DOLLAR_SIGN__gion: 1,
-        },
-      },
-      { $project: { _id: 0 } },
-    ]);
-  });
-
   it('can generate delete steps', () => {
     const pipeline: Pipeline = [
       { name: 'domain', domain: 'test_cube' },
@@ -76,24 +54,6 @@ describe('Pipeline to mongo translator', () => {
         $project: {
           Manager: 0,
           Region: 0,
-          _id: 0,
-        },
-      },
-    ]);
-  });
-
-  it('can generate delete steps with escaped characters', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'test_cube' },
-      { name: 'delete', columns: ['Man$', 'Re$$gion'] },
-    ];
-    const querySteps = mongo36translator.translate(pipeline);
-    expect(querySteps).toEqual([
-      { $match: { domain: 'test_cube' } },
-      {
-        $project: {
-          Man__DOLLAR_SIGN__: 0,
-          Re__DOLLAR_SIGN____DOLLAR_SIGN__gion: 0,
           _id: 0,
         },
       },
@@ -116,28 +76,6 @@ describe('Pipeline to mongo translator', () => {
       {
         $project: {
           Region: 0,
-          _id: 0,
-        },
-      },
-    ]);
-  });
-
-  it('can generate rename steps with escaped characters', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'test_cube' },
-      { name: 'rename', oldname: 'Reg$ion', newname: 'zone$' },
-    ];
-    const querySteps = mongo36translator.translate(pipeline);
-    expect(querySteps).toEqual([
-      { $match: { domain: 'test_cube' } },
-      {
-        $addFields: {
-          zone__DOLLAR_SIGN__: '$Reg__DOLLAR_SIGN__ion',
-        },
-      },
-      {
-        $project: {
-          Reg__DOLLAR_SIGN__ion: 0,
           _id: 0,
         },
       },
@@ -2122,6 +2060,72 @@ describe('Pipeline to mongo translator', () => {
       },
       {
         $project: {
+          _id: 0,
+        },
+      },
+    ]);
+  });
+});
+
+describe('Pipeline to mongo translator with fieldNames character escaping', () => {
+  const mongo36translator = getTranslator('mongo36') as Mongo36Translator;
+
+  mongo36translator.setFieldNamesEscapingFunction(fieldName =>
+    fieldName.replace(/\$/g, '__DOLLAR_SIGN__'),
+  );
+
+  it('can generate select steps', () => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'test_cube' },
+      { name: 'select', columns: ['Man$', 'Re$$gion'] },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      { $match: { domain: 'test_cube' } },
+      {
+        $project: {
+          Man__DOLLAR_SIGN__: 1,
+          Re__DOLLAR_SIGN____DOLLAR_SIGN__gion: 1,
+        },
+      },
+      { $project: { _id: 0 } },
+    ]);
+  });
+
+  it('can generate delete steps', () => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'test_cube' },
+      { name: 'delete', columns: ['Man$', 'Re$$gion'] },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      { $match: { domain: 'test_cube' } },
+      {
+        $project: {
+          Man__DOLLAR_SIGN__: 0,
+          Re__DOLLAR_SIGN____DOLLAR_SIGN__gion: 0,
+          _id: 0,
+        },
+      },
+    ]);
+  });
+
+  it('can generate rename steps', () => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'test_cube' },
+      { name: 'rename', oldname: 'Reg$ion', newname: 'zone$' },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      { $match: { domain: 'test_cube' } },
+      {
+        $addFields: {
+          zone__DOLLAR_SIGN__: '$Reg__DOLLAR_SIGN__ion',
+        },
+      },
+      {
+        $project: {
+          Reg__DOLLAR_SIGN__ion: 0,
           _id: 0,
         },
       },

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -2131,4 +2131,23 @@ describe('Pipeline to mongo translator with fieldNames character escaping', () =
       },
     ]);
   });
+
+  it('can generate filter steps', () => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'test_cube' },
+      { name: 'filter', condition: { column: 'Man$ager', value: 'Pier$re', operator: 'eq' } },
+      { name: 'filter', condition: { column: 'A$ge', value: 10, operator: 'lt' } },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      {
+        $match: {
+          domain: 'test_cube',
+          Man__DOLLAR_SIGN__ager: { $eq: 'Pier$re' },
+          A__DOLLAR_SIGN__ge: { $lt: 10 },
+        },
+      },
+      { $project: { _id: 0 } },
+    ]);
+  });
 });


### PR DESCRIPTION
I suggest that `MongoTranslator` have a settable `escapeFieldName` function that will be used to replace all unauthorized characters from field names.
The mongo documentation suggest not to use `$` or `.` and provides different workarounds, such as replacing these characters by their unicode equivalent, or by special reserved strings. Another option would be to throw an exception if these characters are found, preventing the query to be translated.

As this is a database-specific rule, it seems logic to me that it stays in the `MongoTranslator`.