### PR TITLE
DataTypesMenu :: Deactivate date conversion option for non string columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The way we handle backendMessages (error/warning) by `BackendService`
 - Parameters order in text and formula steps forms
+- Deactivate date conversion option depending on columnn datatype in `DataTypesMenu`
 
 ## [0.17.2] - 2020-05-13
 

--- a/tests/unit/data-types-menu.spec.ts
+++ b/tests/unit/data-types-menu.spec.ts
@@ -93,6 +93,19 @@ describe('Data Types Menu', () => {
       expect(store.state.vqb.selectedStepIndex).toEqual(1);
     });
 
+    it('should close any existing open form if another step was being edited', async () => {
+      const store = setupMockStore({
+        ...buildStateWithOnePipeline([{ name: 'domain', domain: 'test' }], {
+          currentStepFormName: 'formula',
+        }),
+      });
+      const wrapper = shallowMount(DataTypesMenu, { store, localVue });
+      const actionsWrapper = wrapper.find('.data-types-menu__option--active');
+      actionsWrapper.trigger('click');
+      await localVue.nextTick();
+      expect(wrapper.vm.$store.state.currentStepFormName).toBeUndefined();
+    });
+
     it('should emit a close event', async () => {
       const store = setupMockStore();
       const wrapper = shallowMount(DataTypesMenu, { store, localVue });
@@ -102,7 +115,7 @@ describe('Data Types Menu', () => {
       expect(wrapper.emitted().closed).toBeTruthy();
     });
 
-    it('should not emit a close event if clicking on a deactivatedoption', async () => {
+    it('should not emit a close event if clicking on a deactivated option', async () => {
       const store = setupMockStore({
         dataset: {
           headers: [{ name: 'columnA', type: 'integer' }],


### PR DESCRIPTION
If a column datatype is not a string, now the date conversion is deactivated. After several user feedback, I believe that this improves a bit the UX while avoiding impossible conversions that yield mongo errors difficult to understand for the users.

![image](https://user-images.githubusercontent.com/34442515/81849593-09f58480-9557-11ea-8137-108560bd7fc4.png)
