### PR TITLE
Fix popover position

### DIFF
--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -102,7 +102,7 @@ describe('Action Menu', () => {
   it('should instantiate with popover', async () => {
     const { wrapper } = await mountWrapper(false, true);
     expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.classes()).toContain('popover-container');
+    expect(wrapper.classes()).toContain('popover');
   });
 
   it('should not display the apply filter button', async () => {

--- a/tests/unit/data-types-menu.spec.ts
+++ b/tests/unit/data-types-menu.spec.ts
@@ -13,7 +13,7 @@ describe('Data Types Menu', () => {
   it('should instantiate with the popover', () => {
     const wrapper = mount(DataTypesMenu);
     expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.classes()).toContain('popover-container');
+    expect(wrapper.classes()).toContain('popover');
   });
 
   it('should contain the right set of data types', () => {

--- a/tests/unit/popover.spec.ts
+++ b/tests/unit/popover.spec.ts
@@ -239,187 +239,100 @@ describe('Popover', function() {
     expect(slotContentWrapper.text()).toEqual('Lorem ipsum');
   });
 
-  it('should append itself to the document body', function() {
-    createWrapper({ props: { visible: true } });
-
-    expect(popoverWrapper.element.parentElement).toEqual(document.body);
-  });
-
-  it('should remove its DOM upon destruction', function() {
-    createWrapper({ props: { visible: true } });
-    popoverWrapper.destroy();
-
-    expect(document.body.querySelector('.tc-popover')).toBeNull();
-  });
-
-  it('should be above by default', async function() {
-    createWrapper({
-      props: { visible: true },
-      parentStyle: {
-        height: '40px',
-        left: '200px',
-        position: 'absolute',
-        top: '200px',
-        width: '100px',
-      },
-    });
-
-    await wrapper.vm.$nextTick();
-    const parentBounds = wrapper.element.getBoundingClientRect();
-    const popoverBounds = popoverWrapper.vm.$data.elementStyle;
-
-    expect(popoverBounds.top).toEqual(`${parentBounds.top - POPOVER_SHADOW_GAP}px`);
-    expect(popoverBounds.left).toEqual(`${parentBounds.left + 100 / 2}px`);
-  });
-
-  it('should update its position on orientation change', async function() {
-    createWrapper({
-      props: { visible: true },
-      parentStyle: {
-        height: '40px',
-        left: '200px',
-        position: 'absolute',
-        top: '200px',
-        width: '100px',
-      },
-    });
-    const popoverWrapper = wrapper.find({ ref: 'popover' });
-
-    await wrapper.vm.$nextTick();
-    wrapper.element.style.left = '100px';
-    window.dispatchEvent(new Event('orientationchange'));
-
-    await wrapper.vm.$nextTick();
-    const parentBounds = wrapper.element.getBoundingClientRect();
-    const popoverBounds = popoverWrapper.vm.$data.elementStyle;
-
-    expect(popoverBounds.left).toEqual(`${parentBounds.left + 100 / 2}px`);
-  });
-
-  it('should update its position when resized', async function() {
-    createWrapper({
-      props: { visible: true },
-      parentStyle: {
-        height: '40px',
-        left: '200px',
-        position: 'absolute',
-        top: '200px',
-        width: '100px',
-      },
-      slotStyle: {
-        height: '140px',
-        width: '140px',
-      },
-    });
-    const popoverWrapper = wrapper.find({ ref: 'popover' });
-
-    await wrapper.vm.$nextTick();
-    wrapper.element.style.left = '100px';
-    window.dispatchEvent(new Event('resize'));
-
-    await wrapper.vm.$nextTick();
-    const parentBounds = wrapper.element.getBoundingClientRect();
-    const popoverBounds = popoverWrapper.vm.$data.elementStyle;
-
-    expect(popoverBounds.left).toEqual(`${parentBounds.left + 100 / 2}px`);
-  });
-
-  it('should update its position when scrolled', async function() {
-    createWrapper({
-      props: { visible: true },
-      parentStyle: {
-        height: '40px',
-        left: '200px',
-        position: 'absolute',
-        top: '200px',
-        width: '100px',
-      },
-      slotStyle: {
-        height: '140px',
-        width: '140px',
-      },
-    });
-    const popoverWrapper = wrapper.find({ ref: 'popover' });
-
-    await wrapper.vm.$nextTick();
-    wrapper.element.style.left = '100px';
-    wrapper.element.dispatchEvent(new Event('scroll'));
-
-    await wrapper.vm.$nextTick();
-    const parentBounds = wrapper.element.getBoundingClientRect();
-    const popoverBounds = popoverWrapper.vm.$data.elementStyle;
-
-    expect(popoverBounds.left).toEqual(`${parentBounds.left + 100 / 2}px`);
-  });
-
-  it('should emit "closed" on click away', async function() {
-    createWrapper({
-      props: { visible: true },
-      parentStyle: {
-        height: '40px',
-        left: '200px',
-        position: 'absolute',
-        top: '200px',
-        width: '100px',
-      },
-      slotStyle: {
-        height: '140px',
-        width: '140px',
-      },
-    });
-    const popoverWrapper = wrapper.find({ ref: 'popover' });
-    const anotherelement = wrapper.find('#anotherelement');
-    await wrapper.vm.$nextTick();
-
-    await anotherelement.trigger('click');
-    await wrapper.vm.$nextTick();
-    expect(popoverWrapper.emitted().closed.length).toEqual(1);
-  });
-
-  it('should not emit "closed" on click on it', async function() {
-    createWrapper({
-      props: { visible: true },
-      parentStyle: {
-        height: '40px',
-        left: '200px',
-        position: 'absolute',
-        top: '200px',
-        width: '100px',
-      },
-      slotStyle: {
-        height: '140px',
-        width: '140px',
-      },
-    });
-    const popoverWrapper = wrapper.find({ ref: 'popover' });
-    await wrapper.vm.$nextTick();
-
-    await popoverWrapper.trigger('click');
-    await wrapper.vm.$nextTick();
-    expect(popoverWrapper.emitted().closed).toBeUndefined();
-  });
-
   it('should not emit "closed" when not visible', async function() {
-    createWrapper({
-      props: { visible: false },
-      parentStyle: {
-        height: '40px',
-        left: '200px',
-        position: 'absolute',
-        top: '200px',
-        width: '100px',
-      },
-      slotStyle: {
-        height: '140px',
-        width: '140px',
-      },
-    });
-    const popoverWrapper = wrapper.find({ ref: 'popover' });
+    createWrapper({ props: { visible: false }, slotText: 'Lorem ipsum' });
     const anotherelement = wrapper.find('#anotherelement');
-    await wrapper.vm.$nextTick();
-
     await anotherelement.trigger('click');
     await wrapper.vm.$nextTick();
     expect(popoverWrapper.emitted().closed).toBeUndefined();
+  });
+
+  describe('setupPositioning', function() {
+    beforeEach(async function() {
+      createWrapper({
+        props: { visible: true },
+        parentStyle: {
+          height: '40px',
+          left: '200px',
+          position: 'absolute',
+          top: '200px',
+          width: '100px',
+        },
+        slotStyle: {
+          height: '140px',
+          width: '140px',
+        },
+      });
+      await popoverWrapper.vm.$nextTick();
+    });
+
+    it('should call setupPositioning when visible becomes true', async function() {
+      createWrapper({ props: { visible: false } });
+      const setupPositioningSpy: any = jest.spyOn(popoverWrapper.vm as any, 'setupPositioning');
+      popoverWrapper.setProps({ visible: true });
+      await popoverWrapper.vm.$nextTick();
+      expect(setupPositioningSpy).toHaveBeenCalled();
+    });
+
+    it('should append itself to the document body', function() {
+      expect(popoverWrapper.element.parentElement).toEqual(document.body);
+    });
+
+    it('should be above by default', function() {
+      const parentBounds = wrapper.element.getBoundingClientRect();
+      const popoverBounds = popoverWrapper.vm.$data.elementStyle;
+      expect(popoverBounds.top).toEqual(`${parentBounds.top - POPOVER_SHADOW_GAP}px`);
+      expect(popoverBounds.left).toEqual(`${parentBounds.left + 100 / 2}px`);
+    });
+
+    it('should update its position on orientation change', async function() {
+      wrapper.element.style.left = '100px';
+      window.dispatchEvent(new Event('orientationchange'));
+      await wrapper.vm.$nextTick();
+      const parentBounds = wrapper.element.getBoundingClientRect();
+      const popoverBounds = popoverWrapper.vm.$data.elementStyle;
+      expect(popoverBounds.left).toEqual(`${parentBounds.left + 100 / 2}px`);
+    });
+
+    it('should update its position when resized', async function() {
+      wrapper.element.style.left = '100px';
+      window.dispatchEvent(new Event('resize'));
+      await wrapper.vm.$nextTick();
+      const parentBounds = wrapper.element.getBoundingClientRect();
+      const popoverBounds = popoverWrapper.vm.$data.elementStyle;
+      expect(popoverBounds.left).toEqual(`${parentBounds.left + 100 / 2}px`);
+    });
+
+    it('should update its position when scrolled', async function() {
+      wrapper.element.style.left = '100px';
+      wrapper.element.dispatchEvent(new Event('scroll'));
+      await wrapper.vm.$nextTick();
+      const parentBounds = wrapper.element.getBoundingClientRect();
+      const popoverBounds = popoverWrapper.vm.$data.elementStyle;
+      expect(popoverBounds.left).toEqual(`${parentBounds.left + 100 / 2}px`);
+    });
+
+    it('should emit "closed" on click away', async function() {
+      const anotherelement = wrapper.find('#anotherelement');
+      await anotherelement.trigger('click');
+      await wrapper.vm.$nextTick();
+      expect(popoverWrapper.emitted().closed.length).toEqual(1);
+    });
+
+    it('should not emit "closed" on click on it', async function() {
+      await popoverWrapper.trigger('click');
+      await wrapper.vm.$nextTick();
+      expect(popoverWrapper.emitted().closed).toBeUndefined();
+    });
+  });
+
+  describe('destroyPositioning', function() {
+    it('should call destroyPosition when visible becomes false', async function() {
+      createWrapper({ props: { visible: true } });
+      await popoverWrapper.vm.$nextTick();
+      const destroyPositioningSpy: any = jest.spyOn(popoverWrapper.vm as any, 'destroyPositioning');
+      popoverWrapper.setProps({ visible: false });
+      expect(destroyPositioningSpy).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Before:
  - the positioning is done when popover is mounted
  - as the content is generaly hidden when pover is mounted, we compute the position without the good dimension of the content (the with is 0, because content does not exists)
Now:
  - the positioning computation happens when the "visible" props becomes "true". It waits the content to appear before computing position.

Before:
![image](https://user-images.githubusercontent.com/15191323/81344826-c82c9000-90b7-11ea-804a-cdcbda6bded8.png)


After: 
![image](https://user-images.githubusercontent.com/15191323/81344678-8996d580-90b7-11ea-8ec2-1a03705b3884.png)


