### PR TITLE
fix: remove duplicate delete row icon

### DIFF
--- a/src/components/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/ConditionsEditor/ConditionsGroup.vue
@@ -52,7 +52,6 @@
       >
         <i aria-hidden="true" class=" far fa-trash-alt" />
       </div>
-      <i class="far fa-trash-alt" aria-hidden="true" />
     </div>
     <div
       class="conditions-group__child-group"


### PR DESCRIPTION
#599 created a duplicate icon:
![Screenshot from 2020-08-14 17-41-50](https://user-images.githubusercontent.com/932583/90267168-7d0fdf00-de55-11ea-9173-049171c0326e.png)
