### PR TITLE
Fix: column unique values are of any type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# unreleased
+
+### Changed
+
+- `totalCount` becomes mandatory in `paginationContext` in DataSet
+
+### Fixed
+
+- pagination appears if DataSet is not complete 
+
+
 ## [0.16.0] - 2020-04-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - pagination appears if DataSet is not complete 
+- column unique values can be of any type
 
 
 ## [0.16.0] - 2020-04-29

--- a/src/components/ListUniqueValues.vue
+++ b/src/components/ListUniqueValues.vue
@@ -10,10 +10,10 @@
       <div
         class="list-unique-values__checkbox"
         v-for="option in searchedOptions"
-        :key="option.value"
+        :key="stringify(option.value)"
       >
         <CheckboxWidget
-          :label="`${option.value} (${option.count})`"
+          :label="`${stringify(option.value)} (${option.count})`"
           :value="isChecked(option)"
           @input="toggleCheck(option)"
         />
@@ -138,9 +138,16 @@ export default class ListUniqueValues extends Vue {
     return this.options.filter(option => this.searchFunction(option.value, this.search));
   }
 
-  // TODO: enhance `searchFunction`
-  searchFunction(value: string, search: string) {
-    return value.toLowerCase().startsWith(search.toLowerCase());
+  stringify(value: any): string {
+    return JSON.stringify(value)
+      .replace(/^"/, '')
+      .replace(/"$/, ''); // remove `"` introduce by JSON.stringify around strings;
+  }
+
+  searchFunction(value: any, search: string) {
+    return this.stringify(value)
+      .toLowerCase()
+      .includes(search.toLowerCase());
   }
 
   loadAllValues() {

--- a/src/lib/dataset/helpers.ts
+++ b/src/lib/dataset/helpers.ts
@@ -50,9 +50,9 @@ function localUniqueStats(dataset: DataSet) {
   for (const [, record] of enumerate(iterateRecords(dataset))) {
     for (const [colname, value] of Object.entries(record)) {
       const colRecord = columnValuesCount[colname];
-      const valueStringified = value instanceof Object ? JSON.stringify(value) : value;
+      const valueStringified = JSON.stringify(value);
       if (colRecord[valueStringified] === undefined) {
-        colRecord[valueStringified] = { value: valueStringified, count: 1 };
+        colRecord[valueStringified] = { value, count: 1 };
       } else {
         colRecord[valueStringified].count++;
       }

--- a/tests/unit/dataset.spec.ts
+++ b/tests/unit/dataset.spec.ts
@@ -460,9 +460,9 @@ describe('dataset local uniques computation', () => {
           name: 'population',
           uniques: {
             values: [
-              { value: '{"population":9}', count: 2 },
-              { value: '{"population":4}', count: 1 },
-              { value: '{"population":3}', count: 1 },
+              { value: { population: 9 }, count: 2 },
+              { value: { population: 4 }, count: 1 },
+              { value: { population: 3 }, count: 1 },
             ],
             loaded: true,
           },
@@ -561,9 +561,9 @@ describe('dataset local uniques computation', () => {
           name: 'population',
           uniques: {
             values: [
-              { value: '{"population":9}', count: 2 },
-              { value: '{"population":4}', count: 1 },
-              { value: '{"population":3}', count: 1 },
+              { value: { population: 9 }, count: 2 },
+              { value: { population: 4 }, count: 1 },
+              { value: { population: 3 }, count: 1 },
             ],
             loaded: false,
           },

--- a/tests/unit/list-unique-values.spec.ts
+++ b/tests/unit/list-unique-values.spec.ts
@@ -178,73 +178,113 @@ describe('List Unique Value', () => {
     });
   });
 
-  describe('search box with "in" operator', () => {
-    beforeEach(async () => {
-      const input = wrapper.find('.list-unique-values__search-box').element as HTMLInputElement;
-      input.value = 'Fr'; // "Fr" like the start of "France" and "Framboise"
-      await wrapper.find('.list-unique-values__search-box').trigger('input');
-    });
+  describe('search box', () => {
+    describe('with "in" operator', () => {
+      beforeEach(async () => {
+        const input = wrapper.find('.list-unique-values__search-box').element as HTMLInputElement;
+        input.value = 'Fr'; // "Fr" like the start of "France" and "Framboise"
+        await wrapper.find('.list-unique-values__search-box').trigger('input');
+      });
 
-    it('should filter the unique value when search on the searchbox', async () => {
-      const CheckboxWidgetArray = wrapper.findAll('CheckboxWidget-stub');
-      expect(CheckboxWidgetArray.length).toEqual(2);
-      expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('France (10)');
-      expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('Framboise (9)');
-    });
+      it('should filter the unique value when search on the searchbox', async () => {
+        const CheckboxWidgetArray = wrapper.findAll('CheckboxWidget-stub');
+        expect(CheckboxWidgetArray.length).toEqual(2);
+        expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('France (10)');
+        expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('Framboise (9)');
+      });
 
-    it('should emit new value when click "select all" button (with "in" operator)', async () => {
-      await wrapper.find('.list-unique-values__select-all').trigger('click');
-      // "France" and "Framboise" only should be updated:
-      expect(wrapper.emitted().input[0][0]).toEqual({
-        column: 'col1',
-        operator: 'in',
-        value: ['France', 'Spain', 'Framboise'],
+      it('should emit new value when click "select all" button (with "in" operator)', async () => {
+        await wrapper.find('.list-unique-values__select-all').trigger('click');
+        // "France" and "Framboise" only should be updated:
+        expect(wrapper.emitted().input[0][0]).toEqual({
+          column: 'col1',
+          operator: 'in',
+          value: ['France', 'Spain', 'Framboise'],
+        });
+      });
+
+      it('should emit new value when click "clear all" button (with "in" operator)', async () => {
+        await wrapper.find('.list-unique-values__clear-all').trigger('click');
+        // "France" and "Framboise" only should be updated
+        expect(wrapper.emitted().input[0][0]).toEqual({
+          column: 'col1',
+          operator: 'in',
+          value: ['Spain'],
+        });
       });
     });
 
-    it('should emit new value when click "clear all" button (with "in" operator)', async () => {
-      await wrapper.find('.list-unique-values__clear-all').trigger('click');
-      // "France" and "Framboise" only should be updated
-      expect(wrapper.emitted().input[0][0]).toEqual({
-        column: 'col1',
-        operator: 'in',
-        value: ['Spain'],
+    describe('with "nin" operator', () => {
+      beforeEach(async () => {
+        wrapper = shallowMountWrapper(['France', 'Spain'], 'nin');
+        const input = wrapper.find('.list-unique-values__search-box').element as HTMLInputElement;
+        input.value = 'Fr'; // "Fr" like the start of "France" and "Framboise"
+        await wrapper.find('.list-unique-values__search-box').trigger('input');
+      });
+
+      it('should filter the unique value when search on the searchbox', async () => {
+        const CheckboxWidgetArray = wrapper.findAll('CheckboxWidget-stub');
+        expect(CheckboxWidgetArray.length).toEqual(2);
+        expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('France (10)');
+        expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('Framboise (9)');
+      });
+
+      it('should emit new value when click "select all" button (with "nin" operator)', async () => {
+        await wrapper.find('.list-unique-values__select-all').trigger('click');
+        // "France" and "Framboise" only should be updated:
+        expect(wrapper.emitted().input[0][0]).toEqual({
+          column: 'col1',
+          operator: 'nin',
+          value: ['Spain'],
+        });
+      });
+
+      it('should emit new value when click "clear all" button (with "nin" operator)', async () => {
+        await wrapper.find('.list-unique-values__clear-all').trigger('click');
+        // "France" and "Framboise" only should be updated
+        expect(wrapper.emitted().input[0][0]).toEqual({
+          column: 'col1',
+          operator: 'nin',
+          value: ['France', 'Spain', 'Framboise'],
+        });
       });
     });
-  });
 
-  describe('search box with "nin" operator', () => {
-    beforeEach(async () => {
-      wrapper = shallowMountWrapper(['France', 'Spain'], 'nin');
-      const input = wrapper.find('.list-unique-values__search-box').element as HTMLInputElement;
-      input.value = 'Fr'; // "Fr" like the start of "France" and "Framboise"
-      await wrapper.find('.list-unique-values__search-box').trigger('input');
-    });
-
-    it('should filter the unique value when search on the searchbox', async () => {
-      const CheckboxWidgetArray = wrapper.findAll('CheckboxWidget-stub');
-      expect(CheckboxWidgetArray.length).toEqual(2);
-      expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('France (10)');
-      expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('Framboise (9)');
-    });
-
-    it('should emit new value when click "select all" button (with "nin" operator)', async () => {
-      await wrapper.find('.list-unique-values__select-all').trigger('click');
-      // "France" and "Framboise" only should be updated:
-      expect(wrapper.emitted().input[0][0]).toEqual({
-        column: 'col1',
-        operator: 'nin',
-        value: ['Spain'],
-      });
-    });
-
-    it('should emit new value when click "clear all" button (with "nin" operator)', async () => {
-      await wrapper.find('.list-unique-values__clear-all').trigger('click');
-      // "France" and "Framboise" only should be updated
-      expect(wrapper.emitted().input[0][0]).toEqual({
-        column: 'col1',
-        operator: 'nin',
-        value: ['France', 'Spain', 'Framboise'],
+    describe('with with object value', () => {
+      it('should filter the unique value when search on the searchbox', async () => {
+        wrapper = shallowMount(ListUniqueValues, {
+          store: setupMockStore({
+            dataset: {
+              headers: [{ name: 'col1' }],
+              data: [],
+            },
+          }),
+          localVue,
+          propsData: {
+            filter: {
+              column: 'col1',
+              operator: 'nin',
+              value: [],
+            },
+            options: [
+              { value: { population: 10 }, count: 12 },
+              { value: { population: 2 }, count: 9 },
+              { value: { population: 3 }, count: 4 },
+            ],
+            loaded: true,
+          },
+        });
+        let CheckboxWidgetArray = wrapper.findAll('CheckboxWidget-stub');
+        expect(CheckboxWidgetArray.length).toEqual(3);
+        expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('{"population":10} (12)');
+        expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('{"population":2} (9)');
+        expect(CheckboxWidgetArray.at(2).vm.$props.label).toEqual('{"population":3} (4)');
+        const input = wrapper.find('.list-unique-values__search-box').element as HTMLInputElement;
+        input.value = '2'; // "Fr" like the start of "France" and "Framboise"
+        await wrapper.find('.list-unique-values__search-box').trigger('input');
+        CheckboxWidgetArray = wrapper.findAll('CheckboxWidget-stub');
+        expect(CheckboxWidgetArray.length).toEqual(1);
+        expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('{"population":2} (9)');
       });
     });
   });


### PR DESCRIPTION
In state, unique values of a column can be of any type. Thus, in ListUnqiueValues we must be careful to stringify them any time it is necessary. For search, for display and for v-for key.