### PR TITLE
Replace id of widgets by class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed bad sort step from initialization
 - Fixed columnPicker to prevent the mutation of the props
+- Fixed the no uniqueness of widgets ids by replacing them by class
 
 ## [0.15.0] - 2020-03-24
 

--- a/docs/_docs/contributing/new-step.md
+++ b/docs/_docs/contributing/new-step.md
@@ -358,7 +358,7 @@ Here is a possible template for your step:
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="column1Input"
+      class="column1Input"
       v-model="editedStep.column1"
       name="First column..."
       placeholder="Enter a column"
@@ -366,7 +366,7 @@ Here is a possible template for your step:
       :errors="errors"
     />
     <ColumnPicker
-      id="column2Input"
+      class="column2Input"
       v-model="editedStep.column2"
       name="Secpmd column..."
       placeholder="Enter a column"
@@ -374,7 +374,7 @@ Here is a possible template for your step:
       :errors="errors"
     />
     <InputTextWidget
-      id="newColumnInput"
+      class="newColumnInput"
       v-model="editedStep.newColumn"
       name="New column name:"
       placeholder="Enter a column name"

--- a/src/components/stepforms/AddTextColumnStepForm.vue
+++ b/src/components/stepforms/AddTextColumnStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <InputTextWidget
-      id="textInput"
+      class="textInput"
       v-model="editedStep.text"
       name="Enter a text:"
       placeholder
@@ -10,7 +10,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="newColumnInput"
+      class="newColumnInput"
       v-model="editedStep.new_column"
       name="New colum:"
       placeholder="Enter a new column name"

--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <MultiselectWidget
-      id="groupbyColumnsInput"
+      class="groupbyColumnsInput"
       v-model="editedStep.on"
       name="Group rows by..."
       :options="columnNames"
@@ -13,7 +13,7 @@
     />
     <ListWidget
       addFieldName="Add aggregation"
-      id="toremove"
+      class="toremove"
       name="And aggregate..."
       v-model="aggregations"
       :defaultItem="defaultAggregation"

--- a/src/components/stepforms/AppendStepForm.vue
+++ b/src/components/stepforms/AppendStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <MultiselectWidget
-      id="pipelinesInput"
+      class="pipelinesInput"
       v-model="editedStep.pipelines"
       name="Select datasets to append:"
       :options="Object.keys(pipelines).filter(p => p !== currentPipelineName)"

--- a/src/components/stepforms/ArgmaxStepForm.vue
+++ b/src/components/stepforms/ArgmaxStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="valueColumnInput"
+      class="valueColumnInput"
       v-model="editedStep.column"
       name="Search max value in..."
       placeholder="Enter a column name"
@@ -10,7 +10,7 @@
       :errors="errors"
     />
     <MultiselectWidget
-      id="groupbyColumnsInput"
+      class="groupbyColumnsInput"
       v-model="editedStep.groups"
       name="(Optional) Group by..."
       :options="columnNames"

--- a/src/components/stepforms/ArgminStepForm.vue
+++ b/src/components/stepforms/ArgminStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="valueColumnInput"
+      class="valueColumnInput"
       v-model="editedStep.column"
       name="Search min value in..."
       placeholder="Enter a column name"
@@ -10,7 +10,7 @@
       :errors="errors"
     />
     <MultiselectWidget
-      id="groupbyColumnsInput"
+      class="groupbyColumnsInput"
       v-model="editedStep.groups"
       name="(Optional) Group by..."
       :options="columnNames"

--- a/src/components/stepforms/ColumnPicker.vue
+++ b/src/components/stepforms/ColumnPicker.vue
@@ -21,9 +21,6 @@ import { MutationCallbacks } from '@/store/mutations';
 
 @Component({ components: { AutocompleteWidget } })
 export default class ColumnPicker extends Vue {
-  @Prop({ type: String, default: 'columnInput' })
-  id!: string;
-
   @Prop({ type: String, default: 'column' })
   name!: string;
 

--- a/src/components/stepforms/ConcatenateStepForm.vue
+++ b/src/components/stepforms/ConcatenateStepForm.vue
@@ -3,7 +3,7 @@
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ListWidget
       addFieldName="Add columns"
-      id="toConcatenate"
+      class="toConcatenate"
       name="Columns to concatenate:"
       v-model="toConcatenate"
       :defaultItem="[]"
@@ -14,7 +14,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="separator"
+      class="separator"
       v-model="editedStep.separator"
       name="Separator:"
       placeholder="Enter string of any length"
@@ -22,7 +22,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="newColumnName"
+      class="newColumnName"
       v-model="editedStep.new_column_name"
       name="New column name:"
       placeholder="Enter a columnn name"

--- a/src/components/stepforms/ConvertStepForm.vue
+++ b/src/components/stepforms/ConvertStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <MultiselectWidget
-      id="columnsInput"
+      class="columnsInput"
       v-model="editedStep.columns"
       name="Convert columns:"
       :options="columnNames"
@@ -12,7 +12,7 @@
       :errors="errors"
     />
     <AutocompleteWidget
-      id="typeInput"
+      class="typeInput"
       name="To data type:"
       v-model="editedStep.data_type"
       :options="dataTypes"

--- a/src/components/stepforms/CumSumStepForm.vue
+++ b/src/components/stepforms/CumSumStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="valueColumnInput"
+      class="valueColumnInput"
       v-model="editedStep.valueColumn"
       name="Value column to sum"
       placeholder="Enter a column"
@@ -11,7 +11,7 @@
       :errors="errors"
     />
     <ColumnPicker
-      id="referenceColumnInput"
+      class="referenceColumnInput"
       v-model="editedStep.referenceColumn"
       name="Reference column to sort (usually dates)"
       placeholder="Enter a column"
@@ -20,7 +20,7 @@
       :errors="errors"
     />
     <MultiselectWidget
-      id="groupbyInput"
+      class="groupbyInput"
       v-model="editedStep.groupby"
       name="(Optional) Group cumulated sum by:"
       :options="columnNames"
@@ -29,7 +29,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="newColumnInput"
+      class="newColumnInput"
       v-model="editedStep.newColumn"
       name="(Optional) New column name:"
       :placeholder="`${editedStep.valueColumn}_CUMSUM`"

--- a/src/components/stepforms/DateExtractStepForm.vue
+++ b/src/components/stepforms/DateExtractStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="column"
+      class="column"
       v-model="editedStep.column"
       name="Column to work on:"
       :options="columnNames"
@@ -12,7 +12,7 @@
     />
     <AutocompleteWidget
       name="Property to extract"
-      id="operation"
+      class="operation"
       :options="operations"
       :value="currentOperation"
       @input="updateCurrentOperation"
@@ -23,7 +23,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="newColumnName"
+      class="newColumnName"
       v-model="editedStep.new_column_name"
       name="New column name:"
       :placeholder="newColumnNamePlaceholder"

--- a/src/components/stepforms/DeleteColumnStepForm.vue
+++ b/src/components/stepforms/DeleteColumnStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <MultiselectWidget
-      id="columnsInput"
+      class="columnsInput"
       v-model="editedStep.columns"
       name="Delete columns..."
       :options="columnNames"

--- a/src/components/stepforms/DomainStepForm.vue
+++ b/src/components/stepforms/DomainStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <AutocompleteWidget
-      id="domainInput"
+      class="domainInput"
       v-model="editedStep.domain"
       name="Select domain..."
       :options="domains"

--- a/src/components/stepforms/DuplicateColumnStepForm.vue
+++ b/src/components/stepforms/DuplicateColumnStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="columnInput"
+      class="columnInput"
       v-model="editedStep.column"
       name="Duplicate column..."
       placeholder="Enter a column"
@@ -10,7 +10,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="newColumnNameInput"
+      class="newColumnNameInput"
       v-model="editedStep.new_column_name"
       name="New column name:"
       placeholder="Enter a column name"

--- a/src/components/stepforms/EvolutionStepForm.vue
+++ b/src/components/stepforms/EvolutionStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="dateColumnInput"
+      class="dateColumnInput"
       v-model="editedStep.dateCol"
       name="Date column:"
       placeholder="Enter a column"
@@ -11,7 +11,7 @@
       :errors="errors"
     />
     <ColumnPicker
-      id="valueColumnInput"
+      class="valueColumnInput"
       v-model="editedStep.valueCol"
       name="Value column:"
       placeholder="Enter a column"
@@ -20,7 +20,7 @@
       :errors="errors"
     />
     <AutocompleteWidget
-      id="evolutionType"
+      class="evolutionType"
       name="Compute evolution versus:"
       v-model="evolutionType"
       :options="evolutionTypes"
@@ -28,7 +28,7 @@
       :label="`label`"
     />
     <AutocompleteWidget
-      id="evolutionFormat"
+      class="evolutionFormat"
       name="Compute evolution in:"
       v-model="evolutionFormat"
       :options="evolutionFormats"
@@ -36,7 +36,7 @@
       :label="`label`"
     />
     <MultiselectWidget
-      id="indexColumnsInput"
+      class="indexColumnsInput"
       v-model="editedStep.indexColumns"
       name="(Optional) Index columns (labels):"
       :options="columnNames"
@@ -45,7 +45,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="newColumnInput"
+      class="newColumnInput"
       v-model="editedStep.newColumn"
       name="(Optional) New column name"
       placeholder="Enter a name"

--- a/src/components/stepforms/FillnaStepForm.vue
+++ b/src/components/stepforms/FillnaStepForm.vue
@@ -3,14 +3,14 @@
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
       v-model="editedStep.column"
-      id="columnInput"
+      class="columnInput"
       name="Replace null values in..."
       placeholder="Enter a column"
       data-path=".column"
       :errors="errors"
     />
     <InputTextWidget
-      id="valueInput"
+      class="valueInput"
       v-model="editedStep.value"
       name="With..."
       placeholder="Enter a value"

--- a/src/components/stepforms/FormulaStepForm.vue
+++ b/src/components/stepforms/FormulaStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <InputTextWidget
-      id="formulaInput"
+      class="formulaInput"
       v-model="editedStep.formula"
       name="Formula:"
       placeholder
@@ -10,7 +10,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="newColumnInput"
+      class="newColumnInput"
       v-model="editedStep.new_column"
       name="New colum:"
       placeholder="Enter a new column name"

--- a/src/components/stepforms/FromDateStepForm.vue
+++ b/src/components/stepforms/FromDateStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="column"
+      class="column"
       v-model="editedStep.column"
       name="Column to convert:"
       :options="columnNames"
@@ -11,7 +11,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="format"
+      class="format"
       v-model="editedStep.format"
       name="Date format of output text:"
       placeholder="Enter a date format"

--- a/src/components/stepforms/JoinStepForm.vue
+++ b/src/components/stepforms/JoinStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <AutocompleteWidget
-      id="rightPipelineInput"
+      class="rightPipelineInput"
       v-model="editedStep.right_pipeline"
       name="Select a dataset to join (as right dataset):"
       :options="Object.keys(pipelines).filter(p => p !== currentPipelineName)"
@@ -11,7 +11,7 @@
       :errors="errors"
     />
     <AutocompleteWidget
-      id="typeInput"
+      class="typeInput"
       v-model="editedStep.type"
       name="Select a join type:"
       :options="joinTypes"
@@ -22,7 +22,7 @@
     <ListWidget
       addFieldName="Add columns"
       name="Join based on column(s):"
-      id="joinColumns"
+      class="joinColumns"
       v-model="on"
       :defaultItem="['', '']"
       :widget="joinColumns"

--- a/src/components/stepforms/PercentageStepForm.vue
+++ b/src/components/stepforms/PercentageStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="valueColumnInput"
+      class="valueColumnInput"
       v-model="editedStep.column"
       name="Value column..."
       placeholder="Enter a column"
@@ -10,7 +10,7 @@
       :errors="errors"
     />
     <MultiselectWidget
-      id="groupbyColumnsInput"
+      class="groupbyColumnsInput"
       v-model="editedStep.group"
       name="(Optional) Group by..."
       :options="columnNames"
@@ -19,7 +19,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="newColumnNameInput"
+      class="newColumnNameInput"
       v-model="editedStep.newColumnName"
       name="(Optional) New column name:"
       :placeholder="`${editedStep.column}_PCT`"

--- a/src/components/stepforms/PivotStepForm.vue
+++ b/src/components/stepforms/PivotStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <MultiselectWidget
-      id="indexInput"
+      class="indexInput"
       v-model="editedStep.index"
       name="Keep columns..."
       :options="columnNames"
@@ -11,7 +11,7 @@
       :errors="errors"
     />
     <ColumnPicker
-      id="columnToPivotInput"
+      class="columnToPivotInput"
       v-model="editedStep.column_to_pivot"
       name="Pivot column..."
       placeholder="Enter a column"
@@ -19,7 +19,7 @@
       :errors="errors"
     />
     <AutocompleteWidget
-      id="valueColumnInput"
+      class="valueColumnInput"
       v-model="editedStep.value_column"
       name="Use values in..."
       :options="columnNames"
@@ -28,7 +28,7 @@
       :errors="errors"
     />
     <AutocompleteWidget
-      id="aggregationFunctionInput"
+      class="aggregationFunctionInput"
       v-model="editedStep.agg_function"
       name="Aggregate values using..."
       :options="aggregationFunctions"

--- a/src/components/stepforms/RenameStepForm.vue
+++ b/src/components/stepforms/RenameStepForm.vue
@@ -3,14 +3,14 @@
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
       v-model="editedStep.oldname"
-      id="oldnameInput"
+      class="oldnameInput"
       name="Old name:"
       placeholder="Enter the old column name"
       data-path=".oldname"
       :errors="errors"
     />
     <InputTextWidget
-      id="newnameInput"
+      class="newnameInput"
       v-model="editedStep.newname"
       name="New name:"
       placeholder="Enter a new column name"

--- a/src/components/stepforms/ReplaceStepForm.vue
+++ b/src/components/stepforms/ReplaceStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="searchColumnInput"
+      class="searchColumnInput"
       v-model="editedStep.search_column"
       name="Search in column..."
       placeholder="Enter a column"
@@ -11,7 +11,7 @@
     />
     <ListWidget
       addFieldName="Add a value to replace"
-      id="toReplace"
+      class="toReplace"
       name="Values to replace:"
       v-model="toReplace"
       :defaultItem="[]"

--- a/src/components/stepforms/RollupStepForm.vue
+++ b/src/components/stepforms/RollupStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <MultiselectWidget
-      id="hierarchyColumnsInput"
+      class="hierarchyColumnsInput"
       v-model="editedStep.hierarchy"
       name="Hierarchical columns (from top to bottom level):"
       :options="columnNames"
@@ -12,7 +12,7 @@
       :errors="errors"
     />
     <ListWidget
-      id="aggregationsInput"
+      class="aggregationsInput"
       addFieldName="Add aggregation"
       name="Columns to aggregate:"
       v-model="aggregations"
@@ -23,7 +23,7 @@
       :errors="errors"
     />
     <MultiselectWidget
-      id="groupbyColumnsInput"
+      class="groupbyColumnsInput"
       v-model="editedStep.groupby"
       name="(Optional) Group rollup by:"
       :options="columnNames"
@@ -33,7 +33,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="labelColumnInput"
+      class="labelColumnInput"
       v-model="editedStep.labelCol"
       name="(Optional) Label column name to be created:"
       placeholder="label"
@@ -41,7 +41,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="levelColumnInput"
+      class="levelColumnInput"
       v-model="editedStep.levelCol"
       name="(Optional) Level column name to be created:"
       placeholder="level"
@@ -49,7 +49,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="parentColumnInput"
+      class="parentColumnInput"
       v-model="editedStep.parentLabelCol"
       name="(Optional) Parent column name to be created:"
       placeholder="parent"

--- a/src/components/stepforms/SelectColumnStepForm.vue
+++ b/src/components/stepforms/SelectColumnStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <MultiselectWidget
-      id="columnsInput"
+      class="columnsInput"
       v-model="editedStep.columns"
       name="Keep columns..."
       :options="columnNames"

--- a/src/components/stepforms/SortStepForm.vue
+++ b/src/components/stepforms/SortStepForm.vue
@@ -3,7 +3,7 @@
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ListWidget
       addFieldName="Add Column"
-      id="sortColumn"
+      class="sortColumn"
       v-model="sortColumns"
       :widget="widgetSortColumn"
       :defaultItem="{ column: '', order: 'asc' }"

--- a/src/components/stepforms/SplitStepForm.vue
+++ b/src/components/stepforms/SplitStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="columnToSplit"
+      class="columnToSplit"
       v-model="editedStep.column"
       name="Split column..."
       placeholder="Enter a column"
@@ -10,7 +10,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="delimiter"
+      class="delimiter"
       v-model="editedStep.delimiter"
       name="Delimiter:"
       placeholder="Enter a text delimiter"
@@ -18,7 +18,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="numberColsToKeep"
+      class="numberColsToKeep"
       v-model.number="editedStep.number_cols_to_keep"
       type="number"
       name="Number of columns to keep:"

--- a/src/components/stepforms/SubstringStepForm.vue
+++ b/src/components/stepforms/SubstringStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="column"
+      class="column"
       v-model="editedStep.column"
       name="Extract a substring from..."
       placeholder="Enter a column"
@@ -10,7 +10,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="startIndex"
+      class="startIndex"
       v-model.number="editedStep.start_index"
       type="number"
       name="Substring starts at character position:"
@@ -19,7 +19,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="endIndex"
+      class="endIndex"
       v-model.number="editedStep.end_index"
       type="number"
       name="And ends at character position:"
@@ -28,7 +28,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="newColumnNameInput"
+      class="newColumnNameInput"
       v-model="editedStep.newColumnName"
       name="(Optional) New column name:"
       :placeholder="`${editedStep.column}_SUBSTR`"

--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="column"
+      class="column"
       v-model="editedStep.column"
       name="Column to convert:"
       :options="columnNames"
@@ -12,7 +12,7 @@
     />
     <InputTextWidget
       v-if="this.translator === 'mongo40'"
-      id="dateFormat"
+      class="dateFormat"
       v-model.number="editedStep.format"
       name="Date format:"
       placeholder="%Y-%m-%d"

--- a/src/components/stepforms/ToLowerStepForm.vue
+++ b/src/components/stepforms/ToLowerStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="columnInput"
+      class="columnInput"
       v-model="editedStep.column"
       name="Convert column..."
       placeholder="Enter a column"

--- a/src/components/stepforms/ToUpperStepForm.vue
+++ b/src/components/stepforms/ToUpperStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <ColumnPicker
-      id="columnInput"
+      class="columnInput"
       v-model="editedStep.column"
       name="Convert column..."
       placeholder="Enter a column"

--- a/src/components/stepforms/TopStepForm.vue
+++ b/src/components/stepforms/TopStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <InputTextWidget
-      id="limitInput"
+      class="limitInput"
       v-model.number="editedStep.limit"
       type="number"
       name="Get top..."
@@ -11,7 +11,7 @@
       :errors="errors"
     />
     <ColumnPicker
-      id="rankOnInput"
+      class="rankOnInput"
       v-model="editedStep.rank_on"
       name="Sort column..."
       placeholder="Enter a column"
@@ -20,7 +20,7 @@
       :errors="errors"
     />
     <AutocompleteWidget
-      id="sortOrderInput"
+      class="sortOrderInput"
       v-model="editedStep.sort"
       name="Sort order:"
       :options="['asc', 'desc']"
@@ -29,7 +29,7 @@
       :errors="errors"
     />
     <MultiselectWidget
-      id="groupbyColumnsInput"
+      class="groupbyColumnsInput"
       v-model="editedStep.groups"
       name="(Optional) Group by..."
       :options="columnNames"

--- a/src/components/stepforms/UniqueGroupsStepForm.vue
+++ b/src/components/stepforms/UniqueGroupsStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <MultiselectWidget
-      id="groupbyColumnsInput"
+      class="groupbyColumnsInput"
       v-model="editedStep.on"
       name="Get unique groups/values in columns:"
       :options="columnNames"

--- a/src/components/stepforms/UnpivotStepForm.vue
+++ b/src/components/stepforms/UnpivotStepForm.vue
@@ -2,7 +2,7 @@
   <div>
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <MultiselectWidget
-      id="keepColumnInput"
+      class="keepColumnInput"
       v-model="editedStep.keep"
       name="Keep columns..."
       :options="columnNames"
@@ -12,7 +12,7 @@
       :errors="errors"
     />
     <MultiselectWidget
-      id="unpivotColumnInput"
+      class="unpivotColumnInput"
       v-model="editedStep.unpivot"
       name="Unpivot columns..."
       :options="columnNames"
@@ -21,7 +21,7 @@
       data-path=".unpivot"
       :errors="errors"
     />
-    <CheckboxWidget id="dropnaCheckbox" :label="checkboxLabel" v-model="editedStep.dropna" />
+    <CheckboxWidget class="dropnaCheckbox" :label="checkboxLabel" v-model="editedStep.dropna" />
     <StepFormButtonbar />
   </div>
 </template>

--- a/src/components/stepforms/widgets/Aggregation.vue
+++ b/src/components/stepforms/widgets/Aggregation.vue
@@ -1,7 +1,7 @@
 <template>
   <fieldset class="widget-aggregation__container">
     <AutocompleteWidget
-      id="columnInput"
+      class="columnInput"
       :options="columnNames"
       v-model="aggregationColumn"
       name="Column:"
@@ -10,7 +10,7 @@
       :errors="errors"
     />
     <AutocompleteWidget
-      id="aggregationFunctionInput"
+      class="aggregationFunctionInput"
       v-model="aggregationFunction"
       name="Function:"
       :options="aggregationFunctions"

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="widget-autocomplete__container" :class="toggleClassErrorWarning">
-    <label class="widget-autocomplete__label" v-if="name" :for="id">{{ name }}</label>
+    <label class="widget-autocomplete__label" v-if="name">{{ name }}</label>
     <multiselect
       :value="value"
       :options="options"
@@ -30,9 +30,6 @@ import FormWidget from './FormWidget.vue';
   },
 })
 export default class AutocompleteWidget extends Mixins(FormWidget) {
-  @Prop({ type: String, default: null })
-  id!: string;
-
   @Prop({ type: String, default: '' })
   name!: string;
 

--- a/src/components/stepforms/widgets/CodeEditorWidget.vue
+++ b/src/components/stepforms/widgets/CodeEditorWidget.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="widget-code-editor__container" :class="toggleClassErrorWarning">
-    <label v-if="name" :for="id">{{ name }}</label>
+    <label v-if="name">{{ name }}</label>
     <component
       :is="CodeEditor"
-      :id="id"
       :class="elementClass"
       :placeholder="placeholder"
       v-model="editedValue"
@@ -30,9 +29,6 @@ import FormWidget from './FormWidget.vue';
   name: 'code-editor-widget',
 })
 export default class CodeEditorWidget extends Mixins(FormWidget) {
-  @Prop({ type: String, default: null })
-  id!: string;
-
   @Prop({ type: String, default: '' })
   name!: string;
 

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -2,7 +2,7 @@
   <div class="filter-form-simple-condition__container">
     <div class="filter-form-simple-condition-column-input">
       <AutocompleteWidget
-        :id="`${dataPath.replace(/[^a-zA-Z0-9]/g, '')}-columnInput`"
+        :class="`${dataPath.replace(/[^a-zA-Z0-9]/g, '')}-columnInput`"
         :value="value.column"
         :options="columnNames"
         @input="updateStepColumn"
@@ -13,7 +13,7 @@
     </div>
     <div class="filter-form-simple-condition-operator-input">
       <AutocompleteWidget
-        :id="`${dataPath.replace(/[^a-zA-Z0-9]/g, '')}-filterOperator`"
+        :class="`${dataPath.replace(/[^a-zA-Z0-9]/g, '')}-filterOperator`"
         :value="operator"
         @input="updateStepOperator"
         :options="operators"
@@ -23,7 +23,7 @@
       />
     </div>
     <component
-      :id="`${dataPath.replace(/[^a-zA-Z0-9]/g, '')}-filterValue`"
+      :class="`${dataPath.replace(/[^a-zA-Z0-9]/g, '')}-filterValue`"
       v-if="inputWidget"
       :is="inputWidget"
       :value="value.value"

--- a/src/components/stepforms/widgets/InputText.vue
+++ b/src/components/stepforms/widgets/InputText.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="widget-input-text__container" :class="toggleClassErrorWarning">
     <div class="widget-input-text__label">
-      <label v-if="name" :for="id">{{ name }}</label>
+      <label v-if="name" @click="$refs.input.focus()">{{ name }}</label>
       <a v-if="docUrl" :href="docUrl" target="_blank" rel="noopener">
         <i class="fas fa-question-circle" />
       </a>
     </div>
     <input
-      :id="id"
+      ref="input"
       :class="elementClass"
       :placeholder="placeholder"
       type="text"
@@ -36,9 +36,6 @@ import FormWidget from './FormWidget.vue';
   name: 'input-text-widget',
 })
 export default class InputTextWidget extends Mixins(FormWidget) {
-  @Prop({ type: String, default: null })
-  id!: string;
-
   @Prop({ type: String, default: '' })
   name!: string;
 

--- a/src/components/stepforms/widgets/JoinColumns.vue
+++ b/src/components/stepforms/widgets/JoinColumns.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="widget-join-column__container">
     <AutocompleteWidget
-      id="leftOn"
+      class="leftOn"
       v-model="leftOnColumn"
       placeholder="Current dataset column"
       :options="columnNames"
@@ -9,7 +9,7 @@
       :errors="errors"
     />
     <InputTextWidget
-      id="rightOn"
+      class="rightOn"
       v-model="rightOnColumn"
       placeholder="Right dataset column"
       :data-path="`${dataPath}[1]`"

--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="widget-list__container" :class="toggleClassErrorWarning">
-    <label :for="id">{{ name }}</label>
+    <label v-if="name">{{ name }}</label>
     <div class="widget-list__body">
       <div class="widget-list__child" v-for="(child, index) in children" :key="index">
         <span class="widget-list__component-sep" v-if="index > 0 && separatorLabel">{{
@@ -59,9 +59,6 @@ export default class ListWidget extends Mixins(FormWidget) {
 
   @Prop({ type: Object, default: () => {} })
   componentProps!: object;
-
-  @Prop({ type: String, default: null })
-  id!: string;
 
   @Prop({ type: String, default: '' })
   name!: string;

--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -24,9 +24,6 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
   },
 })
 export default class MultiInputTextWidget extends Vue {
-  @Prop({ type: String, default: null })
-  id!: string;
-
   @Prop({ type: String, default: '' })
   name!: string;
 

--- a/src/components/stepforms/widgets/Multiselect.vue
+++ b/src/components/stepforms/widgets/Multiselect.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="widget-multiselect__container" :class="toggleClassErrorWarning">
-    <label class="widget-multiselect__label" :for="id">{{ name }}</label>
+    <label class="widget-multiselect__label">{{ name }}</label>
     <multiselect
       v-model="editedValue"
       :options="options"
@@ -29,9 +29,6 @@ import FormWidget from './FormWidget.vue';
   },
 })
 export default class MultiselectWidget extends Mixins(FormWidget) {
-  @Prop({ type: String, default: null })
-  id!: string;
-
   @Prop({ type: String, default: '' })
   name!: string;
 

--- a/src/components/stepforms/widgets/Replace.vue
+++ b/src/components/stepforms/widgets/Replace.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="widget-to-replace__container">
     <InputTextWidget
-      id="valueToReplace"
+      class="valueToReplace"
       v-model="valueToReplace"
       placeholder="Value to replace"
       :data-path="`${dataPath}[0]`"
       :errors="errors"
     />
     <InputTextWidget
-      id="newValue"
+      class="newValue"
       v-model="newValueToReplace"
       placeholder="New value"
       :data-path="`${dataPath}[1]`"

--- a/src/components/stepforms/widgets/SortColumn.vue
+++ b/src/components/stepforms/widgets/SortColumn.vue
@@ -1,7 +1,7 @@
 <template>
   <fieldset class="widget-sort__container">
     <AutocompleteWidget
-      id="columnInput"
+      class="columnInput"
       :options="columnNames"
       v-model="sortColumn"
       name="Column"
@@ -10,7 +10,7 @@
       :errors="errors"
     />
     <AutocompleteWidget
-      id="sortOrderInput"
+      class="sortOrderInput"
       v-model="sortOrder"
       name="Order"
       :options="['asc', 'desc']"

--- a/tests/unit/aggregation-widget.spec.ts
+++ b/tests/unit/aggregation-widget.spec.ts
@@ -63,7 +63,7 @@ describe('Widget AggregationWidget', () => {
       localVue,
       propsData: { value: { column: 'foo', newcolumn: '', aggfunction: 'sum' } },
     });
-    wrapper.find('AutocompleteWidget-stub#columnInput').vm.$emit('input', 'plop');
+    wrapper.find('AutocompleteWidget-stub.columnInput').vm.$emit('input', 'plop');
     expect(wrapper.emitted().input).toBeDefined();
     expect(wrapper.emitted().input[0]).toEqual([
       { column: 'plop', newcolumn: '', aggfunction: 'sum' },
@@ -76,7 +76,7 @@ describe('Widget AggregationWidget', () => {
       localVue,
       propsData: { value: { column: 'foo', newcolumn: '', aggfunction: 'sum' } },
     });
-    wrapper.find('AutocompleteWidget-stub#aggregationFunctionInput').vm.$emit('input', 'avg');
+    wrapper.find('AutocompleteWidget-stub.aggregationFunctionInput').vm.$emit('input', 'avg');
     expect(wrapper.emitted().input).toBeDefined();
     expect(wrapper.emitted().input[0]).toEqual([
       { column: 'foo', newcolumn: '', aggfunction: 'avg' },

--- a/tests/unit/evolution-step-form.spec.ts
+++ b/tests/unit/evolution-step-form.spec.ts
@@ -69,12 +69,12 @@ describe('Evolution Step Form', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('#dateColumnInput').props('value')).toEqual('date');
-    expect(wrapper.find('#valueColumnInput').props('value')).toEqual('value');
-    expect(wrapper.find('#evolutionType').props('value').evolutionType).toEqual('vsLastYear');
-    expect(wrapper.find('#evolutionFormat').props('value').evolutionFormat).toEqual('pct');
-    expect(wrapper.find('#indexColumnsInput').props('value')).toEqual(['index']);
-    expect(wrapper.find('#newColumnInput').props('value')).toEqual('foo');
+    expect(wrapper.find('.dateColumnInput').props('value')).toEqual('date');
+    expect(wrapper.find('.valueColumnInput').props('value')).toEqual('value');
+    expect(wrapper.find('.evolutionType').props('value').evolutionType).toEqual('vsLastYear');
+    expect(wrapper.find('.evolutionFormat').props('value').evolutionFormat).toEqual('pct');
+    expect(wrapper.find('.indexColumnsInput').props('value')).toEqual(['index']);
+    expect(wrapper.find('.newColumnInput').props('value')).toEqual('foo');
   });
 
   it('should pass set evolutionFormat properly', async () => {
@@ -91,7 +91,7 @@ describe('Evolution Step Form', () => {
     });
     await wrapper.vm.$nextTick();
     wrapper
-      .find('#evolutionFormat')
+      .find('.evolutionFormat')
       .vm.$emit('input', { evolutionFormat: 'pct', label: 'percentage' });
     expect(wrapper.vm.$data.editedStep.evolutionFormat).toEqual('pct');
   });
@@ -110,7 +110,7 @@ describe('Evolution Step Form', () => {
     });
     await wrapper.vm.$nextTick();
     wrapper
-      .find('#evolutionType')
+      .find('.evolutionType')
       .vm.$emit('input', { evolutionType: 'vsLastMonth', label: 'last month' });
     expect(wrapper.vm.$data.editedStep.evolutionType).toEqual('vsLastMonth');
   });

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -138,7 +138,7 @@ describe('Widget FilterSimpleCondition', () => {
       value: { column: '', value: [], operator: 'in' },
     });
     await wrapper.vm.$nextTick();
-    let valueInputWrapper = wrapper.find('#condition-filterValue');
+    let valueInputWrapper = wrapper.find('.condition-filterValue');
     expect(valueInputWrapper.is(MultiInputTextWidget)).toBe(true);
     expect(valueInputWrapper.attributes('placeholder')).toEqual('Enter a value');
 
@@ -147,7 +147,7 @@ describe('Widget FilterSimpleCondition', () => {
       value: { column: '', value: null, operator: 'isnull' },
     });
     await wrapper.vm.$nextTick();
-    valueInputWrapper = wrapper.find('#condition-filterValue');
+    valueInputWrapper = wrapper.find('.condition-filterValue');
     expect(valueInputWrapper.exists()).toBeFalsy();
 
     // matches operator
@@ -155,7 +155,7 @@ describe('Widget FilterSimpleCondition', () => {
       value: { column: '', value: '', operator: 'matches' },
     });
     await wrapper.vm.$nextTick();
-    valueInputWrapper = wrapper.find('#condition-filterValue');
+    valueInputWrapper = wrapper.find('.condition-filterValue');
     expect(valueInputWrapper.is(InputTextWidget)).toBe(true);
     expect(valueInputWrapper.attributes('placeholder')).toEqual('Enter a regex, e.g. "[Ss]ales"');
   });
@@ -184,7 +184,7 @@ describe('Widget FilterSimpleCondition', () => {
     });
     expect(wrapper.emitted().input[0]).toEqual([{ column: '', value: '', operator: 'eq' }]);
 
-    const valueInputWrapper = wrapper.find('#condition-filterValue');
+    const valueInputWrapper = wrapper.find('.condition-filterValue');
     valueInputWrapper.vm.$emit('input', 'toto');
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted().input[1]).toEqual([{ column: '', value: 'toto', operator: 'eq' }]);

--- a/tests/unit/pivot-step-form.spec.ts
+++ b/tests/unit/pivot-step-form.spec.ts
@@ -119,9 +119,9 @@ describe('Pivot Step Form', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('#indexInput').props('value')).toEqual(['label']);
-    expect(wrapper.find('#valueColumnInput').props('value')).toEqual('value');
-    expect(wrapper.find('#aggregationFunctionInput').props('value')).toEqual('sum');
+    expect(wrapper.find('.indexInput').props('value')).toEqual(['label']);
+    expect(wrapper.find('.valueColumnInput').props('value')).toEqual('value');
+    expect(wrapper.find('.aggregationFunctionInput').props('value')).toEqual('sum');
   });
 
   it('should instantiate indexInput widget multiselect with column names', () => {
@@ -132,7 +132,7 @@ describe('Pivot Step Form', () => {
       },
     };
     const wrapper = runner.shallowMount(initialState);
-    expect(wrapper.find('#indexInput').attributes('options')).toEqual('columnA,columnB,columnC');
+    expect(wrapper.find('.indexInput').attributes('options')).toEqual('columnA,columnB,columnC');
   });
 
   it('should instantiate valueColumnInput widget autocomplete with column names', () => {
@@ -143,14 +143,14 @@ describe('Pivot Step Form', () => {
       },
     };
     const wrapper = runner.shallowMount(initialState);
-    expect(wrapper.find('#valueColumnInput').attributes('options')).toEqual(
+    expect(wrapper.find('.valueColumnInput').attributes('options')).toEqual(
       'columnA,columnB,columnC',
     );
   });
 
   it('should instantiate aggregationFunctionInput widget autocomplete with the right aggregation function names', () => {
     const wrapper = runner.shallowMount();
-    expect(wrapper.find('#aggregationFunctionInput').attributes('options')).toEqual(
+    expect(wrapper.find('.aggregationFunctionInput').attributes('options')).toEqual(
       'sum,avg,count,min,max',
     );
   });

--- a/tests/unit/split-step-form.spec.ts
+++ b/tests/unit/split-step-form.spec.ts
@@ -37,7 +37,7 @@ describe('Split Step Form', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('#delimiter').props('value')).toEqual('-');
-    expect(wrapper.find('#numberColsToKeep').props('value')).toEqual(3);
+    expect(wrapper.find('.delimiter').props('value')).toEqual('-');
+    expect(wrapper.find('.numberColsToKeep').props('value')).toEqual(3);
   });
 });

--- a/tests/unit/substring-step-form.spec.ts
+++ b/tests/unit/substring-step-form.spec.ts
@@ -57,7 +57,7 @@ describe('Substring Step Form', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('#startIndex').props('value')).toEqual(1);
-    expect(wrapper.find('#endIndex').props('value')).toEqual(3);
+    expect(wrapper.find('.startIndex').props('value')).toEqual(1);
+    expect(wrapper.find('.endIndex').props('value')).toEqual(3);
   });
 });

--- a/tests/unit/top-step-form.spec.ts
+++ b/tests/unit/top-step-form.spec.ts
@@ -41,9 +41,9 @@ describe('Top Step Form', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('#limitInput').props('value')).toEqual(10);
-    expect(wrapper.find('#sortOrderInput').props('value')).toEqual('asc');
-    expect(wrapper.find('#groupbyColumnsInput').props('value')).toEqual(['test']);
+    expect(wrapper.find('.limitInput').props('value')).toEqual(10);
+    expect(wrapper.find('.sortOrderInput').props('value')).toEqual('asc');
+    expect(wrapper.find('.groupbyColumnsInput').props('value')).toEqual(['test']);
   });
 
   it('should accept templatable values', async () => {

--- a/tests/unit/unpivot-step-form.spec.ts
+++ b/tests/unit/unpivot-step-form.spec.ts
@@ -72,8 +72,8 @@ describe('Unpivot Step Form', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('#keepColumnInput').props('value')).toEqual(['foo', 'bar']);
-    expect(wrapper.find('#unpivotColumnInput').props('value')).toEqual(['baz']);
+    expect(wrapper.find('.keepColumnInput').props('value')).toEqual(['foo', 'bar']);
+    expect(wrapper.find('.unpivotColumnInput').props('value')).toEqual(['baz']);
     const widgetCheckbox = wrapper.find(CheckboxWidget);
     expect(widgetCheckbox.classes()).not.toContain('widget-checkbox--checked');
   });
@@ -86,10 +86,10 @@ describe('Unpivot Step Form', () => {
       },
     };
     const wrapper = runner.shallowMount(initialState);
-    expect(wrapper.find('#keepColumnInput').attributes('options')).toEqual(
+    expect(wrapper.find('.keepColumnInput').attributes('options')).toEqual(
       'columnA,columnB,columnC',
     );
-    expect(wrapper.find('#unpivotColumnInput').attributes('options')).toEqual(
+    expect(wrapper.find('.unpivotColumnInput').attributes('options')).toEqual(
       'columnA,columnB,columnC',
     );
   });


### PR DESCRIPTION
Before: id of widget are not unique
Now: we replace id by class so there is not unicity problem anymore

- replace id from widgets template by class
- remove id from all widgets props
- replace reference to id in spec files by class
- remove reference to id in label (attribute "for")
   In the input wigget I preserved the focus behavior by triggering the focus of input in js.

closes #487