### PR TITLE
fix: remove grouping of addFields steps in mongo query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Pagination: always display pagination for multiple pages dataset
 - Filters: keep value if typeof match on operator change
+- MongoQuery: degroup addFields
 
 ## Added
 - Util to compare value types

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -117,8 +117,7 @@ export function _simplifyMongoPipeline(mongoSteps: MongoStep[]): MongoStep[] {
 
   for (const step of mongoSteps.slice(1)) {
     const [stepOperator] = Object.keys(step);
-    const isMergeable =
-      stepOperator === '$project' || stepOperator === '$addFields' || stepOperator === '$match';
+    const isMergeable = stepOperator === '$project' || stepOperator === '$match';
     if (isMergeable && lastStep[stepOperator] !== undefined) {
       for (const key in step[stepOperator]) {
         /**

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -889,7 +889,6 @@ describe('Pipeline to mongo translator', () => {
         },
       },
       {
-        // Two steps with common keys should not be merged
         $addFields: {
           Country: {
             $switch: {
@@ -897,6 +896,10 @@ describe('Pipeline to mongo translator', () => {
               default: '$Country',
             },
           },
+        },
+      },
+      {
+        $addFields: {
           Population: { $divide: ['$Population', 1000] },
         },
       },
@@ -1036,7 +1039,6 @@ describe('Pipeline to mongo translator', () => {
         },
       },
       {
-        // Two steps with common keys should not be merged
         $addFields: {
           Zone: {
             $switch: {
@@ -1044,6 +1046,10 @@ describe('Pipeline to mongo translator', () => {
               default: '$Zone',
             },
           },
+        },
+      },
+      {
+        $addFields: {
           Population: { $divide: ['$Population', 1000] },
         },
       },
@@ -1417,13 +1423,9 @@ describe('Pipeline to mongo translator', () => {
     ];
     const querySteps = mongo36translator.translate(pipeline);
     expect(querySteps).toEqual([
-      {
-        $addFields: {
-          foo: '$bar',
-          constant: 42,
-          with_parentheses: '$test',
-        },
-      },
+      { $addFields: { foo: '$bar' } },
+      { $addFields: { constant: 42 } },
+      { $addFields: { with_parentheses: '$test' } },
       { $project: { _id: 0 } },
     ]);
   });
@@ -1465,6 +1467,10 @@ describe('Pipeline to mongo translator', () => {
               },
             ],
           },
+        },
+      },
+      {
+        $addFields: {
           bar: {
             $multiply: [
               {
@@ -1483,6 +1489,10 @@ describe('Pipeline to mongo translator', () => {
               10,
             ],
           },
+        },
+      },
+      {
+        $addFields: {
           test_precedence: {
             $add: [
               {

--- a/tests/unit/mongo4.spec.ts
+++ b/tests/unit/mongo4.spec.ts
@@ -108,9 +108,25 @@ describe('Pipeline to mongo translator', () => {
         $addFields: {
           foo: { $convert: { input: '$foo', to: 'bool' } },
           bar: { $convert: { input: '$bar', to: 'bool' } },
+        },
+      },
+      {
+        $addFields: {
           date: { $convert: { input: '$date', to: 'date' } },
+        },
+      },
+      {
+        $addFields: {
           float: { $convert: { input: '$float', to: 'double' } },
+        },
+      },
+      {
+        $addFields: {
           int: { $convert: { input: '$int', to: 'int' } },
+        },
+      },
+      {
+        $addFields: {
           text: { $convert: { input: '$text', to: 'string' } },
         },
       },


### PR DESCRIPTION
We merged addFields.
It causes issue if we try to use another added column as variable ( she won't exist as she is added at the same time).
We need to degroup add fields.