### PR TITLE
fix(filters): keep value if typeof match on operator change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Pagination: always display pagination for multiple pages dataset
+- Filters: keep value if typeof match on operator change
 
 ## Added
 - Util to compare value types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - Pagination: always display pagination for multiple pages dataset
 
+## Added
+- Util to compare value types
+
 ## [0.19.3] - 2020-07-20
 
 ### Fixed

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -47,6 +47,7 @@ import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue'
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import { VariableDelimiters } from '@/components/stepforms/widgets/VariableInput/extract-variable-identifier';
 import { VariablesBucket } from '@/components/stepforms/widgets/VariableInput/VariableInput.vue';
+import { compareArrayType, compareType } from '@/lib/helpers';
 import { FilterSimpleCondition } from '@/lib/steps';
 import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
@@ -171,11 +172,11 @@ export default class FilterSimpleConditionWidget extends Vue {
     const updatedValue = { ...this.value };
     updatedValue.operator = newOperator.operator;
     if (updatedValue.operator === 'in' || updatedValue.operator === 'nin') {
-      updatedValue.value = [];
+      updatedValue.value = compareArrayType(updatedValue.value, []);
     } else if (updatedValue.operator === 'isnull' || updatedValue.operator === 'notnull') {
       updatedValue.value = null;
     } else {
-      updatedValue.value = '';
+      updatedValue.value = compareType(updatedValue.value, '');
     }
     this.$emit('input', updatedValue);
   }

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -47,7 +47,7 @@ import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue'
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import { VariableDelimiters } from '@/components/stepforms/widgets/VariableInput/extract-variable-identifier';
 import { VariablesBucket } from '@/components/stepforms/widgets/VariableInput/VariableInput.vue';
-import { compareArrayType, compareType } from '@/lib/helpers';
+import { keepCurrentValueIfArrayType, keepCurrentValueIfCompatibleType } from '@/lib/helpers';
 import { FilterSimpleCondition } from '@/lib/steps';
 import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
@@ -172,11 +172,11 @@ export default class FilterSimpleConditionWidget extends Vue {
     const updatedValue = { ...this.value };
     updatedValue.operator = newOperator.operator;
     if (updatedValue.operator === 'in' || updatedValue.operator === 'nin') {
-      updatedValue.value = compareArrayType(updatedValue.value, []);
+      updatedValue.value = keepCurrentValueIfArrayType(updatedValue.value, []);
     } else if (updatedValue.operator === 'isnull' || updatedValue.operator === 'notnull') {
       updatedValue.value = null;
     } else {
-      updatedValue.value = compareType(updatedValue.value, '');
+      updatedValue.value = keepCurrentValueIfCompatibleType(updatedValue.value, '');
     }
     this.$emit('input', updatedValue);
   }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -78,7 +78,10 @@ export function* enumerate<T>(values: Iterable<T>, start = 0): Generator<[number
  * @param value the selected value
  * @param defaultValue the default to compare
  */
-export function compareType(value: ValueType | ValueType[], defaultValue: ValueType): ValueType {
+export function keepCurrentValueIfCompatibleType(
+  value: ValueType | ValueType[],
+  defaultValue: ValueType,
+): ValueType {
   if (Array.isArray(value)) return defaultValue;
   return typeof value === typeof defaultValue ? value : defaultValue;
 }
@@ -89,7 +92,7 @@ export function compareType(value: ValueType | ValueType[], defaultValue: ValueT
  * @param value the selected value
  * @param defaultValue the default to compare
  */
-export function compareArrayType(
+export function keepCurrentValueIfArrayType(
   value: ValueType | ValueType[],
   defaultValue: ValueType[],
 ): ValueType[] {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,7 @@
 import { DataSetColumnType } from './dataset';
 
+type ValueType = number | boolean | string | null;
+
 function isBooleanString(string: string): boolean {
   return (
     string === 'true' ||
@@ -68,4 +70,28 @@ export function* enumerate<T>(values: Iterable<T>, start = 0): Generator<[number
   for (const value of values) {
     yield [idx++, value];
   }
+}
+
+/**
+ * Return default value if selected value has different typeof
+ *
+ * @param value the selected value
+ * @param defaultValue the default to compare
+ */
+export function compareType(value: ValueType | ValueType[], defaultValue: ValueType): ValueType {
+  if (Array.isArray(value)) return defaultValue;
+  return typeof value === typeof defaultValue ? value : defaultValue;
+}
+
+/**
+ * Return default value if selected value is not an array
+ *
+ * @param value the selected value
+ * @param defaultValue the default to compare
+ */
+export function compareArrayType(
+  value: ValueType | ValueType[],
+  defaultValue: ValueType[],
+): ValueType[] {
+  return Array.isArray(value) ? value : defaultValue;
 }

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -231,4 +231,48 @@ describe('Widget FilterSimpleCondition', () => {
     await wrapper.vm.$nextTick();
     expect(store.state.vqb.selectedColumns).toEqual(['columnB']);
   });
+
+  it('should keep value when operator is changed and types match', async () => {
+    const store = setupMockStore({
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+      selectedColumns: ['columnA'],
+    });
+    const wrapper = mount(FilterSimpleConditionWidget, {
+      propsData: {
+        value: { column: 'columnA', value: 'bar', operator: 'eq' },
+      },
+      store,
+      localVue,
+      sync: false,
+    });
+    wrapper.find('.filterOperator').vm.$emit('input', { operator: 'ne' });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted().input[0]).toEqual([
+      { column: 'columnA', value: 'bar', operator: 'ne' },
+    ]);
+  });
+
+  it("should replace value with default when operator is changed and types don't match", async () => {
+    const store = setupMockStore({
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+      selectedColumns: ['columnA'],
+    });
+    const wrapper = mount(FilterSimpleConditionWidget, {
+      propsData: {
+        value: { column: 'columnA', value: 'bar', operator: 'eq' },
+      },
+      store,
+      localVue,
+      sync: false,
+    });
+    wrapper.find('.filterOperator').vm.$emit('input', { operator: 'in' });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted().input[0]).toEqual([{ column: 'columnA', value: [], operator: 'in' }]);
+  });
 });

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -1,8 +1,8 @@
 import {
   $$,
   castFromString,
-  compareType,
   compareArrayType,
+  compareType,
   enumerate,
   generateNewColumnName,
 } from '@/lib/helpers';
@@ -117,7 +117,7 @@ describe('castFromString', () => {
     it('should return default if selected value is an array', () => {
       expect(compareType(['a'], '')).toEqual('');
     });
-    it('should return default if its type doesn\'t match selected value', () => {
+    it("should return default if its type doesn't match selected value", () => {
       expect(compareType(3, '')).toEqual('');
     });
     it('should return selected value if its type match default one', () => {

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -1,4 +1,11 @@
-import { $$, castFromString, enumerate, generateNewColumnName } from '@/lib/helpers';
+import {
+  $$,
+  castFromString,
+  compareType,
+  compareArrayType,
+  enumerate,
+  generateNewColumnName,
+} from '@/lib/helpers';
 
 describe('castFromString', () => {
   it('should cast numeric string to number type', () => {
@@ -103,6 +110,27 @@ describe('castFromString', () => {
         [1, 'bar'],
         [2, 'baz'],
       ]);
+    });
+  });
+
+  describe('compareType', () => {
+    it('should return default if selected value is an array', () => {
+      expect(compareType(['a'], '')).toEqual('');
+    });
+    it('should return default if its type doesn\'t match selected value', () => {
+      expect(compareType(3, '')).toEqual('');
+    });
+    it('should return selected value if its type match default one', () => {
+      expect(compareType('3', '')).toEqual('3');
+    });
+  });
+
+  describe('compareArrayType', () => {
+    it('should return default if selected value is not an array', () => {
+      expect(compareArrayType('a', [])).toEqual([]);
+    });
+    it('should return selected value if its type is an array', () => {
+      expect(compareArrayType(['a'], [])).toEqual(['a']);
     });
   });
 });

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -1,10 +1,10 @@
 import {
   $$,
   castFromString,
-  compareArrayType,
-  compareType,
   enumerate,
   generateNewColumnName,
+  keepCurrentValueIfArrayType,
+  keepCurrentValueIfCompatibleType,
 } from '@/lib/helpers';
 
 describe('castFromString', () => {
@@ -113,24 +113,24 @@ describe('castFromString', () => {
     });
   });
 
-  describe('compareType', () => {
+  describe('keepCurrentValueIfCompatibleType', () => {
     it('should return default if selected value is an array', () => {
-      expect(compareType(['a'], '')).toEqual('');
+      expect(keepCurrentValueIfCompatibleType(['a'], '')).toEqual('');
     });
     it("should return default if its type doesn't match selected value", () => {
-      expect(compareType(3, '')).toEqual('');
+      expect(keepCurrentValueIfCompatibleType(3, '')).toEqual('');
     });
     it('should return selected value if its type match default one', () => {
-      expect(compareType('3', '')).toEqual('3');
+      expect(keepCurrentValueIfCompatibleType('3', '')).toEqual('3');
     });
   });
 
-  describe('compareArrayType', () => {
+  describe('keepCurrentValueIfArrayType', () => {
     it('should return default if selected value is not an array', () => {
-      expect(compareArrayType('a', [])).toEqual([]);
+      expect(keepCurrentValueIfArrayType('a', [])).toEqual([]);
     });
     it('should return selected value if its type is an array', () => {
-      expect(compareArrayType(['a'], [])).toEqual(['a']);
+      expect(keepCurrentValueIfArrayType(['a'], [])).toEqual(['a']);
     });
   });
 });


### PR DESCRIPTION
**Before:**  when changing operator with filter condition widget, value was reset to fit new type.
**After:** when changing operator with filter condition widget, value is reset only if its type don't match new type. Else keep previous value as selected one.