### PR TITLE
fix(multiselect): display the custom label

### DIFF
--- a/src/components/stepforms/AppendStepForm.vue
+++ b/src/components/stepforms/AppendStepForm.vue
@@ -11,7 +11,6 @@
       :errors="errors"
       track-by="trackBy"
       label="label"
-      with-example
     />
     <StepFormButtonbar />
   </div>

--- a/src/components/stepforms/widgets/Multiselect.vue
+++ b/src/components/stepforms/widgets/Multiselect.vue
@@ -19,15 +19,12 @@
         :taggable="true"
         :closeOnSelect="false"
         openDirection="bottom"
+        :customLabel="customLabel"
       >
-        <!-- If you want to use those templates you should provide a 'label' and 
-    'example' key in the options-->
-        <template v-if="withExample" slot="singleLabel" slot-scope="props">
-          <span class="option__title">{{ props.option.label }}</span>
-        </template>
+        <!-- If you want to use those templates you should provide a 'label' and 'example' key in the options-->
         <template v-if="withExample" slot="option" slot-scope="props">
           <div class="option__container" :title="props.option.tooltip">
-            <div class="option__title">{{ props.option.label }}</div>
+            <div class="option__title">{{ customLabel(props.option) }}</div>
             <div class="option__example">{{ props.option.example }}</div>
           </div>
         </template>
@@ -37,11 +34,11 @@
             v-if="isVariable(option)"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
-            :value="option"
+            :value="customLabel(option)"
             @removed="remove(option)"
           />
           <span class="multiselect__tag widget-multiselect__tag" v-else>
-            <span v-html="option" />
+            <span v-html="customLabel(option)" />
             <i
               tabindex="1"
               class="multiselect__tag-icon"
@@ -123,6 +120,18 @@ export default class MultiselectWidget extends Mixins(FormWidget) {
   isVariable(value: string) {
     const identifier = extractVariableIdentifier(value, this.variableDelimiters);
     return identifier != null;
+  }
+
+  /**
+   * Returns the option's label field if possible,
+   * return the whole option otherwise
+   */
+  customLabel(option) {
+    if (typeof option === 'object' && this.label != null) {
+      return option[this.label];
+    } else {
+      return option;
+    }
   }
 }
 </script>

--- a/src/components/stepforms/widgets/Multiselect.vue
+++ b/src/components/stepforms/widgets/Multiselect.vue
@@ -13,11 +13,11 @@
         v-model="editedValue"
         :options="options"
         :placeholder="placeholder"
-        :track-by="trackBy"
+        :trackBy="trackBy"
         :label="label"
         :multiple="true"
         :taggable="true"
-        :close-on-select="false"
+        :closeOnSelect="false"
         openDirection="bottom"
       >
         <!-- If you want to use those templates you should provide a 'label' and 

--- a/tests/unit/append-step-form.spec.ts
+++ b/tests/unit/append-step-form.spec.ts
@@ -50,7 +50,6 @@ describe('Append Step Form', () => {
       { trackBy: 'dataset1', label: 'dataset1' },
       { trackBy: 'dataset2', label: 'dataset2' },
     ]);
-    expect(widgetMultiselect.props('withExample')).toEqual(true);
     expect(widgetMultiselect.props('trackBy')).toEqual('trackBy');
     expect(widgetMultiselect.props('label')).toEqual('label');
   });


### PR DESCRIPTION
This PR makes the `Multiselect` component use the `option[label]` as label, when option is an object and label is defined.