### PR TITLE
Js translator

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,18 +1,15 @@
 # From https://docs.featurepeek.com/github-actions/
-name: Build storybook
+name: Build playground
 on: push
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: '12.x'
     - name: Cache node modules
       uses: actions/cache@v1
       with:
@@ -24,11 +21,15 @@ jobs:
           ${{ runner.OS }}-
     - name: Install dependencies
       run: yarn --frozen-lockfile
-    - name: Build Weaverbird components bundle
-      run: yarn storybook:bundle
-    - name: Build storybook
-      run: yarn storybook:build
+    - name: Build Weaverbird module
+      run: yarn build-bundle
+    - name: Copy weaverbird script into dist folder
+      run: cp --remove-destination dist/weaverbird.browser.js playground/dist/weaverbird.browser.js
+    - name: Copy weaverbird CSS into dist folder
+      run: cp --remove-destination dist/weaverbird.css playground/dist/playground.css
+    - name: Copy playground script into dist folder
+      run: cp --remove-destination playground/app.js playground/dist/app.js
     - name: Ping FeaturePeek
-      run: bash <(curl -s https://peek.run/ci) -a storybook
+      run: bash <(curl -s https://peek.run/ci) -a playground
       env:
         CI: true

--- a/peek.yml
+++ b/peek.yml
@@ -1,5 +1,9 @@
 version: 2
 
-main:
+playground:
+  type: static
+  path: /playground/dist
+
+storybook:
   type: static
   path: /.storybook/dist

--- a/playground/app.js
+++ b/playground/app.js
@@ -161,10 +161,7 @@ class MongoService {
   }
 }
 
-const mongoservice = new MongoService();
-const mongoBackendPlugin = servicePluginFactory(mongoservice);
-
-class DataService {
+class JsDataService {
   constructor() {
     this.dataDomains = {
       defaultDataset: [{
@@ -204,9 +201,17 @@ class DataService {
       };
     }
   }
+
+  async loadCSV(file) {
+    throw Error('Not implemented');
+  }
 }
 
-const dataService = new DataService();
+/* Use either:
+   - `JsDataService`: to execute all data transforms directly in the browser
+   - `MongoService`: to query against a Mongo database
+ */
+const dataService = new JsDataService();
 const dataBackendPlugin = servicePluginFactory(dataService);
 
 async function buildVueApp() {
@@ -258,7 +263,7 @@ async function buildVueApp() {
           groupname: 'Group 1',
         },
       });
-      const collections = await mongoservice.listCollections();
+      const collections = await dataService.listCollections();
       store.commit(VQBnamespace('setDomains'), { domains: collections });
       store.dispatch(VQBnamespace('updateDataset'));
     },
@@ -325,7 +330,7 @@ async function buildVueApp() {
         this.draggedover = false;
         event.preventDefault();
         // For the moment, only take one file and we should also test event.target
-        const { collection: domain } = await mongoservice.loadCSV(event.dataTransfer.files[0]);
+        const { collection: domain } = await dataService.loadCSV(event.dataTransfer.files[0]);
         await setupInitialData(store, domain);
         event.target.value = null;
       },

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -156,13 +156,13 @@ export type FilterSimpleCondition =
   | FilterConditionEquality
   | FilterConditionInclusion;
 
-type FilterConditionComparison = {
+export type FilterConditionComparison = {
   column: string;
   value: number | string;
   operator: 'gt' | 'ge' | 'lt' | 'le';
 };
 
-type FilterConditionEquality = {
+export type FilterConditionEquality = {
   column: string;
   value: any;
   operator: 'eq' | 'ne' | 'isnull' | 'notnull' | 'matches' | 'notmatches';

--- a/src/lib/translators/index.ts
+++ b/src/lib/translators/index.ts
@@ -8,6 +8,7 @@
 import { PipelineStepName } from '@/lib/steps';
 
 import { BaseTranslator } from './base';
+import { JavaScriptTranslator } from './js';
 import { Mongo36Translator } from './mongo';
 import { Mongo40Translator } from './mongo4';
 
@@ -57,5 +58,6 @@ export function availableTranslators() {
   return { ...TRANSLATORS };
 }
 
+registerTranslator('js', JavaScriptTranslator);
 registerTranslator('mongo36', Mongo36Translator);
 registerTranslator('mongo40', Mongo40Translator);

--- a/src/lib/translators/js.ts
+++ b/src/lib/translators/js.ts
@@ -110,6 +110,20 @@ export class JavaScriptTranslator extends BaseTranslator {
       return data.filter(filteringFunctionForCondition(filterStep.condition));
     };
   }
+
+  // transform a "text" step into corresponding function
+  text(step: Readonly<S.AddTextColumnStep>): JsStepFunction {
+    function addTextColumnToRow(row: Readonly<DataRow>) {
+      return {
+        ...row,
+        [step.new_column]: step.text,
+      };
+    }
+
+    return function(data: Readonly<DataTable>, _dataDomains: Readonly<DataDomains>) {
+      return data.map(addTextColumnToRow);
+    };
+  }
 }
 
 /**

--- a/src/lib/translators/js.ts
+++ b/src/lib/translators/js.ts
@@ -124,6 +124,19 @@ export class JavaScriptTranslator extends BaseTranslator {
       return data.map(addTextColumnToRow);
     };
   }
+
+  /**
+   * Transform a "custom" step into corresponding function
+   *
+   * The "query" parameter of the custom step should be a javascript function, of which the first parameter will be
+   * the data table, and the second an object of all available domains.
+   */
+  custom(step: Readonly<S.CustomStep>) {
+    const func = Function('"use strict";return (' + step.query + ')')();
+    return function(data: Readonly<DataTable>, dataDomains: Readonly<DataDomains>) {
+      return func(data, dataDomains);
+    };
+  }
 }
 
 /**

--- a/src/lib/translators/js.ts
+++ b/src/lib/translators/js.ts
@@ -1,0 +1,70 @@
+/**
+ * The JavaScript translator turns pipelines steps into functions.
+ *
+ * With it, pipelines can be executed right in the browser, without any
+ * database engine. This is very useful for testing, getting an idea of how
+ * transformations works and provide a specification for transformations steps.
+ * For web apps, it can also enable offline data processing.
+ *
+ * Input data must be of the form:
+ * ```
+ * {
+ *   "domainA": [{
+ *     "column1": 123,
+ *     "column2": 456,
+ *     ...
+ *   }, ...],
+ *  "domainB": [...],
+ *  ...
+ *  }
+ *  ```
+ */
+import * as S from '@/lib/steps';
+import { BaseTranslator } from '@/lib/translators/base';
+
+type ColumnName = string | number;
+type DataRow = Record<ColumnName, any>;
+export type DataTable = DataRow[];
+export type DataDomains = Record<string, DataTable>;
+
+/**
+ * Each step will be translated into a function that outputs a data table. We call these StepFunctions.
+ *
+ * Some step functions needs the entire library of data domains as argument (domain and combination steps),
+ * but most only needs the current data table. They all have the same signature so they can be called easily in a loop.
+ */
+type JsStepFunction = (data: Readonly<DataTable>, domains: Readonly<DataDomains>) => DataTable;
+
+export class JavaScriptTranslator extends BaseTranslator {
+  static label = 'JavaScript';
+
+  constructor() {
+    super();
+  }
+
+  translate(pipeline: S.Pipeline): JsStepFunction[] {
+    return super.translate(pipeline) as JsStepFunction[];
+  }
+
+  // transform a "domain" step into corresponding function
+  domain(domainStep: Readonly<S.DomainStep>): JsStepFunction {
+    return function(_data: Readonly<DataTable>, dataDomains: Readonly<DataDomains>) {
+      return dataDomains[domainStep.domain];
+    };
+  }
+}
+
+/**
+ * The execute function provides a simple way to execute all the translated JsStepFunctions sequentially, to return the
+ * result of the data transformation.
+ */
+export function execute(
+  dataDomains: Readonly<DataDomains>,
+  jsStepFunctions: Readonly<JsStepFunction[]>,
+): DataTable {
+  let result: DataTable = [];
+  for (const jsStepFunction of jsStepFunctions) {
+    result = jsStepFunction(result, dataDomains);
+  }
+  return result;
+}

--- a/tests/unit/js.spec.ts
+++ b/tests/unit/js.spec.ts
@@ -69,7 +69,7 @@ describe('Pipeline to js function translator', () => {
           operator: 'eq',
         },
       });
-      expect(filterALabel(SAMPLE_DATA, {})).toEqual([{label: 'A', value: 1}]);
+      expect(filterALabel(SAMPLE_DATA, {})).toEqual([{ label: 'A', value: 1 }]);
     });
 
     it('should handle and conditions with matches and gt', () => {
@@ -91,7 +91,7 @@ describe('Pipeline to js function translator', () => {
         },
       });
       expect(filterValuesGreaterThan1AndLabelsWithOnlyOneLetter(SAMPLE_DATA, {})).toEqual([
-        {label: 'B', value: 2},
+        { label: 'B', value: 2 },
       ]);
     });
 
@@ -114,9 +114,9 @@ describe('Pipeline to js function translator', () => {
         },
       });
       expect(filterLabelsWithMoreThanOneLetterOrValuesLessThan1(SAMPLE_DATA, {})).toEqual([
-        {label: 'A', value: 1},
-        {label: 'alpha', value: 0.1},
-        {label: 'beta', value: 0.2},
+        { label: 'A', value: 1 },
+        { label: 'alpha', value: 0.1 },
+        { label: 'beta', value: 0.2 },
       ]);
     });
 
@@ -171,9 +171,9 @@ describe('Pipeline to js function translator', () => {
         },
       });
       expect(filterNotEqual(SAMPLE_DATA, {})).toEqual([
-        {label: 'B', value: 2},
-        {label: 'alpha', value: 0.1},
-        {label: 'beta', value: 0.2},
+        { label: 'B', value: 2 },
+        { label: 'alpha', value: 0.1 },
+        { label: 'beta', value: 0.2 },
       ]);
     });
 
@@ -182,7 +182,7 @@ describe('Pipeline to js function translator', () => {
         name: 'filter',
         condition: {
           or: [
-            {column: 'value', operator: 'lt', value: 0.2},
+            { column: 'value', operator: 'lt', value: 0.2 },
             {
               column: 'value',
               operator: 'ge',
@@ -192,8 +192,8 @@ describe('Pipeline to js function translator', () => {
         },
       });
       expect(filterLowerThan1OrGreatherThan1(SAMPLE_DATA, {})).toEqual([
-        {label: 'B', value: 2},
-        {label: 'alpha', value: 0.1},
+        { label: 'B', value: 2 },
+        { label: 'alpha', value: 0.1 },
       ]);
     });
 
@@ -207,8 +207,8 @@ describe('Pipeline to js function translator', () => {
         },
       });
       expect(filterIn(SAMPLE_DATA, {})).toEqual([
-        {label: 'A', value: 1},
-        {label: 'alpha', value: 0.1},
+        { label: 'A', value: 1 },
+        { label: 'alpha', value: 0.1 },
       ]);
     });
 

--- a/tests/unit/js.spec.ts
+++ b/tests/unit/js.spec.ts
@@ -1,0 +1,38 @@
+import { getTranslator } from '@/lib/translators';
+import {execute, JavaScriptTranslator, DataTable, DataDomains} from '@/lib/translators/js';
+import {Pipeline} from "@/lib/steps";
+
+describe('Pipeline to js function translator', () => {
+  const jsTranslator = getTranslator('js') as JavaScriptTranslator;
+  const SAMPLE_DATA: DataDomains = {
+    domainA: [
+      {label: 'A', value: 1},
+      {label: 'B', value: 2}
+    ],
+    domainB: [
+      {label: 'alpha', value: 0.1},
+      {label: 'beta', value: 0.2}
+    ]
+  }
+
+  function expectResultFromPipeline(pipeline: Pipeline, data: DataDomains, expectedResult: DataTable) {
+    expect(execute(data, jsTranslator.translate(pipeline))).toEqual(expectedResult);
+  }
+
+  it('can handle domain steps', () => {
+    expectResultFromPipeline(
+      [{ name: 'domain', domain: 'domainA' }],
+      SAMPLE_DATA,
+      [
+      {label: 'A', value: 1},
+      {label: 'B', value: 2}
+    ]);
+    expectResultFromPipeline(
+      [{ name: 'domain', domain: 'domainB' }],
+      SAMPLE_DATA,
+      [
+      {label: 'alpha', value: 0.1},
+      {label: 'beta', value: 0.2}
+    ]);
+  });
+});

--- a/tests/unit/js.spec.ts
+++ b/tests/unit/js.spec.ts
@@ -240,4 +240,18 @@ describe('Pipeline to js function translator', () => {
       expect(() => invalidFilter(SAMPLE_DATA, {})).toThrow();
     });
   });
+
+  describe('text step', () => {
+    it('should add a column with text to each row', () => {
+      const addTextColumn = jsTranslator.text({
+        name: 'text',
+        text: 'some text',
+        new_column: 'text_new_column',
+      });
+      expect(addTextColumn(SAMPLE_DATA.domainA, {})).toEqual([
+        { label: 'A', value: 1, text_new_column: 'some text' },
+        { label: 'B', value: 2, text_new_column: 'some text' },
+      ]);
+    });
+  });
 });

--- a/tests/unit/js.spec.ts
+++ b/tests/unit/js.spec.ts
@@ -254,4 +254,23 @@ describe('Pipeline to js function translator', () => {
       ]);
     });
   });
+
+  describe('custom step', () => {
+    it('should apply the custom function to data', () => {
+      const addPlipPloupAndDoubleValue = jsTranslator.custom({
+        name: 'custom',
+        query: `function transformData(data) {
+          return data.map(d => ({
+            ...d,
+            value: d.value * 2,
+            plip: "ploup"
+          }));
+        }`,
+      });
+      expect(addPlipPloupAndDoubleValue(SAMPLE_DATA.domainA, {})).toEqual([
+        { label: 'A', value: 2, plip: 'ploup' },
+        { label: 'B', value: 4, plip: 'ploup' },
+      ]);
+    });
+  });
 });

--- a/tests/unit/js.spec.ts
+++ b/tests/unit/js.spec.ts
@@ -1,38 +1,243 @@
+import { Pipeline } from '@/lib/steps';
 import { getTranslator } from '@/lib/translators';
-import {execute, JavaScriptTranslator, DataTable, DataDomains} from '@/lib/translators/js';
-import {Pipeline} from "@/lib/steps";
+import { DataDomains, DataTable, execute, JavaScriptTranslator } from '@/lib/translators/js';
 
 describe('Pipeline to js function translator', () => {
   const jsTranslator = getTranslator('js') as JavaScriptTranslator;
   const SAMPLE_DATA: DataDomains = {
     domainA: [
-      {label: 'A', value: 1},
-      {label: 'B', value: 2}
+      { label: 'A', value: 1 },
+      { label: 'B', value: 2 },
     ],
     domainB: [
-      {label: 'alpha', value: 0.1},
-      {label: 'beta', value: 0.2}
-    ]
-  }
+      { label: 'alpha', value: 0.1 },
+      { label: 'beta', value: 0.2 },
+    ],
+  };
 
-  function expectResultFromPipeline(pipeline: Pipeline, data: DataDomains, expectedResult: DataTable) {
+  function expectResultFromPipeline(
+    pipeline: Pipeline,
+    data: DataDomains,
+    expectedResult: DataTable,
+  ) {
     expect(execute(data, jsTranslator.translate(pipeline))).toEqual(expectedResult);
   }
 
-  it('can handle domain steps', () => {
-    expectResultFromPipeline(
-      [{ name: 'domain', domain: 'domainA' }],
-      SAMPLE_DATA,
-      [
-      {label: 'A', value: 1},
-      {label: 'B', value: 2}
+  it('should handle domain steps', () => {
+    expectResultFromPipeline([{ name: 'domain', domain: 'domainA' }], SAMPLE_DATA, [
+      { label: 'A', value: 1 },
+      { label: 'B', value: 2 },
     ]);
-    expectResultFromPipeline(
-      [{ name: 'domain', domain: 'domainB' }],
-      SAMPLE_DATA,
-      [
-      {label: 'alpha', value: 0.1},
-      {label: 'beta', value: 0.2}
+    expectResultFromPipeline([{ name: 'domain', domain: 'domainB' }], SAMPLE_DATA, [
+      { label: 'alpha', value: 0.1 },
+      { label: 'beta', value: 0.2 },
     ]);
+  });
+
+  describe('filter step', () => {
+    const SAMPLE_DATA = [
+      { label: 'A', value: 1 },
+      { label: 'B', value: 2 },
+      { label: 'alpha', value: 0.1 },
+      { label: 'beta', value: 0.2 },
+    ];
+
+    const DATA_WITH_NULL_LABELS = [
+      {
+        label: 'A',
+      },
+      {
+        label: 'B',
+      },
+      {
+        label: null,
+      },
+      {
+        label: undefined,
+      },
+      {
+        value: 2,
+      },
+    ];
+
+    it('should handle simple equality condition', () => {
+      const filterALabel = jsTranslator.filter({
+        name: 'filter',
+        condition: {
+          column: 'label',
+          value: 'A',
+          operator: 'eq',
+        },
+      });
+      expect(filterALabel(SAMPLE_DATA, {})).toEqual([{label: 'A', value: 1}]);
+    });
+
+    it('should handle and conditions with matches and gt', () => {
+      const filterValuesGreaterThan1AndLabelsWithOnlyOneLetter = jsTranslator.filter({
+        name: 'filter',
+        condition: {
+          and: [
+            {
+              column: 'label',
+              value: '^[A-Za-z]$',
+              operator: 'matches',
+            },
+            {
+              column: 'value',
+              value: 1,
+              operator: 'gt',
+            },
+          ],
+        },
+      });
+      expect(filterValuesGreaterThan1AndLabelsWithOnlyOneLetter(SAMPLE_DATA, {})).toEqual([
+        {label: 'B', value: 2},
+      ]);
+    });
+
+    it('should handle or conditions with notmatches and le', () => {
+      const filterLabelsWithMoreThanOneLetterOrValuesLessThan1 = jsTranslator.filter({
+        name: 'filter',
+        condition: {
+          or: [
+            {
+              column: 'label',
+              value: '^[A-Za-z]$',
+              operator: 'notmatches',
+            },
+            {
+              column: 'value',
+              value: 1,
+              operator: 'le',
+            },
+          ],
+        },
+      });
+      expect(filterLabelsWithMoreThanOneLetterOrValuesLessThan1(SAMPLE_DATA, {})).toEqual([
+        {label: 'A', value: 1},
+        {label: 'alpha', value: 0.1},
+        {label: 'beta', value: 0.2},
+      ]);
+    });
+
+    it('should handle notnull conditions', () => {
+      const filterNotNull = jsTranslator.filter({
+        name: 'filter',
+        condition: {
+          column: 'label',
+          operator: 'notnull',
+          value: null,
+        },
+      });
+      expect(filterNotNull(DATA_WITH_NULL_LABELS, {})).toEqual([
+        {
+          label: 'A',
+        },
+        {
+          label: 'B',
+        },
+      ]);
+    });
+
+    it('should handle null conditions', () => {
+      const filterNull = jsTranslator.filter({
+        name: 'filter',
+        condition: {
+          column: 'label',
+          operator: 'isnull',
+          value: null,
+        },
+      });
+      expect(filterNull(DATA_WITH_NULL_LABELS, {})).toEqual([
+        {
+          label: null,
+        },
+        {
+          label: undefined,
+        },
+        {
+          value: 2,
+        },
+      ]);
+    });
+
+    it('should handle ne conditions', () => {
+      const filterNotEqual = jsTranslator.filter({
+        name: 'filter',
+        condition: {
+          column: 'label',
+          operator: 'ne',
+          value: 'A',
+        },
+      });
+      expect(filterNotEqual(SAMPLE_DATA, {})).toEqual([
+        {label: 'B', value: 2},
+        {label: 'alpha', value: 0.1},
+        {label: 'beta', value: 0.2},
+      ]);
+    });
+
+    it('should handle or conditions with lt and ge', () => {
+      const filterLowerThan1OrGreatherThan1 = jsTranslator.filter({
+        name: 'filter',
+        condition: {
+          or: [
+            {column: 'value', operator: 'lt', value: 0.2},
+            {
+              column: 'value',
+              operator: 'ge',
+              value: 2,
+            },
+          ],
+        },
+      });
+      expect(filterLowerThan1OrGreatherThan1(SAMPLE_DATA, {})).toEqual([
+        {label: 'B', value: 2},
+        {label: 'alpha', value: 0.1},
+      ]);
+    });
+
+    it('should handle in conditions', () => {
+      const filterIn = jsTranslator.filter({
+        name: 'filter',
+        condition: {
+          column: 'label',
+          operator: 'in',
+          value: ['A', 'alpha'],
+        },
+      });
+      expect(filterIn(SAMPLE_DATA, {})).toEqual([
+        {label: 'A', value: 1},
+        {label: 'alpha', value: 0.1},
+      ]);
+    });
+
+    it('should handle nin conditions', () => {
+      const filterNotIn = jsTranslator.filter({
+        name: 'filter',
+        condition: {
+          column: 'label',
+          operator: 'nin',
+          value: ['A', 'alpha'],
+        },
+      });
+      expect(filterNotIn(SAMPLE_DATA, {})).toEqual([
+        { label: 'B', value: 2 },
+        { label: 'beta', value: 0.2 },
+      ]);
+    });
+
+    it('should throw if the operator is not valid', () => {
+      const invalidFilter = jsTranslator.filter({
+        name: 'filter',
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        condition: {
+          column: 'label',
+          operator: 'what',
+        },
+      });
+      expect(() => invalidFilter(SAMPLE_DATA, {})).toThrow();
+    });
   });
 });

--- a/tests/unit/translator.spec.ts
+++ b/tests/unit/translator.spec.ts
@@ -72,7 +72,7 @@ describe('translator registration', () => {
   it('should be possible to register backends', () => {
     registerTranslator('dummy', DummyStringTranslator);
     expect(backendsSupporting('aggregate')).toEqual(['mongo36', 'mongo40']);
-    expect(backendsSupporting('domain')).toEqual(['dummy', 'mongo36', 'mongo40']);
+    expect(backendsSupporting('domain')).toEqual(['dummy', 'js', 'mongo36', 'mongo40']);
   });
 
   it('should throw an error if backend is not available', () => {
@@ -82,6 +82,6 @@ describe('translator registration', () => {
   it('should be possible to get all available translators', () => {
     registerTranslator('dummy', DummyStringTranslator);
     const translators = availableTranslators();
-    expect(Object.keys(translators).sort()).toEqual(['dummy', 'mongo36', 'mongo40']);
+    expect(Object.keys(translators).sort()).toEqual(['dummy', 'js', 'mongo36', 'mongo40']);
   });
 });


### PR DESCRIPTION
As a side-project, I started to develop a translator that transform pipelines into js functions.
This enables the playground to run client-side only. Once complete (all steps supported), it can also be used as reference for how transformations are expected to work (with tests) or to preview transformations when the database/server is not available.

Closes #519 