### PR TITLE
0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.13.0] - 2020-03-06
+## [0.13.1] - 2020-03-06
 
 ### Added
 - Introduce a bracket syntax to escape column names with spaces in formula step
@@ -185,7 +185,7 @@
 
 - Initial version, showtime!
 
-[0.13.0]: https://github.com/ToucanToco/weaverbird/compare/v0.12.0...v0.13.0
+[0.13.1]: https://github.com/ToucanToco/weaverbird/compare/v0.12.0...v0.13.1
 [0.12.0]: https://github.com/ToucanToco/weaverbird/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/ToucanToco/weaverbird/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/ToucanToco/weaverbird/compare/v0.9.0...v0.10.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
     "url": "https://github.com/ToucanToco/weaverbird/issues",


### PR DESCRIPTION
The 0.13.0 version has been published on npm without rebuilding the dist/ folder.
To correct this mistake, let's increment the patch version number.

I already unpublished the 0.13.0 version on the npm repository.