### PR TITLE
Filter editor :: fix missing error prop + add columnNames props

### DIFF
--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -5,6 +5,7 @@
         <FilterSimpleConditionWidget
           :value="slotProps.condition"
           @input="slotProps.updateCondition"
+          :columnNamesProp="columnNames"
           :data-path="slotProps.dataPath"
           :errors="errors"
         />
@@ -39,6 +40,12 @@ export default class FilterEditor extends Vue {
     default: () => ({ column: '', value: '', operator: 'eq' }),
   })
   filterTree!: FilterSimpleCondition | FilterComboAnd | FilterComboOr;
+
+  @Prop({
+    type: Array,
+    default: () => [],
+  })
+  columnNames!: string[];
 
   @Prop({
     type: Array,

--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -14,6 +14,7 @@
 </template>
 
 <script lang="ts">
+import { ErrorObject } from 'ajv';
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import ConditionsEditor from '@/components/ConditionsEditor/ConditionsEditor.vue';
@@ -38,6 +39,12 @@ export default class FilterEditor extends Vue {
     default: () => ({ column: '', value: '', operator: 'eq' }),
   })
   filterTree!: FilterSimpleCondition | FilterComboAnd | FilterComboOr;
+
+  @Prop({
+    type: Array,
+    default: () => [],
+  })
+  errors!: ErrorObject[];
 
   get conditionsTree() {
     return buildConditionsEditorTree(this.filterTree);

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -2,7 +2,11 @@
   <div class="filter-form">
     <StepFormHeader :title="title" :stepName="this.editedStep.name" />
     <div class="filter-form__info">Filter rows matching this condition:</div>
-    <FilterEditor :filter-tree="this.editedStep.condition" @filterTreeUpdated="updateFilterTree" />
+    <FilterEditor
+      :filter-tree="this.editedStep.condition"
+      :errors="errors"
+      @filterTreeUpdated="updateFilterTree"
+    />
     <StepFormButtonbar />
   </div>
 </template>

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -201,7 +201,7 @@ export default class FilterSimpleConditionWidget extends Vue {
   }
 }
 
-.multiselect__tags {
+.filter-form-simple-condition__container /deep/ .multiselect__tags {
   border-radius: 0;
   border: none;
 }

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -87,13 +87,19 @@ export default class FilterSimpleConditionWidget extends Vue {
   })
   value!: FilterSimpleCondition;
 
+  @Prop({
+    type: Array,
+    default: () => [],
+  })
+  columnNamesProp!: string[];
+
   @Prop({ type: String, default: '' })
   dataPath!: string;
 
   @Prop({ type: Array, default: () => [] })
   errors!: ErrorObject[];
 
-  @VQBModule.Getter columnNames!: string[];
+  @VQBModule.Getter('columnNames') columnNamesFromStore!: string[];
 
   @VQBModule.Mutation setSelectedColumns!: MutationCallbacks['setSelectedColumns'];
 
@@ -116,6 +122,16 @@ export default class FilterSimpleConditionWidget extends Vue {
     // In absence of condition, emit directly to the parent the default value
     if (isEqual(this.value, DEFAULT_FILTER)) {
       this.$emit('input', DEFAULT_FILTER);
+    }
+  }
+
+  get columnNames() {
+    if (this.columnNamesProp && this.columnNamesProp.length > 0) {
+      return this.columnNamesProp;
+    } else if (this.columnNamesFromStore && this.columnNamesFromStore.length > 0) {
+      return this.columnNamesFromStore;
+    } else {
+      return [];
     }
   }
 

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -125,6 +125,8 @@ export default class FilterSimpleConditionWidget extends Vue {
     }
   }
 
+  // Column names can be provided either in the store or via a prop
+  // The prop takes priority over the store
   get columnNames() {
     if (this.columnNamesProp && this.columnNamesProp.length > 0) {
       return this.columnNamesProp;

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -58,7 +58,7 @@ describe('Widget FilterSimpleCondition', () => {
     expect(multinnputtextWrappers.exists()).toBeFalsy();
   });
 
-  it('should instantiate a widgetAutocomplete widget with proper options from the store', () => {
+  it('should instantiate a widgetAutocomplete widget with column names from the store', () => {
     const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
@@ -68,6 +68,27 @@ describe('Widget FilterSimpleCondition', () => {
     const wrapper = shallowMount(FilterSimpleConditionWidget, { store, localVue });
     const widgetWrappers = wrapper.findAll('autocompletewidget-stub');
     expect(widgetWrappers.at(0).attributes('options')).toEqual('columnA,columnB,columnC');
+  });
+
+  it('should instantiate a widgetAutocomplete widget with column names from the prop', () => {
+    const wrapper = shallowMount(FilterSimpleConditionWidget, {
+      store: emptyStore,
+      localVue,
+      propsData: {
+        columnNamesProp: ['columnA', 'columnB', 'columnC'],
+      },
+    });
+    const widgetWrappers = wrapper.findAll('autocompletewidget-stub');
+    expect(widgetWrappers.at(0).attributes('options')).toEqual('columnA,columnB,columnC');
+  });
+
+  it('should instantiate a widgetAutocomplete widget with nothing', () => {
+    const wrapper = shallowMount(FilterSimpleConditionWidget, {
+      store: emptyStore,
+      localVue,
+    });
+    const widgetWrappers = wrapper.findAll('autocompletewidget-stub');
+    expect(widgetWrappers.at(0).attributes('options')).toEqual('');
   });
 
   it('should pass down the "column" prop to the first AutocompleteWidget value prop', async () => {


### PR DESCRIPTION
- Filter editor :: add missing error prop
   It was broken when added the new component FilterEditor here #493

- Filter editor :: add columnNames prop
   Add columnNames prop to permit to pass a list of column names from a dataset outside weaverbird

- Fix a CSS style not apply 