### PR TITLE
fix(data-viewer): contextual menus now hide on dataset change

### DIFF
--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -59,7 +59,7 @@
 </template>
 <script lang="ts">
 import Vue from 'vue';
-import { Component } from 'vue-property-decorator';
+import { Component, Watch } from 'vue-property-decorator';
 
 import Pagination from '@/components/Pagination.vue';
 import { DataSet, DataSetColumn, DataSetColumnType } from '@/lib/dataset';
@@ -203,6 +203,16 @@ export default class DataViewer extends Vue {
 
   closeMenu() {
     this.activeActionMenuColumnName = '';
+  }
+
+  /**
+   * These menus are associated to the column headers.
+   * It makes sense to close them when the headers change.
+   */
+  @Watch('columnHeaders')
+  onSelectedColumnsChange() {
+    this.closeMenu();
+    this.closeDataTypeMenu();
   }
 }
 </script>

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -8,12 +8,16 @@
           <thead class="data-viewer__header">
             <tr>
               <td
-                v-for="(column, index) in formattedColumns"
+                v-for="column in formattedColumns"
                 :class="column.class"
                 :key="column.name"
                 @click="toggleColumnSelection({ column: column.name })"
               >
-                <span v-if="column.type" :class="iconClass" @click.stop="openDataTypeMenu(index)">
+                <span
+                  v-if="column.type"
+                  :class="iconClass"
+                  @click.stop="openDataTypeMenu(column.name)"
+                >
                   <DataTypesMenu
                     :column-name="column.name"
                     :visible="isSupported('convert') && column.isDataTypeMenuOpened"
@@ -23,7 +27,7 @@
                   <span v-html="getIconType(column.type)" />
                 </span>
                 <span class="data-viewer__header-label">{{ column.name }}</span>
-                <span class="data-viewer__header-action" @click.stop="openMenu(index)">
+                <span class="data-viewer__header-action" @click.stop="openMenu(column.name)">
                   <ActionMenu
                     :column-name="column.name"
                     :visible="column.isActionMenuOpened"
@@ -106,8 +110,8 @@ export default class DataViewer extends Vue {
   @VQBModule.Mutation toggleColumnSelection!: ({ column }: { column: string }) => void;
   @VQBModule.Mutation setSelectedColumns!: ({ column }: { column: string }) => void;
 
-  indexActiveActionMenu = -1;
-  indexActiveDataTypeMenu = -1;
+  activeActionMenuColumnName = '';
+  activeDataTypeMenuColumnName = '';
 
   /**
    * @description Get our columns with their names and linked classes
@@ -115,23 +119,12 @@ export default class DataViewer extends Vue {
    * @return {Array<object>}
    */
   get formattedColumns() {
-    return this.columnHeaders.map((d, index) => {
-      let isActionMenuOpened = false;
-      let isDataTypeMenuOpened = false;
-
-      if (index === this.indexActiveActionMenu) {
-        isActionMenuOpened = true;
-      }
-
-      if (index === this.indexActiveDataTypeMenu) {
-        isDataTypeMenuOpened = true;
-      }
-
+    return this.columnHeaders.map(d => {
       return {
         name: d.name,
         type: d.type || 'undefined',
-        isActionMenuOpened,
-        isDataTypeMenuOpened,
+        isActionMenuOpened: this.activeActionMenuColumnName === d.name,
+        isDataTypeMenuOpened: this.activeDataTypeMenuColumnName === d.name,
         class: {
           'data-viewer__header-cell': true,
           'data-viewer__header-cell--active': this.isSelected(d.name),
@@ -194,22 +187,22 @@ export default class DataViewer extends Vue {
     }
   }
 
-  openDataTypeMenu(index: number) {
-    this.indexActiveDataTypeMenu = index;
-    this.setSelectedColumns({ column: this.formattedColumns[index].name });
+  openDataTypeMenu(name: string) {
+    this.activeDataTypeMenuColumnName = name;
+    this.setSelectedColumns({ column: name });
   }
 
   closeDataTypeMenu() {
-    this.indexActiveDataTypeMenu = -1;
+    this.activeDataTypeMenuColumnName = '';
   }
 
-  openMenu(index: number) {
-    this.indexActiveActionMenu = index;
-    this.setSelectedColumns({ column: this.formattedColumns[index].name });
+  openMenu(name: string) {
+    this.activeActionMenuColumnName = name;
+    this.setSelectedColumns({ column: name });
   }
 
   closeMenu() {
-    this.indexActiveActionMenu = -1;
+    this.activeActionMenuColumnName = '';
   }
 }
 </script>

--- a/tests/unit/data-viewer.spec.ts
+++ b/tests/unit/data-viewer.spec.ts
@@ -304,6 +304,50 @@ describe('Data Viewer', () => {
       expect(wrapper.findAll('DataTypesMenu-stub').at(0).vm.$props.visible).toBeFalsy();
     });
 
+    it('should close the menu when the dataset is changed', async () => {
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          dataset: {
+            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+            data: [
+              ['value1', 'value2', 'value3'],
+              ['value4', 'value5', 'value6'],
+              ['value7', 'value8', 'value9'],
+              ['value10', 'value11', 'value12'],
+              ['value13', 'value14', 'value15'],
+            ],
+            paginationContext: {
+              totalCount: 50,
+              pagesize: 10,
+              pageno: 1,
+            },
+          },
+        }),
+      );
+      const wrapper = shallowMount(DataViewer, { store, localVue });
+
+      const actionMenuWrapperArray = wrapper.findAll('.data-viewer__header-action');
+      expect(actionMenuWrapperArray.length).toEqual(3);
+
+      const oneActionMenuIcon = actionMenuWrapperArray.at(0);
+      // there is no ActionMenu visible yet:
+      expect(oneActionMenuIcon.find('ActionMenu-stub').exists()).toBeFalsy;
+      // on click on icon:
+      await oneActionMenuIcon.trigger('click');
+      // it should display ActionMenu:
+      const actionMenuOpened = wrapper.findAll('ActionMenu-stub').at(0);
+      expect(actionMenuOpened.vm.$props.visible).toBeTruthy();
+      // change the dataset
+      store.commit('vqb/setDataset', {
+        dataset: {
+          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+          data: [['value1', 'value2', 'value3']],
+        },
+      });
+      // the Action menu disappear:
+      expect(actionMenuOpened.vm.$props.visible).toBeFalsy();
+    });
+
     it('should not have an icon "data type menu" for not supported backends', () => {
       const store = setupMockStore(
         buildStateWithOnePipeline([], {


### PR DESCRIPTION
This PR hides the column menus when the columns headers changes.
They are redefined each time a dataset is (re)loaded.