### PR TITLE
BackendMessages :: Allow to display warnings even if data is displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- The way we handle backendMessages (error/warning) by `BackendService`
+
 ## [0.17.0] - 2020-05-12
 
 ### Added

--- a/playground/app.js
+++ b/playground/app.js
@@ -123,12 +123,14 @@ class MongoService {
         dataset = annotateDataset(dataset, types[0]);
         dataset = autocastDataset(dataset);
       }
-      return {
-        data: dataset,
-      };
+      const response = { data: dataset };
+      if (dataset.paginationContext.totalCount > 50) {
+        response.warning = [{ type: 'warning', message: 'Il y a plus de 50 lignes dans le dataset'}];
+      }
+      return response;
     } else {
       return {
-        error: responseContent.errmsg,
+        error: [{type: 'error', message: responseContent.errmsg}],
       };
     }
   }
@@ -183,13 +185,11 @@ async function setupInitialData(store, domain = null) {
       store.state[VQB_MODULE_NAME].pagesize,
     );
     if (response.error) {
-      store.commit(VQBnamespace('logBackendError'), {
-        backendError: {
-          type: 'error',
-          error: response.error,
-        },
-      });
+      store.commit(VQBnamespace('logBackendMessages'), { backendMessages: response.error } );
     } else {
+      if (response.warning) {
+        store.commit(VQBnamespace('logBackendMessages'), { backendMessages: response.warning });
+      }
       store.commit(VQBnamespace('setDataset'), {
         dataset: response.data,
       });
@@ -306,8 +306,14 @@ async function buildVueApp() {
       thereIsABackendError: function() {
         return this.$store.getters[VQBnamespace('thereIsABackendError')];
       },
-      backendErrorMessage: function() {
-        return this.$store.getters[VQBnamespace('backendErrorMessages')].join('<br/>');
+      backendMessages: function() {
+        return this.$store.state[VQB_MODULE_NAME].backendMessages;
+      },
+      backendErrors: function() {
+        return this.backendMessages.filter(({type}) => type === 'error');
+      },
+      backendWarnings: function() {
+        return this.backendMessages.filter(({type}) => type === 'warning');
       },
     },
     methods: {

--- a/playground/dist/index.html
+++ b/playground/dist/index.html
@@ -88,6 +88,15 @@
         color: white;
         padding: 10px;
       }
+
+      .warning-message {
+        position: absolute;
+        right: 0;
+        top: 0;
+        background: orange;
+        color: white;
+        padding: 10px;
+      }
     </style>
   </head>
 
@@ -106,8 +115,11 @@
         Hide code
       </button>
       <pre v-show="isCodeOpened"><code>{{ code }}</code></pre>
-      <div class="error-message" v-if="thereIsABackendError">
-        <i class="fas fa-exclamation-triangle"></i> {{ backendErrorMessage }}
+      <div class="warning-message" v-if="backendWarnings.length" v-for="warning in backendWarnings">
+        <i class="fas fa-exclamation-triangle"></i> {{ warning.message }}
+      </div>
+      <div class="error-message" v-if="backendErrors.length" v-for="error in backendErrors">
+        <i class="fas fa-exclamation-triangle"></i> {{ error.message }}
       </div>
     </div>
     <!-- built files will be auto injected -->

--- a/src/lib/backend-response.ts
+++ b/src/lib/backend-response.ts
@@ -1,10 +1,13 @@
-type BackendErrorType = 'error' | 'warning';
-
 export type BackendError = {
-  type: BackendErrorType;
+  type: 'error';
+  message: string;
+};
+
+export type BackendWarning = {
+  type: 'warning';
   message: string;
 };
 
 export type BackendResponse<T> =
-  | Promise<{ data: T; error?: never }>
-  | Promise<{ data?: never; error: BackendError }>;
+  | Promise<{ data: T; error?: never; warning?: BackendWarning[] }>
+  | Promise<{ data?: never; error: BackendError[] }>;

--- a/src/store/backend-plugin.ts
+++ b/src/store/backend-plugin.ts
@@ -63,16 +63,13 @@ function _backendify(target: Function, store: Store<any>) {
     try {
       store.commit('vqb/toggleRequestOnGoing', { isRequestOnGoing: true });
       const response = await target.bind(this)(...args);
-      if (response.error) {
-        store.commit('vqb/logBackendError', {
-          backendError: response.error,
-        });
-      }
+      const backendMessages = response.error || response.warning || [];
+      store.commit('vqb/logBackendMessages', { backendMessages });
       return response;
     } catch (error) {
-      const response = { error: { type: 'error', message: error.toString() } };
-      store.commit('vqb/logBackendError', {
-        backendError: response.error,
+      const response = { error: [{ type: 'error', message: error.toString() }] };
+      store.commit('vqb/logBackendMessages', {
+        backendMessages: response.error,
       });
       return response;
     } finally {

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -13,11 +13,6 @@ const getters: GetterTree<VQBState, any> = {
    * the part of the pipeline that is currently selected.
    */
   activePipeline,
-
-  /**
-   * current backend's error message
-   */
-  backendErrorMessages: (state: VQBState) => state.backendErrors,
   /**
    * the list of current dataset's colum names.
    **/
@@ -104,7 +99,7 @@ const getters: GetterTree<VQBState, any> = {
   /**
    * Return true if an error occured in the backend
    */
-  thereIsABackendError: (state: VQBState) => state.backendErrors.length > 0,
+  thereIsABackendError: (state: VQBState) => state.backendMessages.length > 0,
   /**
    * selected columns in the dataviewer (materialized by a styled focus)
    */

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -5,15 +5,15 @@
 import Vue from 'vue';
 import { MutationTree } from 'vuex';
 
-import { BackendError } from '@/lib/backend-response';
+import { BackendError, BackendWarning } from '@/lib/backend-response';
 import { DomainStep, Pipeline, PipelineStepName } from '@/lib/steps';
 
 import { currentPipeline, VQBState } from './state';
 
 // provide types for each possible mutations' payloads
-type BackendErrorMutation = {
-  type: 'logBackendError';
-  payload: BackendError;
+type BackendMessageMutation = {
+  type: 'logBackendMessages';
+  payload: BackendError[] | BackendWarning[];
 };
 
 type DatasetMutation = {
@@ -72,7 +72,7 @@ type ToggleRequestOnGoing = {
 };
 
 export type StateMutation =
-  | BackendErrorMutation
+  | BackendMessageMutation
   | DatasetMutation
   | DeleteStepMutation
   | DomainsMutation
@@ -132,8 +132,11 @@ class Mutations {
   /**
    * log a backend error message.
    */
-  logBackendError(state: VQBState, { backendError }: { backendError: BackendError }) {
-    state.backendErrors.push(backendError);
+  logBackendMessages(
+    state: VQBState,
+    { backendMessages }: { backendMessages: BackendError[] | BackendWarning[] },
+  ) {
+    state.backendMessages = backendMessages;
   }
 
   /**
@@ -146,13 +149,6 @@ class Mutations {
     state.stepFormInitialValue = { ...initialValue };
     state.currentStepFormName = stepName;
     state.stepFormDefaults = undefined;
-  }
-
-  /**
-   * empty error log on VQB's state
-   */
-  resetBackendErrors(state: VQBState) {
-    state.backendErrors = [];
   }
 
   /**

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -3,7 +3,7 @@
  */
 import _fromPairs from 'lodash/fromPairs';
 
-import { BackendError } from '@/lib/backend-response';
+import { BackendError, BackendWarning } from '@/lib/backend-response';
 import { DataSet } from '@/lib/dataset';
 import { Pipeline, PipelineStepName } from '@/lib/steps';
 import { InterpolateFunction, PipelineInterpolator, ScopeContext } from '@/lib/templating';
@@ -65,9 +65,9 @@ export interface VQBState {
   pagesize: number;
 
   /**
-   * error send by backend or catch from its interface
+   * error/warning messages send by backend or catch from its interface
    */
-  backendErrors: BackendError[];
+  backendMessages: BackendError[] | BackendWarning[];
 
   /**
    * An object containing all loading state
@@ -124,7 +124,7 @@ export function emptyState(): VQBState {
     pipelines: {},
     selectedColumns: [],
     pagesize: 50,
-    backendErrors: [],
+    backendMessages: [],
     isLoading: { dataset: false, uniqueValues: false },
     isRequestOnGoing: false,
     variables: {},

--- a/tests/unit/plugins.spec.ts
+++ b/tests/unit/plugins.spec.ts
@@ -68,22 +68,28 @@ describe('backendService', () => {
     it('listCollections', async () => {
       const result = await backendService.listCollections();
       expect(result).toEqual({ data: ['jjg', 'mika'] });
-      expect(commitSpy).toHaveBeenCalledTimes(2);
+      expect(commitSpy).toHaveBeenCalledTimes(3);
       expect(commitSpy).toHaveBeenNthCalledWith(1, VQBnamespace('toggleRequestOnGoing'), {
         isRequestOnGoing: true,
       });
-      expect(commitSpy).toHaveBeenNthCalledWith(2, VQBnamespace('toggleRequestOnGoing'), {
+      expect(commitSpy).toHaveBeenNthCalledWith(2, VQBnamespace('logBackendMessages'), {
+        backendMessages: [],
+      });
+      expect(commitSpy).toHaveBeenNthCalledWith(3, VQBnamespace('toggleRequestOnGoing'), {
         isRequestOnGoing: false,
       });
     });
     it('executePipeline', async () => {
       const result = await backendService.executePipeline([], -1, -1);
       expect(result).toEqual({ data: dummyDataset });
-      expect(commitSpy).toHaveBeenCalledTimes(2);
+      expect(commitSpy).toHaveBeenCalledTimes(3);
       expect(commitSpy).toHaveBeenNthCalledWith(1, VQBnamespace('toggleRequestOnGoing'), {
         isRequestOnGoing: true,
       });
-      expect(commitSpy).toHaveBeenNthCalledWith(2, VQBnamespace('toggleRequestOnGoing'), {
+      expect(commitSpy).toHaveBeenNthCalledWith(2, VQBnamespace('logBackendMessages'), {
+        backendMessages: [],
+      });
+      expect(commitSpy).toHaveBeenNthCalledWith(3, VQBnamespace('toggleRequestOnGoing'), {
         isRequestOnGoing: false,
       });
     });
@@ -94,23 +100,23 @@ describe('backendService', () => {
       service = {
         listCollections: jest
           .fn()
-          .mockResolvedValue({ error: { message: 'foo', type: 'error' as 'error' } }),
+          .mockResolvedValue({ error: [{ message: 'foo', type: 'error' as 'error' }] }),
         executePipeline: jest
           .fn()
-          .mockResolvedValue({ error: { message: 'foo', type: 'error' as 'error' } }),
+          .mockResolvedValue({ error: [{ message: 'foo', type: 'error' as 'error' }] }),
       };
       store = setupMockStore({}, [servicePluginFactory(service)]);
       commitSpy = jest.spyOn(store, 'commit');
     });
     it('listCollections', async () => {
       const result = await backendService.listCollections();
-      expect(result).toEqual({ error: { message: 'foo', type: 'error' as 'error' } });
+      expect(result).toEqual({ error: [{ message: 'foo', type: 'error' as 'error' }] });
       expect(commitSpy).toHaveBeenCalledTimes(3);
       expect(commitSpy).toHaveBeenNthCalledWith(1, VQBnamespace('toggleRequestOnGoing'), {
         isRequestOnGoing: true,
       });
-      expect(commitSpy).toHaveBeenNthCalledWith(2, VQBnamespace('logBackendError'), {
-        backendError: { message: 'foo', type: 'error' },
+      expect(commitSpy).toHaveBeenNthCalledWith(2, VQBnamespace('logBackendMessages'), {
+        backendMessages: [{ message: 'foo', type: 'error' }],
       });
       expect(commitSpy).toHaveBeenNthCalledWith(3, VQBnamespace('toggleRequestOnGoing'), {
         isRequestOnGoing: false,
@@ -118,13 +124,13 @@ describe('backendService', () => {
     });
     it('executePipeline', async () => {
       const result = await backendService.executePipeline([], -1, -1);
-      expect(result).toEqual({ error: { message: 'foo', type: 'error' as 'error' } });
+      expect(result).toEqual({ error: [{ message: 'foo', type: 'error' as 'error' }] });
       expect(commitSpy).toHaveBeenCalledTimes(3);
       expect(commitSpy).toHaveBeenNthCalledWith(1, VQBnamespace('toggleRequestOnGoing'), {
         isRequestOnGoing: true,
       });
-      expect(commitSpy).toHaveBeenNthCalledWith(2, VQBnamespace('logBackendError'), {
-        backendError: { message: 'foo', type: 'error' },
+      expect(commitSpy).toHaveBeenNthCalledWith(2, VQBnamespace('logBackendMessages'), {
+        backendMessages: [{ message: 'foo', type: 'error' }],
       });
       expect(commitSpy).toHaveBeenNthCalledWith(3, VQBnamespace('toggleRequestOnGoing'), {
         isRequestOnGoing: false,
@@ -147,13 +153,13 @@ describe('backendService', () => {
     });
     it('listCollections', async () => {
       const result = await backendService.listCollections();
-      expect(result).toEqual({ error: { message: 'Error: oopsie', type: 'error' as 'error' } });
+      expect(result).toEqual({ error: [{ message: 'Error: oopsie', type: 'error' as 'error' }] });
       expect(commitSpy).toHaveBeenCalledTimes(3);
       expect(commitSpy).toHaveBeenNthCalledWith(1, VQBnamespace('toggleRequestOnGoing'), {
         isRequestOnGoing: true,
       });
-      expect(commitSpy).toHaveBeenNthCalledWith(2, VQBnamespace('logBackendError'), {
-        backendError: { message: 'Error: oopsie', type: 'error' },
+      expect(commitSpy).toHaveBeenNthCalledWith(2, VQBnamespace('logBackendMessages'), {
+        backendMessages: [{ message: 'Error: oopsie', type: 'error' }],
       });
       expect(commitSpy).toHaveBeenNthCalledWith(3, VQBnamespace('toggleRequestOnGoing'), {
         isRequestOnGoing: false,
@@ -161,13 +167,13 @@ describe('backendService', () => {
     });
     it('executePipeline', async () => {
       const result = await backendService.executePipeline([], -1, -1);
-      expect(result).toEqual({ error: { message: 'Error: oopsie', type: 'error' as 'error' } });
+      expect(result).toEqual({ error: [{ message: 'Error: oopsie', type: 'error' as 'error' }] });
       expect(commitSpy).toHaveBeenCalledTimes(3);
       expect(commitSpy).toHaveBeenNthCalledWith(1, VQBnamespace('toggleRequestOnGoing'), {
         isRequestOnGoing: true,
       });
-      expect(commitSpy).toHaveBeenNthCalledWith(2, VQBnamespace('logBackendError'), {
-        backendError: { message: 'Error: oopsie', type: 'error' },
+      expect(commitSpy).toHaveBeenNthCalledWith(2, VQBnamespace('logBackendMessages'), {
+        backendMessages: [{ message: 'Error: oopsie', type: 'error' }],
       });
       expect(commitSpy).toHaveBeenNthCalledWith(3, VQBnamespace('toggleRequestOnGoing'), {
         isRequestOnGoing: false,


### PR DESCRIPTION
When backendErrors was displayed we cannot display data as well.
This refactoring allow to use warnings messages when data is displayed.

Logic:

Update/Add interfaces ( BackendError or BackendWarning )
Renamed old variables to fit messages
Remove unused reset mutation
Update log mutation to replace data when a new query is made ( empty array to reset messages if no messages provided. )
Fix tests
Add playground example based on dataset rows count