### PR TITLE
feat(advanced-variable): update variable delimiters mutation to add advanced delimiters

### DIFF
--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -9,6 +9,7 @@
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
           :use-advanced-variable="useAdvancedVariable"
+          :advanced-variable-delimiters="advancedVariableDelimiters"
           :data-path="slotProps.dataPath"
           :errors="errors"
           :multi-variable="multiVariable"
@@ -60,6 +61,9 @@ export default class FilterEditor extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Boolean, default: true })
   multiVariable!: boolean; // display multiInputText as multiVariableInput

--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -8,7 +8,6 @@
           :columnNamesProp="columnNames"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
-          :use-advanced-variable="useAdvancedVariable"
           :advanced-variable-delimiters="advancedVariableDelimiters"
           :data-path="slotProps.dataPath"
           :errors="errors"
@@ -52,9 +51,6 @@ export default class FilterEditor extends Vue {
     default: () => [],
   })
   columnNames!: string[];
-
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/AddTextColumnStepForm.vue
+++ b/src/components/stepforms/AddTextColumnStepForm.vue
@@ -12,7 +12,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <InputTextWidget
       class="textInput"
@@ -24,7 +23,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <StepFormButtonbar />
   </div>

--- a/src/components/stepforms/AddTextColumnStepForm.vue
+++ b/src/components/stepforms/AddTextColumnStepForm.vue
@@ -11,6 +11,7 @@
       :warning="duplicateColumnName"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <InputTextWidget
@@ -22,6 +23,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <StepFormButtonbar />
@@ -50,6 +52,8 @@ export default class AddTextColumnStepForm extends BaseStepForm<AddTextColumnSte
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'text', new_column: '', text: '' }) })
   initialStepValue!: AddTextColumnStep;

--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -12,6 +12,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <ListWidget
@@ -26,6 +27,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <StepFormButtonbar />
@@ -57,6 +59,8 @@ export default class AggregateStepForm extends BaseStepForm<AggregationStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'aggregate', on: [], aggregations: [] }) })
   initialStepValue!: AggregationStep;

--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -13,7 +13,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <ListWidget
       addFieldName="Add aggregation"
@@ -28,7 +27,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <StepFormButtonbar />
   </div>

--- a/src/components/stepforms/ArgmaxStepForm.vue
+++ b/src/components/stepforms/ArgmaxStepForm.vue
@@ -10,6 +10,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <MultiselectWidget
@@ -22,6 +23,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <StepFormButtonbar />
@@ -52,6 +54,8 @@ export default class ArgmaxStepForm extends BaseStepForm<ArgmaxStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'argmax', column: '' }) })
   initialStepValue!: ArgmaxStep;

--- a/src/components/stepforms/ArgmaxStepForm.vue
+++ b/src/components/stepforms/ArgmaxStepForm.vue
@@ -11,7 +11,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <MultiselectWidget
       class="groupbyColumnsInput"
@@ -24,7 +23,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <StepFormButtonbar />
   </div>

--- a/src/components/stepforms/ArgminStepForm.vue
+++ b/src/components/stepforms/ArgminStepForm.vue
@@ -11,7 +11,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <MultiselectWidget
       class="groupbyColumnsInput"
@@ -24,7 +23,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <StepFormButtonbar />
   </div>

--- a/src/components/stepforms/ArgminStepForm.vue
+++ b/src/components/stepforms/ArgminStepForm.vue
@@ -10,6 +10,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <MultiselectWidget
@@ -22,6 +23,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <StepFormButtonbar />
@@ -52,6 +54,8 @@ export default class ArgminStepForm extends BaseStepForm<ArgminStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'argmin', column: '' }) })
   initialStepValue!: ArgminStep;

--- a/src/components/stepforms/ColumnPicker.vue
+++ b/src/components/stepforms/ColumnPicker.vue
@@ -9,6 +9,7 @@
     :errors="errors"
     :available-variables="availableVariables"
     :variable-delimiters="variableDelimiters"
+    :advanced-variable-delimiters="advancedVariableDelimiters"
     :use-advanced-variable="useAdvancedVariable"
   />
 </template>
@@ -48,6 +49,9 @@ export default class ColumnPicker extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   // Whether the column data of ColumnPicker should react to a change of
   // selected column

--- a/src/components/stepforms/ColumnPicker.vue
+++ b/src/components/stepforms/ColumnPicker.vue
@@ -10,7 +10,6 @@
     :available-variables="availableVariables"
     :variable-delimiters="variableDelimiters"
     :advanced-variable-delimiters="advancedVariableDelimiters"
-    :use-advanced-variable="useAdvancedVariable"
   />
 </template>
 
@@ -40,9 +39,6 @@ export default class ColumnPicker extends Vue {
 
   @Prop({ default: null })
   value!: string;
-
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/ConcatenateStepForm.vue
+++ b/src/components/stepforms/ConcatenateStepForm.vue
@@ -14,6 +14,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <InputTextWidget
@@ -62,6 +63,8 @@ export default class ConcatenateStepForm extends BaseStepForm<ConcatenateStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/ConcatenateStepForm.vue
+++ b/src/components/stepforms/ConcatenateStepForm.vue
@@ -15,7 +15,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <InputTextWidget
       class="separator"

--- a/src/components/stepforms/CumSumStepForm.vue
+++ b/src/components/stepforms/CumSumStepForm.vue
@@ -12,7 +12,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <ColumnPicker
       class="referenceColumnInput"
@@ -34,7 +33,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <InputTextWidget
       class="newColumnInput"

--- a/src/components/stepforms/CumSumStepForm.vue
+++ b/src/components/stepforms/CumSumStepForm.vue
@@ -11,6 +11,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <ColumnPicker
@@ -32,6 +33,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <InputTextWidget
@@ -74,6 +76,8 @@ export default class CumSumStepForm extends BaseStepForm<CumSumStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'cumsum', valueColumn: '', referenceColumn: '' }) })
   initialStepValue!: CumSumStep;

--- a/src/components/stepforms/EvolutionStepForm.vue
+++ b/src/components/stepforms/EvolutionStepForm.vue
@@ -21,7 +21,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <AutocompleteWidget
       class="evolutionType"

--- a/src/components/stepforms/EvolutionStepForm.vue
+++ b/src/components/stepforms/EvolutionStepForm.vue
@@ -20,6 +20,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <AutocompleteWidget
@@ -96,6 +97,8 @@ export default class EvolutionStepForm extends BaseStepForm<EvolutionStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -8,7 +8,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
       @filterTreeUpdated="updateFilterTree"
     />
     <StepFormButtonbar />

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -7,6 +7,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
       @filterTreeUpdated="updateFilterTree"
     />
@@ -49,6 +50,8 @@ export default class FilterStepForm extends BaseStepForm<FilterStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   readonly title: string = 'Filter';
 

--- a/src/components/stepforms/FormulaStepForm.vue
+++ b/src/components/stepforms/FormulaStepForm.vue
@@ -12,7 +12,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <InputTextWidget
       class="formulaInput"

--- a/src/components/stepforms/FormulaStepForm.vue
+++ b/src/components/stepforms/FormulaStepForm.vue
@@ -11,6 +11,7 @@
       :warning="duplicateColumnName"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <InputTextWidget
@@ -49,6 +50,8 @@ export default class FormulaStepForm extends BaseStepForm<FormulaStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'formula', new_column: '', formula: '' }) })
   initialStepValue!: FormulaStep;

--- a/src/components/stepforms/IfThenElseStepForm.vue
+++ b/src/components/stepforms/IfThenElseStepForm.vue
@@ -16,6 +16,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
       @input="updateIfThenElse"
     />
@@ -68,6 +69,8 @@ export default class IfThenElseStepForm extends BaseStepForm<IfThenElseStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/IfThenElseStepForm.vue
+++ b/src/components/stepforms/IfThenElseStepForm.vue
@@ -17,7 +17,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
       @input="updateIfThenElse"
     />
     <StepFormButtonbar />

--- a/src/components/stepforms/RankStepForm.vue
+++ b/src/components/stepforms/RankStepForm.vue
@@ -12,7 +12,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <AutocompleteWidget
       class="orderInput"
@@ -39,7 +38,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <InputTextWidget
       class="newColumnNameInput"

--- a/src/components/stepforms/RankStepForm.vue
+++ b/src/components/stepforms/RankStepForm.vue
@@ -11,6 +11,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <AutocompleteWidget
@@ -37,6 +38,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <InputTextWidget
@@ -79,6 +81,8 @@ export default class RankStepForm extends BaseStepForm<RankStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/SplitStepForm.vue
+++ b/src/components/stepforms/SplitStepForm.vue
@@ -11,7 +11,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <InputTextWidget
       class="delimiter"

--- a/src/components/stepforms/SplitStepForm.vue
+++ b/src/components/stepforms/SplitStepForm.vue
@@ -10,6 +10,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <InputTextWidget
@@ -57,6 +58,8 @@ export default class SplitStepForm extends BaseStepForm<SplitStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/TopStepForm.vue
+++ b/src/components/stepforms/TopStepForm.vue
@@ -21,7 +21,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <AutocompleteWidget
       class="sortOrderInput"
@@ -43,7 +42,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="true"
     />
     <StepFormButtonbar />
   </div>

--- a/src/components/stepforms/TopStepForm.vue
+++ b/src/components/stepforms/TopStepForm.vue
@@ -20,6 +20,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <AutocompleteWidget
@@ -41,6 +42,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="true"
     />
     <StepFormButtonbar />
@@ -75,6 +77,8 @@ export default class TopStepForm extends BaseStepForm<TopStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+
+  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'top', rank_on: '', sort: 'asc' }) })
   initialStepValue!: TopStep;

--- a/src/components/stepforms/widgets/Aggregation.vue
+++ b/src/components/stepforms/widgets/Aggregation.vue
@@ -10,6 +10,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="useAdvancedVariable"
     />
     <AutocompleteWidget
@@ -57,6 +58,9 @@ export default class AggregationWidget extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   @VQBModule.Getter columnNames!: string[];
 

--- a/src/components/stepforms/widgets/Aggregation.vue
+++ b/src/components/stepforms/widgets/Aggregation.vue
@@ -11,7 +11,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="useAdvancedVariable"
     />
     <AutocompleteWidget
       class="aggregationFunctionInput"
@@ -49,9 +48,6 @@ export default class AggregationWidget extends Vue {
 
   @Prop({ type: Array, default: () => [] })
   errors!: ErrorObject[];
-
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -6,7 +6,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="useAdvancedVariable"
       :has-arrow="true"
       @input="updateValue"
     >
@@ -76,9 +75,6 @@ export default class AutocompleteWidget extends Mixins(FormWidget) {
 
   @Prop({ type: Boolean, default: false })
   withExample!: boolean;
-
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -5,6 +5,7 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="useAdvancedVariable"
       :has-arrow="true"
       @input="updateValue"
@@ -84,6 +85,9 @@ export default class AutocompleteWidget extends Mixins(FormWidget) {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   // See https://vuejs.org/v2/guide/components.html#Circular-References-Between-Components
   beforeCreate() {

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -7,7 +7,6 @@
         :available-variables="availableVariables"
         :variable-delimiters="variableDelimiters"
         :advanced-variable-delimiters="advancedVariableDelimiters"
-        :use-advanced-variable="useAdvancedVariable"
         :options="columnNames"
         @input="updateStepColumn"
         placeholder="Column"
@@ -35,7 +34,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="useAdvancedVariable"
       :placeholder="placeholder"
       :data-path="`${dataPath}.value`"
       :errors="errors"
@@ -116,9 +114,6 @@ export default class FilterSimpleConditionWidget extends Vue {
   @VQBModule.Getter('columnNames') columnNamesFromStore!: string[];
 
   @VQBModule.Mutation setSelectedColumns!: MutationCallbacks['setSelectedColumns'];
-
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -6,6 +6,7 @@
         :value="value.column"
         :available-variables="availableVariables"
         :variable-delimiters="variableDelimiters"
+        :advanced-variable-delimiters="advancedVariableDelimiters"
         :use-advanced-variable="useAdvancedVariable"
         :options="columnNames"
         @input="updateStepColumn"
@@ -33,6 +34,7 @@
       :value="value.value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="useAdvancedVariable"
       :placeholder="placeholder"
       :data-path="`${dataPath}.value`"
@@ -123,6 +125,9 @@ export default class FilterSimpleConditionWidget extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   readonly operators: OperatorOption[] = [
     { operator: 'eq', label: 'equals', inputWidget: InputTextWidget },

--- a/src/components/stepforms/widgets/IfThenElseWidget.vue
+++ b/src/components/stepforms/widgets/IfThenElseWidget.vue
@@ -30,7 +30,6 @@
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
           :advanced-variable-delimiters="advancedVariableDelimiters"
-          :use-advanced-variable="useAdvancedVariable"
           @filterTreeUpdated="updateFilterTree"
         />
       </div>
@@ -59,7 +58,6 @@
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
           :advanced-variable-delimiters="advancedVariableDelimiters"
-          :use-advanced-variable="useAdvancedVariable"
           @input="updateThenFormula"
         />
       </div>
@@ -86,7 +84,6 @@
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
             :advanced-variable-delimiters="advancedVariableDelimiters"
-            :use-advanced-variable="useAdvancedVariable"
             @input="updateElseFormula"
           />
         </div>
@@ -100,7 +97,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="useAdvancedVariable"
       @input="updateElseFormula"
       @deletedElseIf="transformElseIfIntoElse"
     />
@@ -140,9 +136,6 @@ import { VQBModule } from '@/store';
   },
 })
 export default class IfThenElseWidget extends Vue {
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
-
   @Prop()
   availableVariables!: VariablesBucket;
 

--- a/src/components/stepforms/widgets/IfThenElseWidget.vue
+++ b/src/components/stepforms/widgets/IfThenElseWidget.vue
@@ -29,6 +29,7 @@
           :data-path="`${dataPath}.if`"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
+          :advanced-variable-delimiters="advancedVariableDelimiters"
           :use-advanced-variable="useAdvancedVariable"
           @filterTreeUpdated="updateFilterTree"
         />
@@ -57,6 +58,7 @@
           :errors="errors"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
+          :advanced-variable-delimiters="advancedVariableDelimiters"
           :use-advanced-variable="useAdvancedVariable"
           @input="updateThenFormula"
         />
@@ -83,6 +85,7 @@
             :errors="errors"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
+            :advanced-variable-delimiters="advancedVariableDelimiters"
             :use-advanced-variable="useAdvancedVariable"
             @input="updateElseFormula"
           />
@@ -96,6 +99,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="useAdvancedVariable"
       @input="updateElseFormula"
       @deletedElseIf="transformElseIfIntoElse"
@@ -144,6 +148,9 @@ export default class IfThenElseWidget extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/widgets/InputNumber.vue
+++ b/src/components/stepforms/widgets/InputNumber.vue
@@ -10,7 +10,6 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :use-advanced-variable="useAdvancedVariable"
       :advanced-variable-delimiters="advancedVariableDelimiters"
       :has-arrow="true"
       @input="updateValue"
@@ -71,9 +70,6 @@ export default class InputNumberWidget extends Mixins(FormWidget) {
 
   @Prop({ type: Number, default: undefined })
   max!: number;
-
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/InputNumber.vue
+++ b/src/components/stepforms/widgets/InputNumber.vue
@@ -11,6 +11,7 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :use-advanced-variable="useAdvancedVariable"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :has-arrow="true"
       @input="updateValue"
     >
@@ -79,6 +80,9 @@ export default class InputNumberWidget extends Mixins(FormWidget) {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   isFocused = false;
 

--- a/src/components/stepforms/widgets/InputText.vue
+++ b/src/components/stepforms/widgets/InputText.vue
@@ -12,7 +12,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="useAdvancedVariable"
       @input="updateValue"
     >
       <input
@@ -59,9 +58,6 @@ export default class InputTextWidget extends Mixins(FormWidget) {
 
   @Prop({ default: undefined })
   docUrl!: string | undefined;
-
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/InputText.vue
+++ b/src/components/stepforms/widgets/InputText.vue
@@ -11,6 +11,7 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="useAdvancedVariable"
       @input="updateValue"
     >
@@ -67,6 +68,9 @@ export default class InputTextWidget extends Mixins(FormWidget) {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   // See https://vuejs.org/v2/guide/components.html#Circular-References-Between-Components
   beforeCreate() {

--- a/src/components/stepforms/widgets/JoinColumns.vue
+++ b/src/components/stepforms/widgets/JoinColumns.vue
@@ -10,7 +10,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="useAdvancedVariable"
     />
     <InputTextWidget
       class="rightOn"
@@ -21,7 +20,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :advanced-variable-delimiters="advancedVariableDelimiters"
-      :use-advanced-variable="useAdvancedVariable"
     />
   </div>
 </template>
@@ -54,9 +52,6 @@ export default class JoinColumns extends Vue {
 
   @Prop({ type: Array, default: () => [] })
   errors!: ErrorObject[];
-
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/JoinColumns.vue
+++ b/src/components/stepforms/widgets/JoinColumns.vue
@@ -9,6 +9,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="useAdvancedVariable"
     />
     <InputTextWidget
@@ -19,6 +20,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :use-advanced-variable="useAdvancedVariable"
     />
   </div>
@@ -61,6 +63,9 @@ export default class JoinColumns extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   @VQBModule.Getter columnNames!: string[];
 

--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -13,6 +13,7 @@
             :value="child.value"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
+            :advanced-variable-delimiters="advancedVariableDelimiters"
             :use-advanced-variable="useAdvancedVariable"
             @input="updateChildValue($event, index)"
             :data-path="`${dataPath}[${index}]`"
@@ -99,6 +100,9 @@ export default class ListWidget extends Mixins(FormWidget) {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   get children() {
     const valueCopy = [...this.value];

--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -14,7 +14,6 @@
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
             :advanced-variable-delimiters="advancedVariableDelimiters"
-            :use-advanced-variable="useAdvancedVariable"
             @input="updateChildValue($event, index)"
             :data-path="`${dataPath}[${index}]`"
             :errors="errors"
@@ -91,9 +90,6 @@ export default class ListWidget extends Mixins(FormWidget) {
 
   @Prop({ default: null })
   dataPath!: string;
-
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
 
   @Prop()
   availableVariables!: VariablesBucket;

--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -5,7 +5,7 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :use-advanced-variable="useAdvancedVariable"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       @input="updateValue"
     >
       <multiselect
@@ -76,14 +76,14 @@ export default class MultiInputTextWidget extends Vue {
   @Prop({ default: () => [] })
   value!: string[] | string;
 
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
-
   @Prop()
   availableVariables!: VariablesBucket;
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ default: true })
   multiVariable!: boolean;

--- a/src/components/stepforms/widgets/MultiVariableInput.vue
+++ b/src/components/stepforms/widgets/MultiVariableInput.vue
@@ -3,7 +3,7 @@
     <VariableInputBase
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :use-advanced-variable="useAdvancedVariable"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :has-arrow="hasArrow"
       :is-multiple="true"
       :value="value"
@@ -30,14 +30,14 @@ export default class MultiVariableInput extends Vue {
   @Prop({ type: Array, default: () => [] })
   value!: any[];
 
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
-
   @Prop({ default: () => [] })
   availableVariables!: VariablesBucket;
 
   @Prop({ default: () => ({ start: '{{', end: '}}' }) })
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ default: false })
   hasArrow?: boolean; //move variable-chooser button to the left if parent has an expand arrow

--- a/src/components/stepforms/widgets/Multiselect.vue
+++ b/src/components/stepforms/widgets/Multiselect.vue
@@ -6,7 +6,7 @@
       :value="stringValue"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :use-advanced-variable="useAdvancedVariable"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :has-arrow="true"
       @input="updateStringValue"
     >
@@ -36,6 +36,7 @@
             v-if="isVariable(option)"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
+            :advanced-variable-delimiters="advancedVariableDelimiters"
             :value="customLabel(option)"
             @removed="remove(option)"
           />
@@ -98,14 +99,14 @@ export default class MultiselectWidget extends Mixins(FormWidget) {
   @Prop({ type: Boolean, default: false })
   withExample!: boolean;
 
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
-
   @Prop()
   availableVariables!: VariablesBucket[];
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   editedValue: string[] | object[] = [];
 

--- a/src/components/stepforms/widgets/VariableInput.vue
+++ b/src/components/stepforms/widgets/VariableInput.vue
@@ -14,7 +14,7 @@
       v-else
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :use-advanced-variable="useAdvancedVariable"
+      :advanced-variable-delimiters="advancedVariableDelimiters"
       :has-arrow="hasArrow"
       @input="chooseVariable"
     >
@@ -44,14 +44,14 @@ export default class VariableInput extends Vue {
   @Prop()
   value!: any;
 
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
-
   @Prop({ default: () => [] })
   availableVariables!: VariablesBucket;
 
   @Prop({ default: () => ({ start: '{{', end: '}}' }) })
   variableDelimiters!: VariableDelimiters;
+
+  @Prop()
+  advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ default: false })
   hasArrow?: boolean; //move variable-chooser button to the left if parent has an expand arrow

--- a/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
@@ -29,7 +29,9 @@
           <span class="widget-variable-chooser__option-value">{{ availableVariable.value }}</span>
         </div>
       </div>
-      <div class="widget-advanced-variable" @click="addAdvancedVariable">Add variable</div>
+      <div v-if="isAdvanced" class="widget-advanced-variable" @click="addAdvancedVariable">
+        Advanced variable
+      </div>
     </div>
   </popover>
 </template>
@@ -51,6 +53,9 @@ import { VariableDelimiters, VariablesBucket, VariablesCategory } from '@/lib/va
 export default class VariableChooser extends Vue {
   @Prop({ default: false })
   isMultiple!: boolean;
+
+  @Prop({ default: false })
+  isAdvanced!: boolean;
 
   @Prop({ default: () => [] })
   selectedVariables!: string[];

--- a/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
@@ -23,6 +23,7 @@
       :available-variables="availableVariables"
       :is-opened="isChoosingVariable"
       :is-multiple="isMultiple"
+      :is-advanced="advancedVariableDelimiters"
       :value="value"
       :selected-variables="selectedVariables"
       @addAdvancedVariable="openAdvancedVariableModal"
@@ -65,11 +66,11 @@ export default class VariableInputBase extends Vue {
   @Prop({ default: () => [] })
   availableVariables!: VariablesBucket;
 
-  @Prop({ default: () => false })
-  useAdvancedVariable!: boolean;
-
   @Prop({ default: () => ({ start: '{{', end: '}}' }) })
   variableDelimiters!: VariableDelimiters;
+
+  @Prop({ default: null })
+  advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ default: false })
   hasArrow!: boolean;
@@ -93,7 +94,8 @@ export default class VariableInputBase extends Vue {
    */
   get canBeVariable() {
     return (
-      (this.availableVariables && this.availableVariables.length > 0) || this.useAdvancedVariable
+      (this.availableVariables && this.availableVariables.length > 0) ||
+      this.advancedVariableDelimiters
     );
   }
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -81,7 +81,13 @@ type VariableDelimitersMutation = {
   payload: Pick<VQBState, 'variableDelimiters'>;
 };
 
+type AdvancedVariableDelimitersMutation = {
+  type: 'setAdvancedVariableDelimiters';
+  payload: Pick<VQBState, 'advancedVariableDelimiters'>;
+};
+
 export type StateMutation =
+  | AdvancedVariableDelimitersMutation
   | AvailableVariablesMutation
   | BackendMessageMutation
   | DatasetMutation
@@ -332,6 +338,16 @@ class Mutations {
     { variableDelimiters }: Pick<VQBState, 'variableDelimiters'>,
   ) {
     state.variableDelimiters = variableDelimiters;
+  }
+
+  /**
+   * set the variable delimiters for templating advanced variables.
+   */
+  setAdvancedVariableDelimiters(
+    state: VQBState,
+    { advancedVariableDelimiters }: Pick<VQBState, 'advancedVariableDelimiters'>,
+  ) {
+    state.advancedVariableDelimiters = advancedVariableDelimiters;
   }
 }
 

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -108,6 +108,7 @@ export interface VQBState {
    * variable delimiter for templating
    */
   variableDelimiters?: VariableDelimiters;
+  advancedVariableDelimiters?: VariableDelimiters;
 }
 
 /**

--- a/stories/variable.js
+++ b/stories/variable.js
@@ -220,8 +220,8 @@ stories.add('wrapping a widget with advanced variable', () => ({
       <Multiselect 
         v-model="value" 
         :available-variables="availableVariables"
-        :variableDelimiters="variableDelimiters"
-        :use-advanced-variable="useAdvancedVariable"
+        :variable-delimiters="variableDelimiters"
+        :advanced-variable-delimiters="advancedVariableDelimiters"
         :options="options"
       />
       <pre>{{ value }}</pre>
@@ -234,9 +234,9 @@ stories.add('wrapping a widget with advanced variable', () => ({
     return {
       value: undefined,
       options: ['foo', 'bar', 'helloworld'],
-      useAdvancedVariable: true,
       availableVariables: SAMPLE_VARIABLES,
       variableDelimiters: { start: '{{', end: '}}' },
+      advancedVariableDelimiters: { start: '<<<', end: '>>>' },
     };
   },
 }));
@@ -246,8 +246,8 @@ stories.add('wrapping a widget with advanced variable and no variables', () => (
     <div>
       <Multiselect 
         v-model="value" 
-        :variableDelimiters="variableDelimiters"
-        :use-advanced-variable="useAdvancedVariable"
+        :variable-delimiters="variableDelimiters"
+        :advanced-variable-delimiters="advancedVariableDelimiters"
         :options="options"
       />
       <pre>{{ value }}</pre>
@@ -260,8 +260,8 @@ stories.add('wrapping a widget with advanced variable and no variables', () => (
     return {
       value: undefined,
       options: ['foo', 'bar', 'helloworld'],
-      useAdvancedVariable: true,
       variableDelimiters: { start: '{{', end: '}}' },
+      advancedVariableDelimiters: { start: '<<<', end: '>>>' },
     };
   },
 }));

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -913,4 +913,13 @@ describe('action tests', () => {
       expect(state.variableDelimiters).toEqual(variableDelimiters);
     });
   });
+
+  describe('setAdvancedVariableDelimiters', function() {
+    it('set advanced variable delimiters', () => {
+      const state = buildState({});
+      const advancedVariableDelimiters = { start: '{{', end: '}}' };
+      mutations.setAdvancedVariableDelimiters(state, { advancedVariableDelimiters });
+      expect(state.advancedVariableDelimiters).toEqual(advancedVariableDelimiters);
+    });
+  });
 });

--- a/tests/unit/variable-chooser.spec.ts
+++ b/tests/unit/variable-chooser.spec.ts
@@ -80,24 +80,30 @@ describe('Variable Chooser', () => {
     });
   });
 
-  it('should always display an "Advanced variable" option ...', () => {
-    expect(wrapper.find('.widget-advanced-variable').exists()).toBe(true);
-  });
-
-  it('... even without other values', async () => {
-    wrapper.setProps({ availableVariables: [] });
-    await wrapper.vm.$nextTick();
-    expect(wrapper.find('.widget-advanced-variable').exists()).toBe(true);
-  });
-
-  describe('when clicking on "Advanced variable"', () => {
-    beforeEach(async () => {
-      wrapper.find('.widget-advanced-variable').trigger('click');
-      await wrapper.vm.$nextTick();
+  describe('when is advanced', () => {
+    beforeEach(() => {
+      wrapper.setProps({ isAdvanced: true });
     });
 
-    it('should emit advancedVariable', () => {
-      expect(wrapper.emitted('addAdvancedVariable')).toHaveLength(1);
+    it('should display an "Advanced variable" option ...', () => {
+      expect(wrapper.find('.widget-advanced-variable').exists()).toBe(true);
+    });
+
+    it('... even without other values', async () => {
+      wrapper.setProps({ availableVariables: [] });
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('.widget-advanced-variable').exists()).toBe(true);
+    });
+
+    describe('when clicking on "Advanced variable"', () => {
+      beforeEach(async () => {
+        wrapper.find('.widget-advanced-variable').trigger('click');
+        await wrapper.vm.$nextTick();
+      });
+
+      it('should emit advancedVariable', () => {
+        expect(wrapper.emitted('addAdvancedVariable')).toHaveLength(1);
+      });
     });
   });
 

--- a/tests/unit/variable-input-base.spec.ts
+++ b/tests/unit/variable-input-base.spec.ts
@@ -79,7 +79,7 @@ describe('Variable Input', () => {
       });
 
       it('... except if advanced variable is allowed', async () => {
-        wrapper.setProps({ useAdvancedVariable: true });
+        wrapper.setProps({ advancedVariableDelimiters: { start: '{{', end: '}}' } });
         await wrapper.vm.$nextTick();
         expect(wrapper.find('.widget-variable__toggle').exists()).toBe(true);
       });


### PR DESCRIPTION
Need to use specific delimiters for advanced variable. Keep same logic than before for now ( willl maybe be better to improve logic by using variableDelimiters as an array or object at end)