### PR TITLE
Change how changes are propagated from JoinColumns widget

### DIFF
--- a/src/components/stepforms/widgets/JoinColumns.vue
+++ b/src/components/stepforms/widgets/JoinColumns.vue
@@ -2,8 +2,7 @@
   <div class="widget-join-column__container">
     <AutocompleteWidget
       id="leftOn"
-      @input="setRightColumn()"
-      v-model="joinColumns[0]"
+      v-model="leftOnColumn"
       placeholder="Current dataset column"
       :options="columnNames"
       :data-path="`${dataPath}[0]`"
@@ -11,7 +10,7 @@
     />
     <InputTextWidget
       id="rightOn"
-      v-model="joinColumns[1]"
+      v-model="rightOnColumn"
       placeholder="Right dataset column"
       :data-path="`${dataPath}[1]`"
       :errors="errors"
@@ -20,8 +19,7 @@
 </template>
 <script lang="ts">
 import { ErrorObject } from 'ajv';
-import _ from 'lodash';
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import { VQBModule } from '@/store';
@@ -50,19 +48,26 @@ export default class JoinColumns extends Vue {
 
   @VQBModule.Getter columnNames!: string[];
 
-  joinColumns: string[] = [...this.value];
-
-  @Watch('joinColumns', { immediate: true, deep: true })
-  onJoinColumnsChanged(newval: any[], oldval: any[]) {
-    if (!_.isEqual(newval, oldval)) {
-      this.$emit('input', this.joinColumns);
-    }
+  get leftOnColumn() {
+    return this.value[0];
   }
 
-  setRightColumn() {
-    if (this.joinColumns[1] === '') {
-      this.joinColumns[1] = this.joinColumns[0];
-    }
+  set leftOnColumn(newLeftOnColumn) {
+    // If no right column, set it to the same as left column (smart default)
+    const newRightColumn = this.rightOnColumn === '' ? newLeftOnColumn : this.rightOnColumn;
+    this.update([newLeftOnColumn, newRightColumn]);
+  }
+
+  get rightOnColumn() {
+    return this.value[1];
+  }
+
+  set rightOnColumn(newRightOnColumn) {
+    this.update([this.leftOnColumn, newRightOnColumn]);
+  }
+
+  update(newJoinColumns: string[]) {
+    this.$emit('input', newJoinColumns);
   }
 }
 </script>

--- a/tests/unit/join-columns.spec.ts
+++ b/tests/unit/join-columns.spec.ts
@@ -1,7 +1,6 @@
-import { createLocalVue, mount, shallowMount } from '@vue/test-utils';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
-import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import JoinColumns from '@/components/stepforms/widgets/JoinColumns.vue';
 
 import { RootState, setupMockStore } from './utils';
@@ -40,39 +39,80 @@ describe('Widget AggregationWidget', () => {
     expect(autocompleteWrapper.attributes('options')).toEqual('columnA,columnB,columnC');
   });
 
-  it('should pass down the right prop to AutocompleteWidget', async () => {
-    const wrapper = shallowMount(JoinColumns, { store: emptyStore, localVue });
-    wrapper.setData({ joinColumns: ['toto', 'tata'] });
-    await localVue.nextTick();
+  it('should pass down the right prop to AutocompleteWidget', () => {
+    const wrapper = shallowMount(JoinColumns, {
+      propsData: {
+        value: ['toto', 'tata'],
+      },
+      store: emptyStore,
+      localVue,
+      sync: false,
+    });
     const autocompleteWrapper = wrapper.find('autocompletewidget-stub');
     expect(autocompleteWrapper.props().value).toEqual('toto');
   });
 
-  it('should pass down the right prop to InputTextWidget', async () => {
-    const wrapper = shallowMount(JoinColumns, { store: emptyStore, localVue });
-    wrapper.setData({ joinColumns: ['toto', 'tata'] });
-    await localVue.nextTick();
+  it('should pass down the right prop to InputTextWidget', () => {
+    const wrapper = shallowMount(JoinColumns, {
+      propsData: {
+        value: ['toto', 'tata'],
+      },
+      store: emptyStore,
+      localVue,
+      sync: false,
+    });
     const inputTextWrapper = wrapper.find('inputtextwidget-stub');
     expect(inputTextWrapper.props().value).toEqual('tata');
   });
 
-  it('should set joinColumns[1] = joinColumns[0] if joinColumns[0] is set while joinColumns[1] is null', async () => {
-    const wrapper = mount(JoinColumns, { store: emptyStore, localVue });
-    wrapper.setData({ joinColumns: ['toto', ''] });
-    await localVue.nextTick();
-    wrapper.find(AutocompleteWidget).trigger('input');
-    await localVue.nextTick();
-    expect(wrapper.vm.$data.joinColumns[1]).toEqual('toto');
-  });
-
-  it('should emit "input" event on "joinColumns" update', async () => {
+  it('should update its value when the left column is modified', () => {
     const wrapper = shallowMount(JoinColumns, {
+      propsData: {
+        value: ['toto', 'tata'],
+      },
       store: emptyStore,
       localVue,
+      sync: false,
     });
-    wrapper.setData({ joinColumns: ['toto', 'tata'] });
-    await localVue.nextTick();
+
+    const autocompleteWrapper = wrapper.find('autocompletewidget-stub');
+    autocompleteWrapper.vm.$emit('input', 'tutu');
+
     expect(wrapper.emitted().input).toBeDefined();
-    expect(wrapper.emitted().input[1]).toEqual([['toto', 'tata']]);
+    expect(wrapper.emitted().input[0]).toEqual([['tutu', 'tata']]);
+  });
+
+  it('should update its value when the right column is modified', () => {
+    const wrapper = shallowMount(JoinColumns, {
+      propsData: {
+        value: ['toto', 'tata'],
+      },
+      store: emptyStore,
+      localVue,
+      sync: false,
+    });
+
+    const inputTextWrapper = wrapper.find('inputtextwidget-stub');
+    inputTextWrapper.vm.$emit('input', 'tutu');
+
+    expect(wrapper.emitted().input).toBeDefined();
+    expect(wrapper.emitted().input[0]).toEqual([['toto', 'tutu']]);
+  });
+
+  it('should update both columns when the left column is modified if the right column was empty', () => {
+    const wrapper = shallowMount(JoinColumns, {
+      propsData: {
+        value: ['toto', ''],
+      },
+      store: emptyStore,
+      localVue,
+      sync: false,
+    });
+
+    const autocompleteWrapper = wrapper.find('autocompletewidget-stub');
+    autocompleteWrapper.vm.$emit('input', 'tutu');
+
+    expect(wrapper.emitted().input).toBeDefined();
+    expect(wrapper.emitted().input[0]).toEqual([['tutu', 'tutu']]);
   });
 });

--- a/tests/unit/join-step-form.spec.ts
+++ b/tests/unit/join-step-form.spec.ts
@@ -57,5 +57,20 @@ describe('join Step Form', () => {
       await wrapper.vm.$nextTick();
       expect(wrapper.find('listwidget-stub').props().value).toEqual([[]]);
     });
+
+    it('should update the edited step when one of the subcomponents emits an updated value', () => {
+      const wrapper = runner.shallowMount(undefined, {
+        data: {
+          editedStep: {
+            name: 'join',
+            right_pipeline: 'pipeline_right',
+            type: 'left',
+            on: [],
+          },
+        },
+      });
+      wrapper.find('ListWidget-stub').vm.$emit('input', ['colRight', 'colLeft']);
+      expect(wrapper.vm.$data.editedStep.on).toEqual(['colRight', 'colLeft']);
+    });
   });
 });


### PR DESCRIPTION
Previously, the initial prop was copied once at component's creation.
The component's internal state was hen modified by the component.
A watcher on the internal state propagated this changes upwards.

This approach had flaws:
- the component holds an internal state, but shouldn't (the source of
truth should be the form complete value object)
- if the form's value is modified outside the component, the
modification will never appear in the component
- additional deep watchers are added, which are quite useless

I restored the usual way of passing down props to components, and emit
up events to communicate changes requests.

Same logic than #457 