### PR TITLE
Fix popover position (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Changed
 - The way we handle backendMessages (error/warning) by `BackendService`
 
+## [0.17.2] - 2020-05-13
+
+### Fixed
+
+- popover positioning and mounting
+
 ## [0.17.0] - 2020-05-12
 
 ### Added
@@ -265,6 +271,7 @@
 
 - Initial version, showtime!
 
+[0.17.2]: https://github.com/ToucanToco/weaverbird/compare/v0.17.0...v0.17.2
 [0.17.0]: https://github.com/ToucanToco/weaverbird/compare/v0.16.1...v0.17.0
 [0.16.1]: https://github.com/ToucanToco/weaverbird/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/ToucanToco/weaverbird/compare/v0.15.1...v0.16.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.17.0",
+  "version": "0.17.2",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
     "url": "https://github.com/ToucanToco/weaverbird/issues",

--- a/src/components/ActionToolbar.vue
+++ b/src/components/ActionToolbar.vue
@@ -10,7 +10,7 @@
         :is-active="button.isActionToolbarMenuOpened"
         :class="button.class"
         @actionClicked="actionClicked"
-        @click.native="openPopover(index)"
+        @click.native.stop="openPopover(index)"
         @closed="closePopover()"
       />
       <search-bar @actionClicked="actionClicked" />

--- a/tests/unit/popover.spec.ts
+++ b/tests/unit/popover.spec.ts
@@ -221,14 +221,14 @@ describe('Popover', function() {
     boundingRectSpy.mockRestore();
   });
 
-  it('should instantiate a popover', function() {
+  it("should instantiate the popover in document's body", function() {
     createWrapper({ props: { visible: true } });
-    expect(_.isElement(popoverWrapper.element)).toBeTruthy();
+    expect(document.body.contains(popoverWrapper.element)).toBeTruthy();
   });
 
-  it('should instantiate a popover', function() {
+  it("should not add the popover in document's body", function() {
     createWrapper({ props: { visible: false } });
-    expect(_.isElement(popoverWrapper.element)).toBeFalsy();
+    expect(document.body.contains(popoverWrapper.element)).toBeFalsy();
   });
 
   it('should include the passed slot content', function() {


### PR DESCRIPTION
- add an "handleEvent" method added to listener and then removed when destroy positioning.
- remove v-if: the element is removed at mount. It is then added to body when setup positioning.
- add a `.stop` propogation event modifier on action toolbar