### PR TITLE
Improve Popover interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED -
 
+### Changed
+- The Popover is not necessary mounted when not visible. Column's action menu are then not mounted, improving performance of DataSetViewer.
+
 ### Fixed
 
 - Fixed bad sort step from initialization

--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <popover :active="isActive" :align="alignLeft" bottom>
+  <popover :visible="visible" :align="alignLeft" bottom @closed="close">
     <div class="action-menu__body">
       <div class="action-menu__section">
         <div class="action-menu__option" @click="createStep('duplicate')">Duplicate column</div>
@@ -15,7 +15,7 @@
   </popover>
 </template>
 <script lang="ts">
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import { POPOVER_ALIGN } from '@/components/constants';
 import { Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
@@ -32,16 +32,16 @@ import Popover from './Popover.vue';
 })
 export default class ActionMenu extends Vue {
   @Prop({
-    type: Boolean,
-    default: () => false,
-  })
-  isActive!: boolean;
-
-  @Prop({
     type: String,
     default: () => '',
   })
   columnName!: string;
+
+  @Prop({
+    type: Boolean,
+    default: true,
+  })
+  visible!: boolean;
 
   @VQBModule.Getter computedActiveStepIndex!: number;
   @VQBModule.Getter isEditingStep!: boolean;
@@ -52,18 +52,6 @@ export default class ActionMenu extends Vue {
   @VQBModule.Mutation closeStepForm!: () => void;
 
   alignLeft: string = POPOVER_ALIGN.LEFT;
-
-  /**
-   * @description Close the popover when clicking outside
-   */
-  clickListener(e: Event) {
-    const target = e.target as HTMLElement;
-    const hasClickOnItSelf = target === this.$el || this.$el.contains(target);
-
-    if (!hasClickOnItSelf) {
-      this.close();
-    }
-  }
 
   close() {
     this.$emit('closed');
@@ -106,15 +94,6 @@ export default class ActionMenu extends Vue {
     this.setPipeline({ pipeline: newPipeline });
     this.selectStep({ index });
     this.close();
-  }
-
-  @Watch('isActive')
-  onIsActiveChanged(val: boolean) {
-    if (val) {
-      window.addEventListener('click', this.clickListener, { capture: true });
-    } else {
-      window.removeEventListener('click', this.clickListener, { capture: true });
-    }
   }
 }
 </script>

--- a/src/components/ActionToolbarButton.vue
+++ b/src/components/ActionToolbarButton.vue
@@ -2,7 +2,7 @@
   <button type="button" class="action-toolbar__btn">
     <i :class="`action-toolbar__btn-icon fas fa-${icon}`" />
     <span class="action-toolbar__btn-txt">{{ label }}</span>
-    <popover :active="isActive" :align="'left'" bottom>
+    <popover :visible="isActive" :align="'left'" bottom @closed="$emit('closed')">
       <div class="action-menu__body">
         <div class="action-menu__section">
           <div
@@ -21,7 +21,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { Component, Prop, Watch } from 'vue-property-decorator';
+import { Component, Prop } from 'vue-property-decorator';
 
 import { ACTION_CATEGORIES, POPOVER_ALIGN } from '@/components/constants';
 import * as S from '@/lib/steps';
@@ -69,18 +69,6 @@ export default class ActionToolbarButton extends Vue {
   @VQBModule.Mutation closeStepForm!: () => void;
 
   /**
-   * @description Close the popover when clicking outside
-   */
-  clickListener(e: Event) {
-    const target = e.target as HTMLElement;
-    const hasClickOnItSelf = target === this.$el || this.$el.contains(target);
-
-    if (!hasClickOnItSelf) {
-      this.close();
-    }
-  }
-
-  /**
    * @description Emit an event with a PipelineStepName in order to open its form
    */
   actionClicked(stepName: S.PipelineStepName, defaults = {}) {
@@ -98,6 +86,7 @@ export default class ActionToolbarButton extends Vue {
     } else {
       this.$emit('actionClicked', stepName, defaults);
     }
+    this.$emit('closed');
   }
 
   createStep(stepName: NoFormStep['name'], defaults: { [prop: string]: any } = {}) {
@@ -114,24 +103,10 @@ export default class ActionToolbarButton extends Vue {
     newPipeline.splice(index, 0, step as S.PipelineStep);
     this.setPipeline({ pipeline: newPipeline });
     this.selectStep({ index });
-    this.close();
   }
 
   get items() {
     return ACTION_CATEGORIES[this.category];
-  }
-
-  close() {
-    this.$emit('closed');
-  }
-
-  @Watch('isActive')
-  onIsActiveChanged(val: boolean) {
-    if (val) {
-      window.addEventListener('click', this.clickListener, { capture: true });
-    } else {
-      window.removeEventListener('click', this.clickListener, { capture: true });
-    }
   }
 }
 </script>

--- a/src/components/DataTypesMenu.vue
+++ b/src/components/DataTypesMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <popover :active="isActive" :align="alignLeft" bottom>
+  <popover :visible="visible" :align="alignLeft" bottom @closed="close">
     <div class="data-types-menu__body">
       <div class="data-types-menu__section">
         <div class="data-types-menu__option" @click="createConvertStep('integer')">
@@ -31,7 +31,7 @@
   </popover>
 </template>
 <script lang="ts">
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import { POPOVER_ALIGN } from '@/components/constants';
 import { ConvertStep, Pipeline } from '@/lib/steps';
@@ -50,16 +50,16 @@ type dataType = 'boolean' | 'date' | 'float' | 'integer' | 'text';
 })
 export default class DataTypesMenu extends Vue {
   @Prop({
-    type: Boolean,
-    default: () => false,
-  })
-  isActive!: boolean;
-
-  @Prop({
     type: String,
     default: () => '',
   })
   columnName!: string;
+
+  @Prop({
+    type: Boolean,
+    default: true,
+  })
+  visible!: boolean;
 
   @VQBModule.Getter computedActiveStepIndex!: number;
   @VQBModule.Getter isEditingStep!: boolean;
@@ -70,18 +70,6 @@ export default class DataTypesMenu extends Vue {
   @VQBModule.Mutation closeStepForm!: () => void;
 
   alignLeft: string = POPOVER_ALIGN.LEFT;
-
-  /**
-   * @description Close the popover when clicking outside
-   */
-  clickListener(e: Event) {
-    const target = e.target as HTMLElement;
-    const hasClickOnItSelf = target === this.$el || this.$el.contains(target);
-
-    if (!hasClickOnItSelf) {
-      this.close();
-    }
-  }
 
   close() {
     this.$emit('closed');
@@ -104,15 +92,6 @@ export default class DataTypesMenu extends Vue {
     this.setPipeline({ pipeline: newPipeline });
     this.selectStep({ index });
     this.close();
-  }
-
-  @Watch('isActive')
-  onIsActiveChanged(val: boolean) {
-    if (val) {
-      window.addEventListener('click', this.clickListener, { capture: true });
-    } else {
-      window.removeEventListener('click', this.clickListener, { capture: true });
-    }
   }
 }
 </script>

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -14,26 +14,23 @@
                 @click="toggleColumnSelection({ column: column.name })"
               >
                 <span v-if="column.type" :class="iconClass" @click.stop="openDataTypeMenu(index)">
-                  <span v-html="getIconType(column.type)" />
                   <DataTypesMenu
-                    v-if="isSupported('convert')"
                     :column-name="column.name"
-                    :is-active="column.isDataTypeMenuOpened"
+                    :visible="isSupported('convert') && column.isDataTypeMenuOpened"
                     @closed="closeDataTypeMenu"
                   />
+                  <span v-html="getIconType(column.type)" />
                 </span>
                 <span class="data-viewer__header-label">{{ column.name }}</span>
-                <i
-                  class="data-viewer__header-action fas fa-angle-down"
-                  @click.stop="openMenu(index)"
-                >
+                <span class="data-viewer__header-action" @click.stop="openMenu(index)">
                   <ActionMenu
                     :column-name="column.name"
-                    :is-active="column.isActionMenuOpened"
+                    :visible="column.isActionMenuOpened"
                     @closed="closeMenu"
                     @actionClicked="openStepForm"
                   />
-                </i>
+                  <i class="fas fa-angle-down" />
+                </span>
               </td>
             </tr>
           </thead>
@@ -339,7 +336,6 @@ export default class DataViewer extends Vue {
   width: 18px;
   height: 18px;
   border-radius: 4px;
-  align-items: center;
   justify-content: center;
 }
 

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -10,21 +10,10 @@ const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Action Menu', () => {
-  it('should instantiate with its popover hidden', () => {
+  it('should instantiate with the popover', () => {
     const wrapper = mount(ActionMenu);
-
     expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.classes()).not.toContain('popover--active');
-  });
-
-  it('should instantiate with the popover active', () => {
-    const wrapper = mount(ActionMenu, {
-      propsData: {
-        isActive: true,
-      },
-    });
-
-    expect(wrapper.classes()).toContain('popover--active');
+    expect(wrapper.classes()).toContain('popover-container');
   });
 
   it('should have an "Rename column" action', () => {

--- a/tests/unit/action-toolbar-button.spec.ts
+++ b/tests/unit/action-toolbar-button.spec.ts
@@ -2,6 +2,7 @@ import { createLocalVue, mount } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import ActionToolbarButton from '@/components/ActionToolbarButton.vue';
+import Popover from '@/components/Popover.vue';
 import { VQBnamespace } from '@/store';
 
 import { buildStateWithOnePipeline, setupMockStore } from './utils';
@@ -63,21 +64,49 @@ function assertMenuEmitsExpected(wrapper: VueMountedType, expectedEmits: emitPar
   return actionsWrappers;
 }
 
-describe('ActionToolbarButton', () => {
+describe('ActionToolbarButton not active', () => {
+  it('should instantiate with icon an label', () => {
+    const wrapper = mount(ActionToolbarButton, {
+      propsData: { category: 'add', label: 'toto', icon: 'plop' },
+      localVue,
+    });
+    expect(wrapper.find('.action-toolbar__btn-txt').text()).toEqual('toto');
+    expect(wrapper.find('.fa-plop').exists()).toBeTruthy();
+  });
+
+  it('should instantiate without popover', () => {
+    const wrapper = mount(ActionToolbarButton, {
+      propsData: { category: 'add' },
+      localVue,
+    });
+    expect(wrapper.find(Popover).vm.$props.visible).toBeFalsy();
+  });
+});
+
+describe('ActionToolbarButton active', () => {
   it('should instantiate an Add button with the right list of actions', () => {
-    const wrapper = mount(ActionToolbarButton, { propsData: { category: 'add' }, localVue });
+    const wrapper = mount(ActionToolbarButton, {
+      propsData: { isActive: true, category: 'add' },
+      localVue,
+    });
     expect(wrapper.exists()).toBeTruthy();
     assertMenuEmitsExpected(wrapper, ['text', 'formula', 'custom']);
   });
 
   it('should instantiate a Filter button with the right list of actions', () => {
-    const wrapper = mount(ActionToolbarButton, { propsData: { category: 'filter' }, localVue });
+    const wrapper = mount(ActionToolbarButton, {
+      propsData: { isActive: true, category: 'filter' },
+      localVue,
+    });
     expect(wrapper.exists()).toBeTruthy();
     assertMenuEmitsExpected(wrapper, ['delete', 'select', 'filter', 'top', 'argmax', 'argmin']);
   });
 
   it('should instantiate a Compute button with the right list of actions', () => {
-    const wrapper = mount(ActionToolbarButton, { propsData: { category: 'compute' }, localVue });
+    const wrapper = mount(ActionToolbarButton, {
+      propsData: { isActive: true, category: 'compute' },
+      localVue,
+    });
     expect(wrapper.exists()).toBeTruthy();
     assertMenuEmitsExpected(wrapper, ['formula', 'evolution', 'cumsum', 'percentage']);
   });
@@ -87,7 +116,7 @@ describe('ActionToolbarButton', () => {
     // such as 'lowercase' can be triggered without creating a form.
     const store = setupMockStore(buildStateWithOnePipeline([], { selectedColumns: ['foo'] }));
     const wrapper = mount(ActionToolbarButton, {
-      propsData: { category: 'text' },
+      propsData: { isActive: true, category: 'text' },
       localVue,
       store,
     });
@@ -104,7 +133,7 @@ describe('ActionToolbarButton', () => {
 
   it('should instantiate a Date button with the right list of actions', () => {
     const wrapper = mount(ActionToolbarButton, {
-      propsData: { category: 'date' },
+      propsData: { isActive: true, category: 'date' },
       store: setupMockStore(),
       localVue,
     });
@@ -131,19 +160,28 @@ describe('ActionToolbarButton', () => {
   });
 
   it('should instantiate an Aggregate button with the right list of actions', () => {
-    const wrapper = mount(ActionToolbarButton, { propsData: { category: 'aggregate' }, localVue });
+    const wrapper = mount(ActionToolbarButton, {
+      propsData: { isActive: true, category: 'aggregate' },
+      localVue,
+    });
     expect(wrapper.exists()).toBeTruthy();
     assertMenuEmitsExpected(wrapper, ['aggregate', 'rollup', 'uniquegroups']);
   });
 
   it('should instantiate a Reshape button with the right list of actions', () => {
-    const wrapper = mount(ActionToolbarButton, { propsData: { category: 'reshape' }, localVue });
+    const wrapper = mount(ActionToolbarButton, {
+      propsData: { isActive: true, category: 'reshape' },
+      localVue,
+    });
     expect(wrapper.exists()).toBeTruthy();
     assertMenuEmitsExpected(wrapper, ['pivot', 'unpivot']);
   });
 
   it('should instantiate a Combine button with the right list of actions', () => {
-    const wrapper = mount(ActionToolbarButton, { propsData: { category: 'combine' }, localVue });
+    const wrapper = mount(ActionToolbarButton, {
+      propsData: { isActive: true, category: 'combine' },
+      localVue,
+    });
     expect(wrapper.exists()).toBeTruthy();
     assertMenuEmitsExpected(wrapper, ['append', 'join']);
   });
@@ -156,7 +194,7 @@ describe('ActionToolbarButton', () => {
         }),
       );
       const wrapper = mount(ActionToolbarButton, {
-        propsData: { category: 'text' },
+        propsData: { isActive: true, category: 'text' },
         store,
         localVue,
       });
@@ -172,7 +210,7 @@ describe('ActionToolbarButton', () => {
         }),
       );
       const wrapper = mount(ActionToolbarButton, {
-        propsData: { category: 'text' },
+        propsData: { isActive: true, category: 'text' },
         store,
         localVue,
       });
@@ -192,7 +230,7 @@ describe('ActionToolbarButton', () => {
         }),
       );
       const wrapper = mount(ActionToolbarButton, {
-        propsData: { category: 'text' },
+        propsData: { isActive: true, category: 'text' },
         store,
         localVue,
       });
@@ -210,7 +248,7 @@ describe('ActionToolbarButton', () => {
         }),
       );
       const wrapper = mount(ActionToolbarButton, {
-        propsData: { category: 'text' },
+        propsData: { isActive: true, category: 'text' },
         store,
         localVue,
       });
@@ -226,7 +264,7 @@ describe('ActionToolbarButton', () => {
         }),
       );
       const wrapper = mount(ActionToolbarButton, {
-        propsData: { category: 'text' },
+        propsData: { isActive: true, category: 'text' },
         store,
         localVue,
       });
@@ -246,7 +284,7 @@ describe('ActionToolbarButton', () => {
         }),
       );
       const wrapper = mount(ActionToolbarButton, {
-        propsData: { category: 'text' },
+        propsData: { isActive: true, category: 'text' },
         store,
         localVue,
       });
@@ -264,7 +302,7 @@ describe('ActionToolbarButton', () => {
         }),
       );
       const wrapper = mount(ActionToolbarButton, {
-        propsData: { category: 'date' },
+        propsData: { isActive: true, category: 'date' },
         store,
         localVue,
       });
@@ -280,7 +318,7 @@ describe('ActionToolbarButton', () => {
         }),
       );
       const wrapper = mount(ActionToolbarButton, {
-        propsData: { category: 'date' },
+        propsData: { isActive: true, category: 'date' },
         store,
         localVue,
       });
@@ -300,7 +338,7 @@ describe('ActionToolbarButton', () => {
         }),
       );
       const wrapper = mount(ActionToolbarButton, {
-        propsData: { category: 'date' },
+        propsData: { isActive: true, category: 'date' },
         store,
         localVue,
       });
@@ -319,7 +357,7 @@ describe('ActionToolbarButton', () => {
           }),
         );
         const wrapper = mount(ActionToolbarButton, {
-          propsData: { category: 'date' },
+          propsData: { isActive: true, category: 'date' },
           store,
           localVue,
         });
@@ -339,7 +377,7 @@ describe('ActionToolbarButton', () => {
           }),
         );
         const wrapper = mount(ActionToolbarButton, {
-          propsData: { category: 'date' },
+          propsData: { isActive: true, category: 'date' },
           store,
           localVue,
         });

--- a/tests/unit/data-types-menu.spec.ts
+++ b/tests/unit/data-types-menu.spec.ts
@@ -10,20 +10,10 @@ const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Data Types Menu', () => {
-  it('should instantiate with its popover hidden', () => {
+  it('should instantiate with the popover', () => {
     const wrapper = mount(DataTypesMenu);
-
     expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.classes()).not.toContain('popover--active');
-  });
-
-  it('should instantiate with the popover active', () => {
-    const wrapper = mount(DataTypesMenu, {
-      propsData: {
-        isActive: true,
-      },
-    });
-    expect(wrapper.classes()).toContain('popover--active');
+    expect(wrapper.classes()).toContain('popover-container');
   });
 
   it('should contain the right set of data types', () => {


### PR DESCRIPTION
**Before**: to open the popover you set active props to “true” (and to close, you set active to “false”)
This is an issue, because the component is alway mounted. As popover is used twice (action menu and datatype menu) in column menu this may cause severe performance issue.
**Now**: to open the popover you use v-if (to not mount the component when not visible) or v-show (if you are ok to mount the component when not visible)
Notes:
  - The v-if or v-show cannot be use directly on the popober.It should be set on a safe html parent. This parent is used to set its position.
  - Update interface of all components that uses popover:
    - `DataTypesMenu` (inside `DataViewer`)
    - `ActionMenu`  (inside `DataViewer`)
    - `ActionToolbarButton` (inside `ActionToolbar`)