### PR TITLE
fix(pagination): always display pagination for multiple pages dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Changes
+
+### Fixed
+- Pagination: always display pagination for multiple pages dataset
+
 ## [0.19.3] - 2020-07-20
 
 ### Fixed

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -40,8 +40,8 @@ export default class Pagination extends Vue {
 
   @VQBModule.Mutation setCurrentPage!: MutationCallbacks['setCurrentPage'];
 
-  get showPager() {
-    return this.pageRows.max !== this.totalCount;
+  get showPager(): boolean {
+    return this.pageCount > 1;
   }
 
   get pageCount() {

--- a/tests/unit/pagination-component.spec.ts
+++ b/tests/unit/pagination-component.spec.ts
@@ -132,4 +132,39 @@ describe('Pagination Component', () => {
     expect(wrapper.find('.pagination-counter__current-max').exists()).toBeFalsy();
     expect(wrapper.find('.pagination-counter__total-count').text()).toEqual('2 rows');
   });
+  describe('Pagination navigation lifecycle', () => {
+    const pagesize = 50;
+    const totalCount = 400;
+    const paginationNavigationExistsOnpageIndex = function(pageno: number): boolean {
+      const store = setupMockStore({
+        dataset: {
+          headers: [{ name: 'city' }, { name: 'population' }, { name: 'isCapitalCity' }],
+          data: [
+            ['Paris', 10000000, true],
+            ['Marseille', 3000000, false],
+          ],
+          paginationContext: {
+            totalCount,
+            pagesize,
+            pageno,
+          },
+        },
+        pagesize,
+      });
+      const wrapper = mount(Pagination, { localVue, store });
+      return wrapper.find('.pagination__list').exists();
+    };
+    it('should display pagination navigation on first page', () => {
+      const pageIndex = 1;
+      expect(paginationNavigationExistsOnpageIndex(pageIndex)).toBe(true);
+    });
+    it('should display pagination navigation on any middle page', () => {
+      const pageIndex = totalCount / pagesize - 2;
+      expect(paginationNavigationExistsOnpageIndex(pageIndex)).toBe(true);
+    });
+    it('should display pagination navigation on last page', () => {
+      const pageIndex = totalCount / pagesize;
+      expect(paginationNavigationExistsOnpageIndex(pageIndex)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Pagination never displayed on last page of multiple pages dataset due to wrong condition.
We need to display pagination for every dataset that have more than one page.