### PR TITLE
fix(autocomplete): keep consistent style for autocomplete in advanced variable modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Multiselect: transform object to string for MultiVariableInput
+- Autocomplete: keep consistent style in advanced variable modal
 
 ## [0.23.1] - 2020-08-18
 

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -136,21 +136,42 @@ export default class AutocompleteWidget extends Mixins(FormWidget) {
   }
 }
 
-.widget-autocomplete__container .multiselect__single {
-  background-color: transparent;
-  color: $base-color-light;
-  font-size: 14px;
-  margin-bottom: 0;
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 100%;
-  white-space: nowrap;
-}
-
-.widget-autocomplete__container .multiselect__content-wrapper {
-  min-width: 100%;
-  width: auto;
+.widget-autocomplete__container {
+  .multiselect__single {
+    background-color: transparent;
+    color: $base-color-light;
+    font-size: 14px;
+    margin-bottom: 0;
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+    white-space: nowrap;
+  }
+  .multiselect__select {
+    display: block;
+  }
+  .multiselect__tags {
+    padding: 8px 40px 0 8px;
+  }
+  .multiselect--active {
+    .multiselect__tags {
+      @extend %form-widget__field--focused;
+    }
+    .multiselect__input {
+      box-shadow: none;
+      padding: 0;
+      height: auto;
+    }
+    .multiselect__content-wrapper {
+      display: block !important;
+      top: 100%;
+    }
+  }
+  .multiselect__content-wrapper {
+    min-width: 100%;
+    width: auto;
+  }
 }
 
 .multiselect__single,


### PR DESCRIPTION
When using an advanced variable modal in a multiinputtext, the autocomplete field had broken style due to unscoped style.
Before:
![before](https://user-images.githubusercontent.com/59559689/91724943-4b5d7e80-eb9e-11ea-83d1-5a912f3c11d8.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/91724957-4ef10580-eb9e-11ea-9aa9-87f639fdb672.gif)
