### PR TITLE
fix(multiselect): force the multiselect to open bellow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.19.2] - 2020-07-06
+
+### Fixed
+
+- Open the vue-multiselect on the bottom direction
+
 ## [0.19.1] - 2020-06-23
 
 ### Fixed
@@ -309,6 +315,7 @@
 
 - Initial version, showtime!
 
+[0.19.2]: https://github.com/ToucanToco/weaverbird/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/ToucanToco/weaverbird/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/ToucanToco/weaverbird/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/ToucanToco/weaverbird/compare/v0.17.4...v0.18.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
     "url": "https://github.com/ToucanToco/weaverbird/issues",

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -10,6 +10,7 @@
       group-values="actions"
       :group-select="false"
       @select="actionClicked"
+      open-direction="bottom"
     />
   </div>
 </template>

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -8,6 +8,7 @@
       :allow-empty="false"
       :track-by="trackBy"
       :label="label"
+      openDirection="bottom"
       @input="$emit('input', $event)"
     >
       <!-- If you want to use those templates you should provide a 'label' and 

--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -16,6 +16,7 @@
         :close-on-select="false"
         :placeholder="placeholder"
         @search-change="updateOptions"
+        open-direction="bottom"
       />
     </VariableInput>
   </div>

--- a/src/components/stepforms/widgets/Multiselect.vue
+++ b/src/components/stepforms/widgets/Multiselect.vue
@@ -8,6 +8,7 @@
       :multiple="true"
       :taggable="true"
       :close-on-select="false"
+      openDirection="bottom"
     />
     <div v-if="messageError" class="field__msg-error">
       <span class="fa fa-exclamation-circle" />


### PR DESCRIPTION
Force the `vue-multiselect` component to open bellow.
This is a desirable behavior because no space is reserved above the widget.

Before (bad user experience):
![BugMultiselect](https://user-images.githubusercontent.com/128057/86607604-c2650500-bfa9-11ea-929f-304de0016eac.gif)

After (more space is used below the widget):
![BugMultiselectFix](https://user-images.githubusercontent.com/128057/86607934-2f789a80-bfaa-11ea-8e96-e98526311fab.gif)
