### PR TITLE
Authorize small drops of total coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,8 @@
 coverage:
   status:
+    project:
+      default:
+        threshold: 5%
     patch:
       default:
         enabled: yes


### PR DESCRIPTION
As long as the patch coverage is 100%, it's fine!
This could happen when covered lines are deleted, making the relative importance of uncovered lines raise.