### PR TITLE
Prevent column override when aggregating on an exiting column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed columnPicker to prevent the mutation of the props
 - Fixed the no uniqueness of widgets ids by replacing them by class
 - Fixed checkbox props propagation
+- Fixed the aggregation step when performing an aggregation on one of the id columns
 
 ## [0.15.0] - 2020-03-24
 

--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -87,6 +87,9 @@ export default class AggregateStepForm extends BaseStepForm<AggregationStep> {
       if (newcolumnOccurences[agg.newcolumn] > 1) {
         agg.newcolumn = `${agg.newcolumn}-${agg.aggfunction}`;
       }
+      if (this.editedStep.on.includes(agg.newcolumn)) {
+        agg.newcolumn = `${agg.newcolumn}-${agg.aggfunction}`;
+      }
     }
     this.$$super.submit();
   }

--- a/tests/unit/aggregate-step-form.spec.ts
+++ b/tests/unit/aggregate-step-form.spec.ts
@@ -157,7 +157,7 @@ describe('Aggregate Step Form', () => {
       expect(wrapper.vm.$data.editedStep.aggregations[0].newcolumn).toEqual('bar');
     });
 
-    it('should set newcolumn cleverly if several aggregations are performed o, the same column', () => {
+    it('should set newcolumn cleverly if several aggregations are performed on the same column', () => {
       const wrapper = runner.mount(undefined, {
         data: {
           editedStep: {
@@ -174,6 +174,21 @@ describe('Aggregate Step Form', () => {
       expect(wrapper.vm.$data.errors).toBeNull();
       expect(wrapper.vm.$data.editedStep.aggregations[0].newcolumn).toEqual('bar-sum');
       expect(wrapper.vm.$data.editedStep.aggregations[1].newcolumn).toEqual('bar-avg');
+    });
+
+    it('should set newcolumn cleverly if the an aggregation is perform on an id column', () => {
+      const wrapper = runner.mount(undefined, {
+        data: {
+          editedStep: {
+            name: 'aggregate',
+            on: ['foo'],
+            aggregations: [{ column: 'foo', newcolumn: '', aggfunction: 'count' }],
+          },
+        },
+      });
+      wrapper.find('.widget-form-action__button--validate').trigger('click');
+      expect(wrapper.vm.$data.errors).toBeNull();
+      expect(wrapper.vm.$data.editedStep.aggregations[0].newcolumn).toEqual('foo-count');
     });
   });
 


### PR DESCRIPTION
Before: if performing an aggregation on one of the id columns the result pipeline result would display only one of the two expected columns
After: the aggregation is rename into {column-name}-{aggregation-name}

Before: (`st` column is aggregated to be counted, but `st` is also an `id` column of the aggregation)

![image](https://user-images.githubusercontent.com/15191323/77806431-f8c6e600-7084-11ea-8254-2c49ed47c29e.png)

After:

![image](https://user-images.githubusercontent.com/15191323/77806506-33c91980-7085-11ea-9768-ee27787d0029.png)


