### PR TITLE
fix: allow to filter with empty or undefined value

### DIFF
--- a/src/components/stepforms/schemas/filter.ts
+++ b/src/components/stepforms/schemas/filter.ts
@@ -99,7 +99,6 @@ export default {
         },
         value: {
           type: ['string', 'number', 'boolean', 'null', 'array'],
-          minLength: 1,
           title: 'Value',
           description: 'The value to compare',
           attrs: {

--- a/tests/unit/filter-step-form.spec.ts
+++ b/tests/unit/filter-step-form.spec.ts
@@ -20,12 +20,12 @@ describe('Filter Step Form', () => {
       data: {
         editedStep: {
           name: 'filter',
-          condition: { column: 'toto', operator: 'eq', value: '' },
+          condition: { column: '', operator: 'eq', value: '' },
         },
       },
       errors: [
         { keyword: 'if', dataPath: '.condition' },
-        { keyword: 'minLength', dataPath: '.condition.value' },
+        { keyword: 'minLength', dataPath: '.condition.column' },
       ],
     },
   ]);

--- a/tests/unit/filter-step-form.spec.ts
+++ b/tests/unit/filter-step-form.spec.ts
@@ -153,6 +153,35 @@ describe('Filter Step Form', () => {
     expect(wrapper.vm.$data.editedStep.condition.column).toEqual('foo');
   });
 
+  it('should not raise errors with undefined or empty value', () => {
+    const initialState = {
+      dataset: {
+        headers: [{ name: 'columnA', type: 'boolean' }],
+        data: [[null]],
+      },
+    };
+    const wrapper = runner.mount(initialState, {
+      propsData: {
+        initialStepValue: {
+          name: 'filter',
+          condition: { column: 'columnA', operator: 'eq', value: '' },
+        },
+      },
+    });
+    wrapper.find('.widget-form-action__button--validate').trigger('click');
+    expect(wrapper.vm.$data.errors).toBeNull();
+    expect(wrapper.emitted()).toEqual({
+      formSaved: [
+        [
+          {
+            name: 'filter',
+            condition: { column: 'columnA', operator: 'eq', value: '' },
+          },
+        ],
+      ],
+    });
+  });
+
   it('should convert input value to integer when the column data type is integer', () => {
     const initialState = {
       dataset: {


### PR DESCRIPTION
Removed minLength on filter input to allow empty or undefined value.
Empty input won't raise error anymore.