### PR TITLE
fix: keep `null` value filter for numeric columns

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -20,7 +20,7 @@ function isBooleanString(string: string): boolean {
  * @returns a boolean to determine if the value can be connverted to a number
  */
 export function castFromString(value: string, type: DataSetColumnType) {
-  if ((type === 'integer' || type === 'float') && !isNaN(Number(value))) {
+  if ((type === 'integer' || type === 'float') && value !== null && !isNaN(Number(value))) {
     return Number(value);
   } else if (type === 'boolean' && isBooleanString(value)) {
     return value === 'true' || value === 'True' || value === 'TRUE' || value === '1';

--- a/tests/unit/filter-step-form.spec.ts
+++ b/tests/unit/filter-step-form.spec.ts
@@ -269,4 +269,33 @@ describe('Filter Step Form', () => {
       ],
     });
   });
+
+  it('should not convert null input value when the column data type is an integer', () => {
+    const initialState = {
+      dataset: {
+        headers: [{ name: 'columnA', type: 'integer' }],
+        data: [[null]],
+      },
+    };
+    const wrapper = runner.mount(initialState, {
+      propsData: {
+        initialStepValue: {
+          name: 'filter',
+          condition: { column: 'columnA', operator: 'eq', value: null },
+        },
+      },
+    });
+    wrapper.find('.widget-form-action__button--validate').trigger('click');
+    expect(wrapper.vm.$data.errors).toBeNull();
+    expect(wrapper.emitted()).toEqual({
+      formSaved: [
+        [
+          {
+            name: 'filter',
+            condition: { column: 'columnA', operator: 'eq', value: null },
+          },
+        ],
+      ],
+    });
+  });
 });


### PR DESCRIPTION
Keep null as null even with integer type (due to cast null values became 0)