### PR TITLE
Fix popover mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 - `FilterEditor` form widgets supports variables that user can choose from a list
 
+### Fixed
+
+- Popover positioning and mount
+
 ## [0.16.1] - 2020-05-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Popover positioning and mount
+- `ActionMenu` always open on first panel, even if user has previously open the second panel
 
 ## [0.16.1] - 2020-05-05
 

--- a/playground/app.js
+++ b/playground/app.js
@@ -224,15 +224,11 @@ async function buildVueApp() {
           pipeline: [
             {
               name: 'domain',
-              domain: 'sales',
+              domain: 'data',
             },
             {
-              name: 'filter',
-              condition: {
-                column: 'Price',
-                operator: 'ge',
-                value: 1200,
-              },
+              name: 'custom',
+              query: '{"$limit":50}'
             }
           ],
           pipelineAmex: [

--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -115,6 +115,7 @@ export default class ActionMenu extends Vue {
   }
 
   close() {
+    this.visiblePanel = 1;
     this.$emit('closed');
   }
 

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -301,5 +301,33 @@ describe('Action Menu', () => {
         expect(store.getters[VQBnamespace('isEditingStep')]).toBeFalsy();
       });
     });
+
+    it('should always open on first panel', async () => {
+      const { wrapper } = await mountWrapperAndClickOnOperation();
+      wrapper.vm.close();
+      await wrapper.vm.$nextTick();
+      wrapper.setProps({ visible: true });
+      await wrapper.vm.$nextTick();
+
+      let el: PanelElement;
+      for (el of FIRST_PANEL) {
+        expect(wrapper.html()).toContain(el.label);
+      }
+      for (el of SECOND_PANEL) {
+        expect(wrapper.html()).not.toContain(el.label);
+      }
+
+      expect(wrapper.find('ListUniqueValues-stub').exists()).toBeTruthy();
+      expect(wrapper.find('ListUniqueValues-stub').vm.$props.loaded).toEqual(false);
+      expect(wrapper.find('ListUniqueValues-stub').vm.$props.filter).toEqual({
+        column: 'dreamfall',
+        value: [],
+        operator: 'nin',
+      });
+      expect(wrapper.find('ListUniqueValues-stub').vm.$props.options).toEqual([
+        { value: 'jjg', count: 2 },
+        { value: 'mika', count: 1 },
+      ]);
+    });
   });
 });

--- a/tests/unit/popover.spec.ts
+++ b/tests/unit/popover.spec.ts
@@ -243,7 +243,7 @@ describe('Popover', function() {
     createWrapper({ props: { visible: false }, slotText: 'Lorem ipsum' });
     const anotherelement = wrapper.find('#anotherelement');
     await anotherelement.trigger('click');
-    await wrapper.vm.$nextTick();
+
     expect(popoverWrapper.emitted().closed).toBeUndefined();
   });
 
@@ -263,14 +263,13 @@ describe('Popover', function() {
           width: '140px',
         },
       });
-      await popoverWrapper.vm.$nextTick();
     });
 
     it('should call setupPositioning when visible becomes true', async function() {
       createWrapper({ props: { visible: false } });
       const setupPositioningSpy: any = jest.spyOn(popoverWrapper.vm as any, 'setupPositioning');
       popoverWrapper.setProps({ visible: true });
-      await popoverWrapper.vm.$nextTick();
+
       expect(setupPositioningSpy).toHaveBeenCalled();
     });
 
@@ -288,7 +287,7 @@ describe('Popover', function() {
     it('should update its position on orientation change', async function() {
       wrapper.element.style.left = '100px';
       window.dispatchEvent(new Event('orientationchange'));
-      await wrapper.vm.$nextTick();
+
       const parentBounds = wrapper.element.getBoundingClientRect();
       const popoverBounds = popoverWrapper.vm.$data.elementStyle;
       expect(popoverBounds.left).toEqual(`${parentBounds.left + 100 / 2}px`);
@@ -297,7 +296,7 @@ describe('Popover', function() {
     it('should update its position when resized', async function() {
       wrapper.element.style.left = '100px';
       window.dispatchEvent(new Event('resize'));
-      await wrapper.vm.$nextTick();
+
       const parentBounds = wrapper.element.getBoundingClientRect();
       const popoverBounds = popoverWrapper.vm.$data.elementStyle;
       expect(popoverBounds.left).toEqual(`${parentBounds.left + 100 / 2}px`);
@@ -306,7 +305,7 @@ describe('Popover', function() {
     it('should update its position when scrolled', async function() {
       wrapper.element.style.left = '100px';
       wrapper.element.dispatchEvent(new Event('scroll'));
-      await wrapper.vm.$nextTick();
+
       const parentBounds = wrapper.element.getBoundingClientRect();
       const popoverBounds = popoverWrapper.vm.$data.elementStyle;
       expect(popoverBounds.left).toEqual(`${parentBounds.left + 100 / 2}px`);
@@ -315,13 +314,13 @@ describe('Popover', function() {
     it('should emit "closed" on click away', async function() {
       const anotherelement = wrapper.find('#anotherelement');
       await anotherelement.trigger('click');
-      await wrapper.vm.$nextTick();
+
       expect(popoverWrapper.emitted().closed.length).toEqual(1);
     });
 
     it('should not emit "closed" on click on it', async function() {
       await popoverWrapper.trigger('click');
-      await wrapper.vm.$nextTick();
+
       expect(popoverWrapper.emitted().closed).toBeUndefined();
     });
   });
@@ -329,10 +328,26 @@ describe('Popover', function() {
   describe('destroyPositioning', function() {
     it('should call destroyPosition when visible becomes false', async function() {
       createWrapper({ props: { visible: true } });
-      await popoverWrapper.vm.$nextTick();
+
       const destroyPositioningSpy: any = jest.spyOn(popoverWrapper.vm as any, 'destroyPositioning');
       popoverWrapper.setProps({ visible: false });
       expect(destroyPositioningSpy).toHaveBeenCalled();
+    });
+
+    it('should call destroyPosition at destroy if visible', async function() {
+      createWrapper({ props: { visible: true } });
+
+      const destroyPositioningSpy: any = jest.spyOn(popoverWrapper.vm as any, 'destroyPositioning');
+      popoverWrapper.destroy();
+      expect(destroyPositioningSpy).toHaveBeenCalled();
+    });
+
+    it('should not call destroyPosition at destroy if not visible', async function() {
+      createWrapper({ props: { visible: false } });
+
+      const destroyPositioningSpy: any = jest.spyOn(popoverWrapper.vm as any, 'destroyPositioning');
+      popoverWrapper.destroy();
+      expect(destroyPositioningSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Remove immediate watch on "visible" prop and handle the behaviour at mounted and destroy
Before: if popover is destroyed when visible is true, the slot content is never remove from DOM because destroyPositioning has not been called
Now: at popover destroy, the slot content is cleaned from DOM