### PR TITLE
feat(codeEditor): use a specific config in a codeEditorWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Added
-- CodeEditor: add `setAvailableCodeEditors` methods and lang param to set specific config for a CodeEditor
+- CodeEditor: replace `setCodeEditor` by `setAvailableCodeEditors` to set specific config for a CodeEditor
 
 ## [0.24.0] - 2020-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- CodeEditor: add `setAvailableCodeEditors` methods and lang param to set specific config for a CodeEditor
+
 ## [0.24.0] - 2020-08-31
 
 ### Added

--- a/docs/_docs/tech/custom-code-editor.md
+++ b/docs/_docs/tech/custom-code-editor.md
@@ -5,53 +5,16 @@ permalink: /docs/code-editor/
 
 # Customize the code editor
 
-The `custom step` allows user to write their own query step. It uses by default a basic textarea, but you might want to customize the code editor with the `setCodeEditor` interface. 
+The `custom step` allows user to write their own query step. It uses by default a basic textarea, but you might want to customize the code editor with the `setAvailableCodeEditors` interface.
 
 ## Example
 
 Here is a simple example, on how to provide a textarea with a fix placeholder:
 
 ```js
-setCodeEditor({
-  props:['value', 'placeholder'],
-  render(createElement) {
-    return createElement("textarea", {
-      domProps: {
-        value: this.value,
-        placeholder: "OMG I have to write code in here",
-      },
-      attrs: {
-        type: "text"
-      },
-      on: {
-        input: (event) => {this.$emit('input', event.target.value)},
-        blur: (event) => {this.$emit('blur')},
-        focus: (event) => {this.$emit('focus')},
-      },
-    })
-  },
-});
-```
-
-## API
-
-`setCodeEditor`'s argument is a Vue component with the following requirements:
-  - It must accept a `value` property and emit an `input` event
-    as it will be used with a `v-model`
-
-  - Optionally:
-    - emit `blur` and `focus` event
-    - a `placeholder` property
-
-# Use different config
-
-`setAvailableCodeEditors` can be used to provide a list of custom codeEditor config.
-
-## Example
-
-```js
-setAvailableCodeEditors(
-  {
+setAvailableCodeEditors({
+  defaultConfig: 'javascript',
+  configs: {
     javascript: {
       props: ['value', 'placeholder'],
       render(createElement) {
@@ -80,11 +43,21 @@ setAvailableCodeEditors(
     json: { ...config },
     html: { ...config },
   },
-  'json',
-);
+});
 ```
 
 ## API
 
-`setAvailableCodeEditors`'s argument is a list of Vue component (see `setCodeEditor` API) keyed to a lang param:
-Then you can call a codeEditor with the choosen `lang` param to apply the associated config.
+`setAvailableCodeEditors`'s argument is an object:
+- *defaultConfig* (opt): the config to use as default one
+- *configs*: a list of configs associated to their lang key
+
+A config is a Vue components with the following requirements:
+- It must accept a `value` property and emit an `input` event
+  as it will be used with a `v-model`
+
+- Optionally:
+  - emit `blur` and `focus` event
+  - a `placeholder` property
+
+After instanciation you can call a codeEditorWidget with the choosen `config` param to apply the associated config.

--- a/docs/_docs/tech/custom-code-editor.md
+++ b/docs/_docs/tech/custom-code-editor.md
@@ -42,3 +42,49 @@ setCodeEditor({
   - Optionally:
     - emit `blur` and `focus` event
     - a `placeholder` property
+
+# Use different config
+
+`setAvailableCodeEditors` can be used to provide a list of custom codeEditor config.
+
+## Example
+
+```js
+setAvailableCodeEditors(
+  {
+    javascript: {
+      props: ['value', 'placeholder'],
+      render(createElement) {
+        return createElement('textarea', {
+          domProps: {
+            value: this.value,
+            placeholder: 'OMG I have to write code in javascript here',
+          },
+          attrs: {
+            type: 'text',
+          },
+          on: {
+            input: event => {
+              this.$emit('input', event.target.value);
+            },
+            blur: event => {
+              this.$emit('blur');
+            },
+            focus: event => {
+              this.$emit('focus');
+            },
+          },
+        });
+      },
+    },
+    json: { ...config },
+    html: { ...config },
+  },
+  'json',
+);
+```
+
+## API
+
+`setAvailableCodeEditors`'s argument is a list of Vue component (see `setCodeEditor` API) keyed to a lang param:
+Then you can call a codeEditor with the choosen `lang` param to apply the associated config.

--- a/playground/app.js
+++ b/playground/app.js
@@ -10,6 +10,7 @@ const {
   servicePluginFactory,
   registerModule,
   setCodeEditor,
+  setAvailableCodeEditors,
 } = vqb;
 
 const TRANSLATOR = 'mongo40';
@@ -38,6 +39,60 @@ setCodeEditor({
   },
 });
 
+// Example to provide custom configs for codeEditor
+// Won't replace setCodeEditor
+setAvailableCodeEditors({
+  javascript: {
+    props: ['value', 'placeholder'],
+    render(createElement) {
+      return createElement('textarea', {
+        domProps: {
+          value: this.value,
+          placeholder: 'OMG I have to write code in javascript in here',
+        },
+        attrs: {
+          type: 'text',
+        },
+        on: {
+          input: event => {
+            this.$emit('input', event.target.value);
+          },
+          blur: event => {
+            this.$emit('blur');
+          },
+          focus: event => {
+            this.$emit('focus');
+          },
+        },
+      });
+    },
+  },
+  json: {
+    props: ['value', 'placeholder'],
+    render(createElement) {
+      return createElement('textarea', {
+        domProps: {
+          value: this.value,
+          placeholder: 'OMG I have to write code in json in here',
+        },
+        attrs: {
+          type: 'text',
+        },
+        on: {
+          input: event => {
+            this.$emit('input', event.target.value);
+          },
+          blur: event => {
+            this.$emit('blur');
+          },
+          focus: event => {
+            this.$emit('focus');
+          },
+        },
+      });
+    },
+  },
+});
 
 const CASTERS = {
   date: val => new Date(val),

--- a/playground/app.js
+++ b/playground/app.js
@@ -9,7 +9,6 @@ const {
   dereferencePipelines,
   servicePluginFactory,
   registerModule,
-  setCodeEditor,
   setAvailableCodeEditors,
 } = vqb;
 
@@ -17,80 +16,41 @@ const TRANSLATOR = 'mongo40';
 
 const mongo40translator = getTranslator(TRANSLATOR);
 
-// Example to set a custom editor:
-// This one is quite simple. It customizes the placeholder.
-setCodeEditor({
-  props:['value', 'placeholder'],
-  render(createElement) {
-    return createElement("textarea", {
-      domProps: {
-        value: this.value,
-        placeholder: "OMG I have to write code in here",
-      },
-      attrs: {
-        type: "text"
-      },
-      on: {
-        input: (event) => {this.$emit('input', event.target.value)},
-        blur: (event) => {this.$emit('blur')},
-        focus: (event) => {this.$emit('focus')},
-      },
-    })
-  },
-});
+// Create a code editor config for a specific lang
+const codeEditorForLang = function(lang) {
+  return {
+    props: ['value', 'placeholder'],
+    render(createElement) {
+      return createElement('textarea', {
+        domProps: {
+          value: this.value,
+          placeholder: `OMG I have to write code in ${lang} in here`,
+        },
+        attrs: {
+          type: 'text',
+        },
+        on: {
+          input: event => {
+            this.$emit('input', event.target.value);
+          },
+          blur: event => {
+            this.$emit('blur');
+          },
+          focus: event => {
+            this.$emit('focus');
+          },
+        },
+      });
+    },
+  };
+};
 
 // Example to provide custom configs for codeEditor
-// Won't replace setCodeEditor
 setAvailableCodeEditors({
-  javascript: {
-    props: ['value', 'placeholder'],
-    render(createElement) {
-      return createElement('textarea', {
-        domProps: {
-          value: this.value,
-          placeholder: 'OMG I have to write code in javascript in here',
-        },
-        attrs: {
-          type: 'text',
-        },
-        on: {
-          input: event => {
-            this.$emit('input', event.target.value);
-          },
-          blur: event => {
-            this.$emit('blur');
-          },
-          focus: event => {
-            this.$emit('focus');
-          },
-        },
-      });
-    },
-  },
-  json: {
-    props: ['value', 'placeholder'],
-    render(createElement) {
-      return createElement('textarea', {
-        domProps: {
-          value: this.value,
-          placeholder: 'OMG I have to write code in json in here',
-        },
-        attrs: {
-          type: 'text',
-        },
-        on: {
-          input: event => {
-            this.$emit('input', event.target.value);
-          },
-          blur: event => {
-            this.$emit('blur');
-          },
-          focus: event => {
-            this.$emit('focus');
-          },
-        },
-      });
-    },
+  defaultConfig: 'json',
+  configs: {
+    javascript: codeEditorForLang('javascript'),
+    json: codeEditorForLang('json'),
   },
 });
 
@@ -181,7 +141,7 @@ class MongoService {
       return { data: dataset };
     } else {
       return {
-        error: [{type: 'error', message: responseContent.errmsg}],
+        error: [{ type: 'error', message: responseContent.errmsg }],
       };
     }
   }
@@ -256,7 +216,7 @@ async function buildVueApp() {
                 operator: 'ge',
                 value: 1200,
               },
-            }
+            },
           ],
           pipelineAmex: [
             {
@@ -270,7 +230,7 @@ async function buildVueApp() {
                 operator: 'eq',
                 value: 'Amex',
               },
-            }
+            },
           ],
           pipelineVisa: [
             {
@@ -284,7 +244,7 @@ async function buildVueApp() {
                 operator: 'eq',
                 value: 'Visa',
               },
-            }
+            },
           ],
           pipelineMastercard: [
             {
@@ -298,7 +258,7 @@ async function buildVueApp() {
                 operator: 'eq',
                 value: 'Mastercard',
               },
-            }
+            },
           ],
         },
         currentDomain: 'sales',
@@ -316,7 +276,7 @@ async function buildVueApp() {
       store.dispatch(VQBnamespace('updateDataset'));
     },
     computed: {
-      activePipeline: function(){
+      activePipeline: function() {
         let activePipeline = this.$store.getters[VQBnamespace('activePipeline')];
         if (!activePipeline) {
           return undefined;
@@ -325,14 +285,14 @@ async function buildVueApp() {
         if (pipelines) {
           return dereferencePipelines(activePipeline, pipelines);
         } else {
-          return activePipeline
+          return activePipeline;
         }
       },
       mongoQueryAsJSON: function() {
         const query = mongo40translator.translate(this.activePipeline);
         return JSON.stringify(query, null, 2);
       },
-      pipelineAsJSON: function(){
+      pipelineAsJSON: function() {
         return JSON.stringify(this.activePipeline, null, 2);
       },
       thereIsABackendError: function() {
@@ -342,10 +302,10 @@ async function buildVueApp() {
         return this.$store.state[VQB_MODULE_NAME].backendMessages;
       },
       backendErrors: function() {
-        return this.backendMessages.filter(({type}) => type === 'error');
+        return this.backendMessages.filter(({ type }) => type === 'error');
       },
       backendWarnings: function() {
-        return this.backendMessages.filter(({type}) => type === 'warning');
+        return this.backendMessages.filter(({ type }) => type === 'warning');
       },
     },
     methods: {

--- a/src/components/code-editor.ts
+++ b/src/components/code-editor.ts
@@ -2,8 +2,8 @@
   This module handles the CodeEditor used in the CodeEditorWidget
   The default CodeEditor is a native textarea.
 
-  You can set another Code Editor passing to `setCodeEditor`
-  a vue component with the following requirements:
+  You can set another CodeEditor passing to `setAvailableCodeEditors`
+  a list of name associated to vue component with the following requirements:
   - It must accept a `value` property and emit an `input` event
     as it will be used with a `v-model`
   - Optionally:
@@ -11,29 +11,33 @@
     - a placeholder `property`
 
   An example of code editor customization can be found in the playground.
+
+  Optionally:
+   - You can add a defaultConfig value to define the default config to use
 */
 import Vue, { VueConstructor } from 'vue';
 
 import DefaultCodeEditor from '@/components/stepforms/widgets/DefaultCodeEditor.vue';
 
-export type CustomCodeEditor = VueConstructor<Vue>;
-let CodeEditor: CustomCodeEditor = DefaultCodeEditor;
+export type CodeEditorConfig = VueConstructor<Vue>;
+let CodeEditor: CodeEditorConfig = DefaultCodeEditor;
 
-export function setCodeEditor(CustomCodeEditor: CustomCodeEditor) {
-  CodeEditor = CustomCodeEditor;
+type CodeEditorConfigs = { [name: string]: CodeEditorConfig };
+let CodeEditorConfigs: CodeEditorConfigs = {};
+
+export function setAvailableCodeEditors({
+  configs,
+  defaultConfig,
+}: {
+  configs: CodeEditorConfigs;
+  defaultConfig?: string;
+}) {
+  CodeEditorConfigs = configs;
+  // Define the default config to use
+  CodeEditor =
+    defaultConfig && CodeEditorConfigs[defaultConfig]
+      ? CodeEditorConfigs[defaultConfig]
+      : Object.values(CodeEditorConfigs)[0];
 }
 
-/*
-Use setAvailableCodeEditors to provide a list of custom codeEditor config
-Each config must be associate to a lang key
-Then in a codeEditorWidget use the lang param to get the associated config
-It won't replace the default setCodeEditor
-*/
-type CustomCodeEditorList = { [lang: string]: CustomCodeEditor };
-let AvailableCodeEditors: CustomCodeEditorList = {};
-
-export function setAvailableCodeEditors(CustomCodeEditors: CustomCodeEditorList) {
-  AvailableCodeEditors = CustomCodeEditors;
-}
-
-export { CodeEditor, AvailableCodeEditors };
+export { CodeEditor, CodeEditorConfigs };

--- a/src/components/code-editor.ts
+++ b/src/components/code-editor.ts
@@ -16,10 +16,24 @@ import Vue, { VueConstructor } from 'vue';
 
 import DefaultCodeEditor from '@/components/stepforms/widgets/DefaultCodeEditor.vue';
 
-let CodeEditor = DefaultCodeEditor;
+export type CustomCodeEditor = VueConstructor<Vue>;
+let CodeEditor: CustomCodeEditor = DefaultCodeEditor;
 
-export function setCodeEditor(CustomCodeEditor: VueConstructor<Vue>) {
+export function setCodeEditor(CustomCodeEditor: CustomCodeEditor) {
   CodeEditor = CustomCodeEditor;
 }
 
-export { CodeEditor };
+/*
+Use setAvailableCodeEditors to provide a list of custom codeEditor config
+Each config must be associate to a lang key
+Then in a codeEditorWidget use the lang param to get the associated config
+It won't replace the default setCodeEditor
+*/
+type CustomCodeEditorList = { [lang: string]: CustomCodeEditor };
+let AvailableCodeEditors: CustomCodeEditorList = {};
+
+export function setAvailableCodeEditors(CustomCodeEditors: CustomCodeEditorList) {
+  AvailableCodeEditors = CustomCodeEditors;
+}
+
+export { CodeEditor, AvailableCodeEditors };

--- a/src/components/stepforms/widgets/CodeEditorWidget.vue
+++ b/src/components/stepforms/widgets/CodeEditorWidget.vue
@@ -21,7 +21,7 @@
 <script lang="ts">
 import { Component, Mixins, Prop, Watch } from 'vue-property-decorator';
 
-import { CodeEditor } from '@/components/code-editor';
+import { AvailableCodeEditors, CodeEditor, CustomCodeEditor } from '@/components/code-editor';
 
 import FormWidget from './FormWidget.vue';
 
@@ -38,12 +38,15 @@ export default class CodeEditorWidget extends Mixins(FormWidget) {
   @Prop({ default: '' })
   value!: string;
 
+  @Prop({ type: String, default: '' })
+  lang!: string;
+
   editedValue = this.value;
 
   isFocused = false;
 
-  CodeEditor = CodeEditor;
   // Code editor is set through a responsive data so it can be change after import
+  CodeEditor: CustomCodeEditor = CodeEditor;
 
   @Watch('editedValue')
   updateValue(newValue: string) {
@@ -55,6 +58,19 @@ export default class CodeEditorWidget extends Mixins(FormWidget) {
       'widget-code-editor': true,
       'widget-code-editor--focused': this.isFocused,
     };
+  }
+
+  created() {
+    this.setEditorLang();
+  }
+
+  /*
+  Use a specific config of AvailableCodeEditors
+  */
+  setEditorLang() {
+    if (this.lang && AvailableCodeEditors[this.lang]) {
+      this.CodeEditor = AvailableCodeEditors[this.lang];
+    }
   }
 
   blur() {

--- a/src/components/stepforms/widgets/CodeEditorWidget.vue
+++ b/src/components/stepforms/widgets/CodeEditorWidget.vue
@@ -2,7 +2,7 @@
   <div class="widget-code-editor__container" :class="toggleClassErrorWarning">
     <label v-if="name">{{ name }}</label>
     <component
-      :is="CodeEditor"
+      :is="codeEditor"
       :class="elementClass"
       :placeholder="placeholder"
       v-model="editedValue"
@@ -21,7 +21,7 @@
 <script lang="ts">
 import { Component, Mixins, Prop, Watch } from 'vue-property-decorator';
 
-import { AvailableCodeEditors, CodeEditor, CustomCodeEditor } from '@/components/code-editor';
+import { CodeEditor, CodeEditorConfig, CodeEditorConfigs } from '@/components/code-editor';
 
 import FormWidget from './FormWidget.vue';
 
@@ -39,14 +39,14 @@ export default class CodeEditorWidget extends Mixins(FormWidget) {
   value!: string;
 
   @Prop({ type: String, default: '' })
-  lang!: string;
+  config!: string;
 
   editedValue = this.value;
 
   isFocused = false;
 
   // Code editor is set through a responsive data so it can be change after import
-  CodeEditor: CustomCodeEditor = CodeEditor;
+  codeEditor: CodeEditorConfig = CodeEditor;
 
   @Watch('editedValue')
   updateValue(newValue: string) {
@@ -61,15 +61,15 @@ export default class CodeEditorWidget extends Mixins(FormWidget) {
   }
 
   created() {
-    this.setEditorLang();
+    this.setEditorConfig();
   }
 
   /*
   Use a specific config of AvailableCodeEditors
   */
-  setEditorLang() {
-    if (this.lang && AvailableCodeEditors[this.lang]) {
-      this.CodeEditor = AvailableCodeEditors[this.lang];
+  setEditorConfig() {
+    if (this.config && CodeEditorConfigs[this.config]) {
+      this.codeEditor = CodeEditorConfigs[this.config];
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@
 export { filterOutDomain, mongoToPipe } from './lib/pipeline';
 export { getTranslator } from './lib/translators';
 export { mongoResultsToDataset, inferTypeFromDataset } from './lib/dataset/mongo';
-export { setCodeEditor } from './components/code-editor';
+export { setCodeEditor, setAvailableCodeEditors } from './components/code-editor';
 
 // export store entrypoints
 export { servicePluginFactory } from '@/store/backend-plugin';

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@
 export { filterOutDomain, mongoToPipe } from './lib/pipeline';
 export { getTranslator } from './lib/translators';
 export { mongoResultsToDataset, inferTypeFromDataset } from './lib/dataset/mongo';
-export { setCodeEditor, setAvailableCodeEditors } from './components/code-editor';
+export { setAvailableCodeEditors } from './components/code-editor';
 
 // export store entrypoints
 export { servicePluginFactory } from '@/store/backend-plugin';

--- a/tests/unit/code-editor-widget.spec.ts
+++ b/tests/unit/code-editor-widget.spec.ts
@@ -1,5 +1,11 @@
 import { mount, shallowMount } from '@vue/test-utils';
+import Vue from 'vue';
 
+import {
+  AvailableCodeEditors,
+  CodeEditor,
+  setAvailableCodeEditors,
+} from '@/components/code-editor';
 import CodeEditorWidget from '@/components/stepforms/widgets/CodeEditorWidget.vue';
 
 describe('Widget CodeEditorWidget', () => {
@@ -125,5 +131,25 @@ describe('Widget CodeEditorWidget', () => {
   it('should not display a warning message if messageError does not exist', () => {
     const wrapper = shallowMount(CodeEditorWidget);
     expect(wrapper.find('.field__msg-warning').exists()).toBeFalsy();
+  });
+
+  describe('custom lang', () => {
+    it('should use custom code editor config if lang param is provided', () => {
+      setAvailableCodeEditors({ json: Vue.extend(), javascript: Vue.extend() });
+      const wrapper = shallowMount(CodeEditorWidget, {
+        propsData: { lang: 'javascript' },
+      });
+      const codeEditor = wrapper.vm.$data.CodeEditor;
+      expect(codeEditor).toEqual(AvailableCodeEditors.javascript);
+    });
+
+    it('... but keep default editor config if lang is unavailable', () => {
+      setAvailableCodeEditors({ json: Vue.extend() });
+      const wrapper = shallowMount(CodeEditorWidget, {
+        propsData: { lang: 'javascript' },
+      });
+      const codeEditor = wrapper.vm.$data.CodeEditor;
+      expect(codeEditor).toEqual(CodeEditor);
+    });
   });
 });

--- a/tests/unit/code-editor-widget.spec.ts
+++ b/tests/unit/code-editor-widget.spec.ts
@@ -1,11 +1,7 @@
 import { mount, shallowMount } from '@vue/test-utils';
 import Vue from 'vue';
 
-import {
-  AvailableCodeEditors,
-  CodeEditor,
-  setAvailableCodeEditors,
-} from '@/components/code-editor';
+import { CodeEditor, CodeEditorConfigs, setAvailableCodeEditors } from '@/components/code-editor';
 import CodeEditorWidget from '@/components/stepforms/widgets/CodeEditorWidget.vue';
 
 describe('Widget CodeEditorWidget', () => {
@@ -135,21 +131,21 @@ describe('Widget CodeEditorWidget', () => {
 
   describe('custom lang', () => {
     it('should use custom code editor config if lang param is provided', () => {
-      setAvailableCodeEditors({ json: Vue.extend(), javascript: Vue.extend() });
+      setAvailableCodeEditors({ configs: { json: Vue.extend(), javascript: Vue.extend() } });
       const wrapper = shallowMount(CodeEditorWidget, {
-        propsData: { lang: 'javascript' },
+        propsData: { config: 'javascript' },
       });
-      const codeEditor = wrapper.vm.$data.CodeEditor;
-      expect(codeEditor).toEqual(AvailableCodeEditors.javascript);
+      const codeEditorData = wrapper.vm.$data.codeEditor;
+      expect(codeEditorData).toEqual(CodeEditorConfigs.javascript);
     });
 
     it('... but keep default editor config if lang is unavailable', () => {
-      setAvailableCodeEditors({ json: Vue.extend() });
+      setAvailableCodeEditors({ configs: { json: Vue.extend() } });
       const wrapper = shallowMount(CodeEditorWidget, {
-        propsData: { lang: 'javascript' },
+        propsData: { config: 'javascript' },
       });
-      const codeEditor = wrapper.vm.$data.CodeEditor;
-      expect(codeEditor).toEqual(CodeEditor);
+      const codeEditorData = wrapper.vm.$data.codeEditor;
+      expect(codeEditorData).toEqual(CodeEditor);
     });
   });
 });

--- a/tests/unit/set-code-editor.spec.ts
+++ b/tests/unit/set-code-editor.spec.ts
@@ -1,40 +1,76 @@
 import { shallowMount } from '@vue/test-utils';
 import Vue, { VNode } from 'vue';
 
-import { setCodeEditor } from '@/components/code-editor';
+import { setAvailableCodeEditors } from '@/components/code-editor';
 import CodeEditorWidget from '@/components/stepforms/widgets/CodeEditorWidget.vue';
 
-describe('setCodeEditor', () => {
-  it('should set the code editor', () => {
-    const CustomCodeEditor = Vue.extend({
-      props: ['value', 'placeholder'],
-      render(createElement): VNode {
-        return createElement('textarea', {
-          domProps: {
-            value: this.value,
-            placeholder: 'OMG I have to write code in here',
+// Create a code editor config for a specific lang
+const codeEditorForLang = function(lang: string): any {
+  return Vue.extend({
+    props: ['value', 'placeholder'],
+    render(createElement): VNode {
+      return createElement('textarea', {
+        domProps: {
+          value: this.value,
+          placeholder: `OMG I have to write code in ${lang} in here`,
+        },
+        attrs: {
+          type: 'text',
+        },
+        on: {
+          input: (event: Event) => {
+            const textarea = event.target as HTMLTextAreaElement;
+            this.$emit('input', textarea.value);
           },
-          attrs: {
-            type: 'text',
+          blur: () => {
+            this.$emit('blur');
           },
-          on: {
-            input: (event: Event) => {
-              const textarea = event.target as HTMLTextAreaElement;
-              this.$emit('input', textarea.value);
-            },
-            blur: () => {
-              this.$emit('blur');
-            },
-            focus: () => {
-              this.$emit('focus');
-            },
+          focus: () => {
+            this.$emit('focus');
           },
-        });
+        },
+      });
+    },
+  });
+};
+
+describe('setAvailableCodeEditors', () => {
+  it('should set the code editor based on defaultConfig ...', () => {
+    const codeEditorConfig = {
+      defaultConfig: 'json',
+      configs: {
+        json: codeEditorForLang('json'),
       },
-    });
-    setCodeEditor(CustomCodeEditor);
+    };
+    setAvailableCodeEditors(codeEditorConfig);
     const CodeEditorWidgetWrapper = shallowMount(CodeEditorWidget);
 
-    expect(CodeEditorWidgetWrapper.vm.$data.CodeEditor).toEqual(CustomCodeEditor);
+    expect(CodeEditorWidgetWrapper.vm.$data.codeEditor).toEqual(codeEditorConfig.configs.json);
+  });
+  it('... or take the first config if not provided ...', () => {
+    const codeEditorConfig = {
+      configs: {
+        javascript: codeEditorForLang('javascript'),
+        json: codeEditorForLang('json'),
+      },
+    };
+    setAvailableCodeEditors(codeEditorConfig);
+    const CodeEditorWidgetWrapper = shallowMount(CodeEditorWidget);
+
+    expect(CodeEditorWidgetWrapper.vm.$data.codeEditor).toEqual(
+      codeEditorConfig.configs.javascript,
+    );
+  });
+  it('... or unavailable', () => {
+    const codeEditorConfig = {
+      defaultConfig: 'javascript',
+      configs: {
+        json: codeEditorForLang('json'),
+      },
+    };
+    setAvailableCodeEditors(codeEditorConfig);
+    const CodeEditorWidgetWrapper = shallowMount(CodeEditorWidget);
+
+    expect(CodeEditorWidgetWrapper.vm.$data.codeEditor).toEqual(codeEditorConfig.configs.json);
   });
 });


### PR DESCRIPTION
Add `setAvailableCodeEditors`, a new method, to provide custom configs associated to a lang key.
CodeEditorWidget can now take a lang param.
It will use the custom config if available otherwise it will use the default one