### PR TITLE
feat (variables): add advanced variable option

### DIFF
--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -8,6 +8,7 @@
           :columnNamesProp="columnNames"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
+          :use-advanced-variable="useAdvancedVariable"
           :data-path="slotProps.dataPath"
           :errors="errors"
           :multi-variable="multiVariable"
@@ -50,6 +51,9 @@ export default class FilterEditor extends Vue {
     default: () => [],
   })
   columnNames!: string[];
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/AddTextColumnStepForm.vue
+++ b/src/components/stepforms/AddTextColumnStepForm.vue
@@ -11,6 +11,7 @@
       :warning="duplicateColumnName"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <InputTextWidget
       class="textInput"
@@ -21,6 +22,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <StepFormButtonbar />
   </div>

--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -12,6 +12,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <ListWidget
       addFieldName="Add aggregation"
@@ -25,6 +26,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <StepFormButtonbar />
   </div>

--- a/src/components/stepforms/ArgmaxStepForm.vue
+++ b/src/components/stepforms/ArgmaxStepForm.vue
@@ -10,6 +10,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <MultiselectWidget
       class="groupbyColumnsInput"
@@ -21,6 +22,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <StepFormButtonbar />
   </div>

--- a/src/components/stepforms/ArgminStepForm.vue
+++ b/src/components/stepforms/ArgminStepForm.vue
@@ -10,6 +10,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <MultiselectWidget
       class="groupbyColumnsInput"
@@ -21,6 +22,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <StepFormButtonbar />
   </div>

--- a/src/components/stepforms/ColumnPicker.vue
+++ b/src/components/stepforms/ColumnPicker.vue
@@ -9,6 +9,7 @@
     :errors="errors"
     :available-variables="availableVariables"
     :variable-delimiters="variableDelimiters"
+    :use-advanced-variable="useAdvancedVariable"
   />
 </template>
 
@@ -38,6 +39,9 @@ export default class ColumnPicker extends Vue {
 
   @Prop({ default: null })
   value!: string;
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/ConcatenateStepForm.vue
+++ b/src/components/stepforms/ConcatenateStepForm.vue
@@ -14,6 +14,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <InputTextWidget
       class="separator"

--- a/src/components/stepforms/CumSumStepForm.vue
+++ b/src/components/stepforms/CumSumStepForm.vue
@@ -11,6 +11,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <ColumnPicker
       class="referenceColumnInput"
@@ -31,6 +32,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <InputTextWidget
       class="newColumnInput"

--- a/src/components/stepforms/EvolutionStepForm.vue
+++ b/src/components/stepforms/EvolutionStepForm.vue
@@ -20,6 +20,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <AutocompleteWidget
       class="evolutionType"

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -7,6 +7,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
       @filterTreeUpdated="updateFilterTree"
     />
     <StepFormButtonbar />

--- a/src/components/stepforms/FormulaStepForm.vue
+++ b/src/components/stepforms/FormulaStepForm.vue
@@ -11,6 +11,7 @@
       :warning="duplicateColumnName"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <InputTextWidget
       class="formulaInput"

--- a/src/components/stepforms/IfThenElseStepForm.vue
+++ b/src/components/stepforms/IfThenElseStepForm.vue
@@ -16,6 +16,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
       @input="updateIfThenElse"
     />
     <StepFormButtonbar />

--- a/src/components/stepforms/RankStepForm.vue
+++ b/src/components/stepforms/RankStepForm.vue
@@ -11,6 +11,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <AutocompleteWidget
       class="orderInput"
@@ -36,6 +37,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <InputTextWidget
       class="newColumnNameInput"

--- a/src/components/stepforms/SplitStepForm.vue
+++ b/src/components/stepforms/SplitStepForm.vue
@@ -10,6 +10,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <InputTextWidget
       class="delimiter"

--- a/src/components/stepforms/TopStepForm.vue
+++ b/src/components/stepforms/TopStepForm.vue
@@ -20,6 +20,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <AutocompleteWidget
       class="sortOrderInput"
@@ -40,6 +41,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="true"
     />
     <StepFormButtonbar />
   </div>

--- a/src/components/stepforms/widgets/Aggregation.vue
+++ b/src/components/stepforms/widgets/Aggregation.vue
@@ -10,6 +10,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="useAdvancedVariable"
     />
     <AutocompleteWidget
       class="aggregationFunctionInput"
@@ -47,6 +48,9 @@ export default class AggregationWidget extends Vue {
 
   @Prop({ type: Array, default: () => [] })
   errors!: ErrorObject[];
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -5,6 +5,7 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="useAdvancedVariable"
       :has-arrow="true"
       @input="updateValue"
     >
@@ -75,6 +76,9 @@ export default class AutocompleteWidget extends Mixins(FormWidget) {
 
   @Prop({ type: Boolean, default: false })
   withExample!: boolean;
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -6,6 +6,7 @@
         :value="value.column"
         :available-variables="availableVariables"
         :variable-delimiters="variableDelimiters"
+        :use-advanced-variable="useAdvancedVariable"
         :options="columnNames"
         @input="updateStepColumn"
         placeholder="Column"
@@ -32,6 +33,7 @@
       :value="value.value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="useAdvancedVariable"
       :placeholder="placeholder"
       :data-path="`${dataPath}.value`"
       :errors="errors"
@@ -112,6 +114,9 @@ export default class FilterSimpleConditionWidget extends Vue {
   @VQBModule.Getter('columnNames') columnNamesFromStore!: string[];
 
   @VQBModule.Mutation setSelectedColumns!: MutationCallbacks['setSelectedColumns'];
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/IfThenElseWidget.vue
+++ b/src/components/stepforms/widgets/IfThenElseWidget.vue
@@ -29,6 +29,7 @@
           :data-path="`${dataPath}.if`"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
+          :use-advanced-variable="useAdvancedVariable"
           @filterTreeUpdated="updateFilterTree"
         />
       </div>
@@ -56,6 +57,7 @@
           :errors="errors"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
+          :use-advanced-variable="useAdvancedVariable"
           @input="updateThenFormula"
         />
       </div>
@@ -81,6 +83,7 @@
             :errors="errors"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
+            :use-advanced-variable="useAdvancedVariable"
             @input="updateElseFormula"
           />
         </div>
@@ -93,6 +96,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="useAdvancedVariable"
       @input="updateElseFormula"
       @deletedElseIf="transformElseIfIntoElse"
     />
@@ -132,6 +136,9 @@ import { VQBModule } from '@/store';
   },
 })
 export default class IfThenElseWidget extends Vue {
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
+
   @Prop()
   availableVariables!: VariablesBucket;
 

--- a/src/components/stepforms/widgets/InputNumber.vue
+++ b/src/components/stepforms/widgets/InputNumber.vue
@@ -10,6 +10,7 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="useAdvancedVariable"
       :has-arrow="true"
       @input="updateValue"
     >
@@ -69,6 +70,9 @@ export default class InputNumberWidget extends Mixins(FormWidget) {
 
   @Prop({ type: Number, default: undefined })
   max!: number;
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/InputText.vue
+++ b/src/components/stepforms/widgets/InputText.vue
@@ -11,6 +11,7 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="useAdvancedVariable"
       @input="updateValue"
     >
       <input
@@ -60,6 +61,9 @@ export default class InputTextWidget extends Mixins(FormWidget) {
 
   @Prop({ default: undefined })
   docUrl!: string | undefined;
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/JoinColumns.vue
+++ b/src/components/stepforms/widgets/JoinColumns.vue
@@ -9,6 +9,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="useAdvancedVariable"
     />
     <InputTextWidget
       class="rightOn"
@@ -18,6 +19,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="useAdvancedVariable"
     />
   </div>
 </template>
@@ -50,6 +52,9 @@ export default class JoinColumns extends Vue {
 
   @Prop({ type: Array, default: () => [] })
   errors!: ErrorObject[];
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -13,6 +13,7 @@
             :value="child.value"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
+            :use-advanced-variable="useAdvancedVariable"
             @input="updateChildValue($event, index)"
             :data-path="`${dataPath}[${index}]`"
             :errors="errors"
@@ -89,6 +90,9 @@ export default class ListWidget extends Mixins(FormWidget) {
 
   @Prop({ default: null })
   dataPath!: string;
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -5,6 +5,7 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="useAdvancedVariable"
       @input="updateValue"
     >
       <multiselect
@@ -74,6 +75,9 @@ export default class MultiInputTextWidget extends Vue {
 
   @Prop({ default: () => [] })
   value!: string[] | string;
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/MultiVariableInput.vue
+++ b/src/components/stepforms/widgets/MultiVariableInput.vue
@@ -3,10 +3,10 @@
     <VariableInputBase
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="useAdvancedVariable"
       :has-arrow="hasArrow"
       :is-multiple="true"
       :value="value"
-      :use-advanced-variable="useAdvancedVariable"
       @input="toggleVariable"
     >
       <slot />

--- a/src/components/stepforms/widgets/MultiVariableInput.vue
+++ b/src/components/stepforms/widgets/MultiVariableInput.vue
@@ -6,6 +6,7 @@
       :has-arrow="hasArrow"
       :is-multiple="true"
       :value="value"
+      :use-advanced-variable="useAdvancedVariable"
       @input="toggleVariable"
     >
       <slot />
@@ -29,6 +30,9 @@ import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 export default class MultiVariableInput extends Vue {
   @Prop({ type: Array, default: () => [] })
   value!: any[];
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop({ default: () => [] })
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/Multiselect.vue
+++ b/src/components/stepforms/widgets/Multiselect.vue
@@ -5,6 +5,7 @@
       :value="stringValue"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :use-advanced-variable="useAdvancedVariable"
       :has-arrow="true"
       @input="updateStringValue"
     >
@@ -95,6 +96,9 @@ export default class MultiselectWidget extends Mixins(FormWidget) {
 
   @Prop({ type: Boolean, default: false })
   withExample!: boolean;
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket[];

--- a/src/components/stepforms/widgets/VariableInput.vue
+++ b/src/components/stepforms/widgets/VariableInput.vue
@@ -15,6 +15,7 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :has-arrow="hasArrow"
+      :use-advanced-variable="useAdvancedVariable"
       @input="chooseVariable"
     >
       <slot />
@@ -43,6 +44,9 @@ import { extractVariableIdentifier, VariableDelimiters, VariablesBucket } from '
 export default class VariableInput extends Vue {
   @Prop()
   value!: any;
+
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
 
   @Prop({ default: () => [] })
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/VariableInput.vue
+++ b/src/components/stepforms/widgets/VariableInput.vue
@@ -14,8 +14,8 @@
       v-else
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :has-arrow="hasArrow"
       :use-advanced-variable="useAdvancedVariable"
+      :has-arrow="hasArrow"
       @input="chooseVariable"
     >
       <slot />

--- a/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
@@ -29,7 +29,7 @@
           <span class="widget-variable-chooser__option-value">{{ availableVariable.value }}</span>
         </div>
       </div>
-      <div class="widget-advanced-variable">advanced variable</div>
+      <div class="widget-advanced-variable">Add variable</div>
     </div>
   </popover>
 </template>
@@ -183,17 +183,17 @@ export default class VariableChooser extends Vue {
 }
 
 .widget-advanced-variable {
+  padding: 12px;
   font-size: 12px;
   font-weight: 500;
-  &:hover {
-    background-color: rgba(42, 102, 161, 0.05);
-    color: #2a66a1;
-  }
-  display: flex;
-  justify-content: space-between;
+  text-align: center;
+  background: #f5f5f5;
+  color: #888888;
   cursor: pointer;
-  margin-bottom: 5px;
-  padding: 12px;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .widget-variable-chooser__option-toggle {

--- a/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
@@ -29,7 +29,7 @@
           <span class="widget-variable-chooser__option-value">{{ availableVariable.value }}</span>
         </div>
       </div>
-      <!-- <div class="widget-advanced-variable">Advanced variable</div> -->
+      <div class="widget-advanced-variable">advanced variable</div>
     </div>
   </popover>
 </template>

--- a/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
@@ -56,6 +56,9 @@ export default class VariableInputBase extends Vue {
   @Prop({ default: () => [] })
   availableVariables!: VariablesBucket;
 
+  @Prop({ default: () => false })
+  useAdvancedVariable!: boolean;
+
   @Prop({ default: () => ({ start: '{{', end: '}}' }) })
   variableDelimiters!: VariableDelimiters;
 
@@ -78,7 +81,9 @@ export default class VariableInputBase extends Vue {
    * Determine whether to authorize or not the selection of a variable
    */
   get canBeVariable() {
-    return this.availableVariables && this.availableVariables.length > 0;
+    return (
+      (this.availableVariables && this.availableVariables.length > 0) || this.useAdvancedVariable
+    );
   }
 
   startChoosingVariable() {

--- a/stories/variable.js
+++ b/stories/variable.js
@@ -213,3 +213,55 @@ stories.add('wrapping a InputNumber', () => ({
     };
   },
 }));
+
+stories.add('wrapping a widget with advanced variable', () => ({
+  template: `
+    <div>
+      <Multiselect 
+        v-model="value" 
+        :available-variables="availableVariables"
+        :variableDelimiters="variableDelimiters"
+        :use-advanced-variable="useAdvancedVariable"
+        :options="options"
+      />
+      <pre>{{ value }}</pre>
+    </div>
+  `,
+
+  components: { Multiselect },
+
+  data() {
+    return {
+      value: undefined,
+      options: ['foo', 'bar', 'helloworld'],
+      useAdvancedVariable: true,
+      availableVariables: SAMPLE_VARIABLES,
+      variableDelimiters: { start: '{{', end: '}}' },
+    };
+  },
+}));
+
+stories.add('wrapping a widget with advanced variable and no variables', () => ({
+  template: `
+    <div>
+      <Multiselect 
+        v-model="value" 
+        :variableDelimiters="variableDelimiters"
+        :use-advanced-variable="useAdvancedVariable"
+        :options="options"
+      />
+      <pre>{{ value }}</pre>
+    </div>
+  `,
+
+  components: { Multiselect },
+
+  data() {
+    return {
+      value: undefined,
+      options: ['foo', 'bar', 'helloworld'],
+      useAdvancedVariable: true,
+      variableDelimiters: { start: '{{', end: '}}' },
+    };
+  },
+}));

--- a/tests/unit/variable-chooser.spec.ts
+++ b/tests/unit/variable-chooser.spec.ts
@@ -80,6 +80,16 @@ describe('Variable Chooser', () => {
     });
   });
 
+  it('should always display an "Advanced variable" option ...', () => {
+    expect(wrapper.find('.widget-advanced-variable').exists()).toBe(true);
+  });
+
+  it('... even without other values', async () => {
+    wrapper.setProps({ availableVariables: [] });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.widget-advanced-variable').exists()).toBe(true);
+  });
+
   describe('when closing the popover', () => {
     beforeEach(async () => {
       wrapper.find('popover-stub').vm.$emit('closed');

--- a/tests/unit/variable-input-base.spec.ts
+++ b/tests/unit/variable-input-base.spec.ts
@@ -73,6 +73,12 @@ describe('Variable Input', () => {
       it('should not be present', () => {
         expect(wrapper.find('.widget-variable__toggle').exists()).toBe(false);
       });
+
+      it('... except if advanced variable is allowed', async () => {
+        wrapper.setProps({ useAdvancedVariable: true });
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find('.widget-variable__toggle').exists()).toBe(true);
+      });
     });
 
     describe('when clicked', () => {


### PR DESCRIPTION
- Add "Advanced variable option" to variable chooser
- Allow to use advanced variable in widget and steps even if no availableVariables are provided
( As we keep need to hide variableChooser in fields that can't be variable, we need to had a boolean from parent through variableInput ). 