### PR TITLE
feat(variableInput): add counter in button picker for multi selected …

### DIFF
--- a/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
@@ -11,11 +11,14 @@
         v-if="canBeVariable"
         class="widget-variable__toggle"
         :class="{
+          'widget-variable__toggle--multi-selected': hasMultipleSelectedVariables,
           'widget-variable__toggle--choosing': isChoosingVariable,
           'widget-variable__toggle--parent-arrow': hasArrow,
         }"
         @click.stop="startChoosingVariable"
-        >{}
+      >
+        <template v-if="hasMultipleSelectedVariables">+{{ selectedVariables.length }}</template>
+        <template v-else>{}</template>
       </span>
     </div>
 
@@ -94,6 +97,13 @@ export default class VariableInputBase extends Vue {
       const identifier = extractVariableIdentifier(value, this.variableDelimiters);
       return identifier ? [...variables, identifier] : variables;
     }, []);
+  }
+
+  /**
+   * Display number of selected variables in multiple mode
+   */
+  get hasMultipleSelectedVariables() {
+    return this.isMultiple && this.selectedVariables.length >= 2;
   }
 
   /**
@@ -197,5 +207,17 @@ export default class VariableInputBase extends Vue {
   &.widget-variable__toggle--parent-arrow {
     right: 35px;
   }
+}
+
+.widget-variable__toggle--multi-selected {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  font-size: 12px;
+  width: 20px;
+  height: 20px;
+  opacity: 1;
+  visibility: visible;
 }
 </style>

--- a/tests/unit/variable-input-base.spec.ts
+++ b/tests/unit/variable-input-base.spec.ts
@@ -216,4 +216,19 @@ describe('Variable Input', () => {
       expect(wrapper.find('AdvancedVariableModal-stub').props().isOpened).toBe(true);
     });
   });
+
+  describe('with multi variables selected (>= 2)', () => {
+    beforeEach(() => {
+      wrapper.setProps({ isMultiple: true, value: ['{{ a }}', '{{ b }}'] });
+    });
+    it('should use multi variables mode', () => {
+      expect((wrapper.vm as any).hasMultipleSelectedVariables).toBe(true);
+    });
+    it('should replace the {} sign in button picker by selected variables length', () => {
+      expect(wrapper.find('.widget-variable__toggle').text()).toBe('+2');
+    });
+    it('should add specific style to button picker', () => {
+      expect(wrapper.find('.widget-variable__toggle--multi-selected').exists()).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Add a counter in multiVariableInputs when there is more than 2 variables to specifiy user how many variables he picked.

Before:
![before](https://user-images.githubusercontent.com/59559689/91316504-2c837480-e7b9-11ea-91e0-3eddca61ad23.png)
After with more than 2 variables (is always visible):
![more](https://user-images.githubusercontent.com/59559689/91316552-3907cd00-e7b9-11ea-9b3b-0a4291e7d22d.png)
![test](https://user-images.githubusercontent.com/59559689/91317089-e975d100-e7b9-11ea-8ba4-4b88878afaed.gif)

