### PR TITLE
feat: allow to use availableVariables and variablesDelimiters from store

### DIFF
--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -27,9 +27,8 @@ import {
   buildFilterStepTree,
 } from '@/components/stepforms/convert-filter-step-tree.ts';
 import FilterSimpleConditionWidget from '@/components/stepforms/widgets/FilterSimpleCondition.vue';
-import { VariableDelimiters } from '@/components/stepforms/widgets/VariableInput/extract-variable-identifier';
-import { VariablesBucket } from '@/components/stepforms/widgets/VariableInput/VariableInput.vue';
 import { FilterCondition } from '@/lib/steps';
+import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 
 @Component({
   name: 'filter-editor',

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -45,10 +45,9 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
-import { VariableDelimiters } from '@/components/stepforms/widgets/VariableInput/extract-variable-identifier';
-import { VariablesBucket } from '@/components/stepforms/widgets/VariableInput/VariableInput.vue';
 import { keepCurrentValueIfArrayType, keepCurrentValueIfCompatibleType } from '@/lib/helpers';
 import { FilterSimpleCondition } from '@/lib/steps';
+import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
 

--- a/src/components/stepforms/widgets/InputText.vue
+++ b/src/components/stepforms/widgets/InputText.vue
@@ -37,10 +37,10 @@
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator';
 
-import { VariableDelimiters } from '@/components/stepforms/widgets/VariableInput/extract-variable-identifier';
+import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 
 import FormWidget from './FormWidget.vue';
-import VariableInput, { VariablesBucket } from './VariableInput/VariableInput.vue';
+import VariableInput from './VariableInput/VariableInput.vue';
 
 @Component({
   name: 'input-text-widget',

--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -26,9 +26,9 @@
 import Multiselect from 'vue-multiselect';
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
-import { VariableDelimiters } from '@/components/stepforms/widgets/VariableInput/extract-variable-identifier';
+import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 
-import VariableInput, { VariablesBucket } from './VariableInput/VariableInput.vue';
+import VariableInput from './VariableInput/VariableInput.vue';
 
 @Component({
   name: 'multi-input-text-widget',

--- a/src/components/stepforms/widgets/VariableInput/VariableInput.vue
+++ b/src/components/stepforms/widgets/VariableInput/VariableInput.vue
@@ -66,22 +66,9 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import { POPOVER_ALIGN } from '@/components/constants';
 import Popover from '@/components/Popover.vue';
+import { VariableDelimiters, VariablesBucket, VariablesCategory } from '@/lib/variables';
 
-import extractVariableIdentifier, { VariableDelimiters } from './extract-variable-identifier';
-
-interface AvailableVariable {
-  identifier: string; // how the variable will be written in the code
-  value: any; // current value of the variable
-  category?: string;
-  label: string;
-}
-
-export type VariablesBucket = AvailableVariable[];
-
-interface VariablesCategory {
-  label: string | undefined;
-  variables: AvailableVariable[];
-}
+import extractVariableIdentifier from './extract-variable-identifier';
 
 /**
  * This component wraps an input of any type and allow replacing its value by a variable chosen from a list or an

--- a/src/components/stepforms/widgets/VariableInput/extract-variable-identifier.ts
+++ b/src/components/stepforms/widgets/VariableInput/extract-variable-identifier.ts
@@ -1,8 +1,4 @@
-export interface VariableDelimiters {
-  start: string;
-  end: string;
-}
-
+import { VariableDelimiters } from '@/lib/variables';
 /**
  * Determine if value is variable surrounded by delimiters or not, and if yes, extract its identifier.
  */

--- a/src/lib/variables.ts
+++ b/src/lib/variables.ts
@@ -1,0 +1,18 @@
+interface AvailableVariable {
+  identifier: string; // how the variable will be written in the code
+  value: any; // current value of the variable
+  category?: string;
+  label: string;
+}
+
+export type VariablesBucket = AvailableVariable[];
+
+export interface VariablesCategory {
+  label: string | undefined;
+  variables: AvailableVariable[];
+}
+
+export interface VariableDelimiters {
+  start: string;
+  end: string;
+}

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -71,7 +71,18 @@ type ToggleRequestOnGoing = {
   payload: BackendError;
 };
 
+type AvailableVariablesMutation = {
+  type: 'setAvailableVariables';
+  payload: Pick<VQBState, 'availableVariables'>;
+};
+
+type VariableDelimitersMutation = {
+  type: 'setVariableDelimiters';
+  payload: Pick<VQBState, 'variableDelimiters'>;
+};
+
 export type StateMutation =
+  | AvailableVariablesMutation
   | BackendMessageMutation
   | DatasetMutation
   | DeleteStepMutation
@@ -83,7 +94,8 @@ export type StateMutation =
   | SelectedStepMutation
   | SetCurrentPage
   | ToggleColumnSelectionMutation
-  | ToggleRequestOnGoing;
+  | ToggleRequestOnGoing
+  | VariableDelimitersMutation;
 
 type MutationByType<M, MT> = M extends { type: MT } ? M : never;
 export type MutationCallbacks = {
@@ -302,6 +314,24 @@ class Mutations {
    */
   toggleRequestOnGoing(state: VQBState, { isRequestOnGoing }: { isRequestOnGoing: boolean }) {
     state.isRequestOnGoing = isRequestOnGoing;
+  }
+  /**
+   * set the list of available variables for templating.
+   */
+  setAvailableVariables(
+    state: VQBState,
+    { availableVariables }: Pick<VQBState, 'availableVariables'>,
+  ) {
+    state.availableVariables = availableVariables;
+  }
+  /**
+   * set the variable delimiters for templating.
+   */
+  setVariableDelimiters(
+    state: VQBState,
+    { variableDelimiters }: Pick<VQBState, 'variableDelimiters'>,
+  ) {
+    state.variableDelimiters = variableDelimiters;
   }
 }
 

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -7,9 +7,14 @@ import { BackendError, BackendWarning } from '@/lib/backend-response';
 import { DataSet } from '@/lib/dataset';
 import { Pipeline, PipelineStepName } from '@/lib/steps';
 import { InterpolateFunction, PipelineInterpolator, ScopeContext } from '@/lib/templating';
+import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 import { dereferencePipelines } from '@/store/utils/dereference-pipeline';
 
 export interface VQBState {
+  /**
+   * available variables for templating
+   */
+  availableVariables?: VariablesBucket;
   /**
    * the current dataset.
    */
@@ -99,6 +104,10 @@ export interface VQBState {
    * the app translator
    */
   translator: string;
+  /**
+   * variable delimiter for templating
+   */
+  variableDelimiters?: VariableDelimiters;
 }
 
 /**

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -366,13 +366,6 @@ describe('mutation tests', () => {
     expect(state.currentDomain).toEqual('foo');
   });
 
-  it('remove current pipeline in available pipelines', () => {
-    const state = buildState({});
-    mutations.setPipelines(state, { pipelines: { pipeline1: [], pipeline2: [] } });
-    mutations.setCurrentPipelineName(state, { name: 'pipeline1' });
-    expect(getters.availablePipelines(state, {}, {}, {})).toEqual(['pipeline2']);
-  });
-
   it('updates current domain when inconsistent with setDomains', () => {
     const state = buildState({ currentDomain: 'babar' });
     expect(state.domains).toEqual([]);
@@ -809,6 +802,27 @@ describe('action tests', () => {
       // call 5:
       expect(commitSpy.mock.calls[5][0]).toEqual(VQBnamespace('setLoading'));
       expect(commitSpy.mock.calls[5][1]).toEqual({ type: 'uniqueValues', isLoading: false });
+    });
+  });
+
+  describe('setAvailableVariables', function() {
+    it('set available variables', () => {
+      const state = buildState({});
+      const availableVariables = [
+        { identifier: 'var1', value: 1, label: 'First variable' },
+        { identifier: 'var2', value: 2, label: 'Second variable' },
+      ];
+      mutations.setAvailableVariables(state, { availableVariables });
+      expect(state.availableVariables).toEqual(availableVariables);
+    });
+  });
+
+  describe('setVariableDelimiters', function() {
+    it('set variable delimiters', () => {
+      const state = buildState({});
+      const variableDelimiters = { start: '{{', end: '}}' };
+      mutations.setVariableDelimiters(state, { variableDelimiters });
+      expect(state.variableDelimiters).toEqual(variableDelimiters);
     });
   });
 });


### PR DESCRIPTION
From now availableVariables and variableDelimiters (used in variableInput) can only be passed as props to widget.
It may be useful to use them in every widget and in QueryBuilder globally.
In prevision: added two mutations to populate state properties: `availableVariables` and `variableDelimiters`