### PR TITLE
sort step :: fix initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED -
+
+### Fixed
+
+- Fixed bad sort step from initialization
+
 ## [0.15.0] - 2020-03-24
 
 ### Changed

--- a/src/components/stepforms/SortStepForm.vue
+++ b/src/components/stepforms/SortStepForm.vue
@@ -6,6 +6,7 @@
       id="sortColumn"
       v-model="sortColumns"
       :widget="widgetSortColumn"
+      :defaultItem="{ column: '', order: 'asc' }"
       :automatic-new-field="false"
       data-path=".columns"
       :errors="errors"
@@ -34,15 +35,19 @@ import SortColumnWidget from './widgets/SortColumn.vue';
   },
 })
 export default class SortStepForm extends BaseStepForm<SortStep> {
-  @Prop({ type: Object, default: () => ({ name: 'sort', columns: [] }) })
+  @Prop({
+    type: Object,
+    default: () => ({ name: 'sort', columns: [{ column: '', order: 'asc' }] }),
+  })
   initialStepValue!: SortStep;
 
   readonly title: string = 'Sort';
   widgetSortColumn = SortColumnWidget;
 
   created() {
-    // If a column is selected in the data table, suggest sorting it by default
-    if (this.selectedColumns.length > 0) {
+    // If a step has not been edited and a column is selected in the data table,
+    // suggest to sort by thus column in ascending order by default
+    if (this.editedStep.columns[0].column === '' && this.selectedColumns.length > 0) {
       this.editedStep.columns = [
         {
           column: this.selectedColumns[0],

--- a/src/components/stepforms/widgets/SortColumn.vue
+++ b/src/components/stepforms/widgets/SortColumn.vue
@@ -78,8 +78,8 @@ export default class SortColumnWidget extends Vue {
     });
   }
 
-  update(newValues) {
-    this.$emit('input', newValues);
+  update(newValue: SortColumnType) {
+    this.$emit('input', newValue);
   }
 }
 </script>

--- a/tests/unit/sort-step-form.spec.ts
+++ b/tests/unit/sort-step-form.spec.ts
@@ -51,12 +51,34 @@ describe('Sort Step Form', () => {
 
   runner.testResetSelectedIndex();
 
-  it('should suggest ordering by the column selected in the data table', function() {
+  it('should suggest the selected column as the column to be sorted', function() {
     const wrapper = runner.shallowMount({
       selectedColumns: ['selectedColumn'],
     });
     expect(wrapper.find('listwidget-stub').props().value).toEqual([
       { column: 'selectedColumn', order: 'asc' },
+    ]);
+  });
+
+  it('should not suggest a column to be sorted if no column is selected', function() {
+    const wrapper = runner.shallowMount({});
+    expect(wrapper.find('listwidget-stub').props().value).toEqual([{ column: '', order: 'asc' }]);
+  });
+
+  it('should not suggest a column to be sorted if the step has already been edited', function() {
+    const wrapper = runner.shallowMount(
+      { selectedColumns: ['selectedColumn'] },
+      {
+        propsData: {
+          initialStepValue: {
+            name: 'sort',
+            columns: [{ column: 'amazing', order: 'desc' }],
+          },
+        },
+      },
+    );
+    expect(wrapper.find('listwidget-stub').props().value).toEqual([
+      { column: 'amazing', order: 'desc' },
     ]);
   });
 


### PR DESCRIPTION
Before this PR, at creation of the sort step form component, editedStep was
always overwritten with a default value.

We only want to suggest a default value when the step has never been edited yet