### PR TITLE
Fix checkbox props propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed bad sort step from initialization
 - Fixed columnPicker to prevent the mutation of the props
 - Fixed the no uniqueness of widgets ids by replacing them by class
+- Fixed checkbox props propagation
 
 ## [0.15.0] - 2020-03-24
 

--- a/src/components/stepforms/widgets/Checkbox.vue
+++ b/src/components/stepforms/widgets/Checkbox.vue
@@ -17,15 +17,12 @@ export default class CheckboxWidget extends Vue {
   @Prop({ type: Boolean, default: true })
   value!: boolean;
 
-  valueCopy = this.value;
-
   get toggleCheckedClass() {
-    return { 'widget-checkbox': true, 'widget-checkbox--checked': this.valueCopy };
+    return { 'widget-checkbox': true, 'widget-checkbox--checked': this.value };
   }
 
   toggleValue() {
-    this.valueCopy = !this.valueCopy;
-    this.$emit('input', this.valueCopy);
+    this.$emit('input', !this.value);
   }
 }
 </script>
@@ -87,5 +84,6 @@ export default class CheckboxWidget extends Vue {
   margin-bottom: 0;
   align-self: center;
   margin-left: 8px;
+  cursor: pointer;
 }
 </style>

--- a/tests/unit/checkbox-widget.spec.ts
+++ b/tests/unit/checkbox-widget.spec.ts
@@ -16,20 +16,21 @@ describe('Widget Checkbox', () => {
     expect(labelWrapper.text()).toEqual('test');
   });
 
-  it('should toggle the right class on click', async () => {
+  it('should be instantiated with the right class', async () => {
     const wrapper = mount(CheckboxWidget, {
       propsData: { value: false },
     });
     expect(wrapper.classes()).not.toContain('widget-checkbox--checked');
-    wrapper.trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.classes()).toContain('widget-checkbox--checked');
-    wrapper.trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.classes()).not.toContain('.widget-checkbox--checked');
   });
 
-  it('should emit "input" event on click', async () => {
+  it('should be instantiated with the right class', async () => {
+    const wrapper = mount(CheckboxWidget, {
+      propsData: { value: true },
+    });
+    expect(wrapper.classes()).toContain('widget-checkbox--checked');
+  });
+
+  it('should emit the right value of "input" event on click', async () => {
     const wrapper = shallowMount(CheckboxWidget, {
       propsData: {
         value: false,
@@ -38,5 +39,16 @@ describe('Widget Checkbox', () => {
     wrapper.trigger('click');
     await localVue.nextTick();
     expect(wrapper.emitted()).toEqual({ input: [[true]] });
+  });
+
+  it('should emit the right value of "input" event on click', async () => {
+    const wrapper = shallowMount(CheckboxWidget, {
+      propsData: {
+        value: true,
+      },
+    });
+    wrapper.trigger('click');
+    await localVue.nextTick();
+    expect(wrapper.emitted()).toEqual({ input: [[false]] });
   });
 });


### PR DESCRIPTION
Does not mutate the state of checkbox inside the component itself. The component listen only his prop "value" to update his template.
This means that parent of checkbox should "give back" to checkbox any emitted value to take into account the new value. For example, a v-model would do perfectly the job.

related to #462

NB: There is (for now) only one checkbox in weaverbird: in the unpivot step :)