### PR TITLE
Fix :: Top groups

### DIFF
--- a/src/components/stepforms/TopStepForm.vue
+++ b/src/components/stepforms/TopStepForm.vue
@@ -33,7 +33,6 @@
       v-model="editedStep.groups"
       name="(Optional) Group by..."
       :options="columnNames"
-      @input="setSelectedColumns({ column: editedStep.groups[editedStep.groups.length - 1] })"
       placeholder="Select columns"
       data-path=".groups"
       :errors="errors"


### PR DESCRIPTION
When setting a group, the setter `stepSelectedColumn` was called that set rank_on value to the last group added.

