### PR TITLE
Aggregation Step (a.k.a "groupby"): add "first" and "last" aggFunction

### DIFF
--- a/src/components/stepforms/schemas/aggregate.ts
+++ b/src/components/stepforms/schemas/aggregate.ts
@@ -32,7 +32,7 @@ const schema = {
           },
           aggfunction: {
             type: 'string',
-            enum: ['sum', 'avg', 'count', 'min', 'max'],
+            enum: ['sum', 'avg', 'count', 'min', 'max', 'first', 'last'],
           },
           newcolumn: {
             type: 'string',

--- a/src/components/stepforms/widgets/Aggregation.vue
+++ b/src/components/stepforms/widgets/Aggregation.vue
@@ -69,7 +69,15 @@ export default class AggregationWidget extends Vue {
     });
   }
 
-  aggregationFunctions: AggFunctionStep['aggfunction'][] = ['sum', 'avg', 'count', 'min', 'max'];
+  aggregationFunctions: AggFunctionStep['aggfunction'][] = [
+    'sum',
+    'avg',
+    'count',
+    'min',
+    'max',
+    'first',
+    'last',
+  ];
 }
 </script>
 <style lang="scss" scoped>

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -23,6 +23,8 @@ const AGGFUNCTION_LABELS = {
   count: 'count',
   min: 'min',
   max: 'max',
+  first: 'first',
+  last: 'last',
 };
 
 /**

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -15,7 +15,7 @@ export type AggFunctionStep = {
   /** Name of the output column */
   newcolumn: string;
   /** the aggregation operation (e.g. `sum` or `count`) */
-  aggfunction: 'sum' | 'avg' | 'count' | 'min' | 'max';
+  aggfunction: 'sum' | 'avg' | 'count' | 'min' | 'max' | 'first' | 'last';
   /** the column the aggregation function is working on */
   column: string;
 };


### PR DESCRIPTION
In Mongo these operators are called "$first" and "$and" so the translation process is the same as "sum" or "avg". Consequently, we do not need to update Mongo translator.

Before:
![image](https://user-images.githubusercontent.com/15191323/77445896-ee3eef00-6ded-11ea-9194-45d879fe5abc.png)

Now:
![image](https://user-images.githubusercontent.com/15191323/77445857-e4b58700-6ded-11ea-8f04-24e17c2b0d36.png)
