### PR TITLE
Add templating support in various steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add 'waterfall' step
 - Add an advanced variable modal component to create custom variable
 - Add a mutation to populate store with advanced variable delimiters
+- Add templating support for several steps parameters
 
 ### Fixed
 

--- a/src/components/stepforms/EvolutionStepForm.vue
+++ b/src/components/stepforms/EvolutionStepForm.vue
@@ -45,6 +45,8 @@
       placeholder="Add columns"
       data-path=".indexColumns"
       :errors="errors"
+      :available-variables="availableVariables"
+      :variable-delimiters="variableDelimiters"
     />
     <InputTextWidget
       class="newColumnInput"

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -159,11 +159,25 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   }
 
   argmax(step: Readonly<S.ArgmaxStep>) {
-    return { ...step };
+    const groups = step.groups
+      ? step.groups.map(col => _interpolate(this.interpolateFunc, col, this.context))
+      : undefined;
+    return {
+      ...step,
+      column: _interpolate(this.interpolateFunc, step.column, this.context),
+      groups,
+    };
   }
 
   argmin(step: Readonly<S.ArgminStep>) {
-    return { ...step };
+    const groups = step.groups
+      ? step.groups.map(col => _interpolate(this.interpolateFunc, col, this.context))
+      : undefined;
+    return {
+      ...step,
+      column: _interpolate(this.interpolateFunc, step.column, this.context),
+      groups,
+    };
   }
 
   concatenate(step: Readonly<S.ConcatenateStep>) {

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -362,7 +362,7 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   }
 
   split(step: Readonly<S.SplitStep>) {
-    return { ...step };
+    return { ...step, column: _interpolate(this.interpolateFunc, step.column, this.context) };
   }
 
   substring(step: Readonly<S.SubstringStep>) {

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -70,16 +70,22 @@ function interpolateFilterCondition(
       case 'le':
         return {
           ...condition,
+          column: _interpolate(interpolate, condition.column, context),
           value: _interpolate(interpolate, condition.value, context, columnType),
         };
       case 'in':
       case 'nin':
         return {
           ...condition,
+          column: _interpolate(interpolate, condition.column, context),
           value: condition.value.map(v => _interpolate(interpolate, v, context, columnType)),
         };
       case 'isnull':
       case 'notnull':
+        return {
+          ...condition,
+          column: _interpolate(interpolate, condition.column, context),
+        };
       default:
         // only for typescript to be happy and see we always have a return value
         return condition;

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -370,7 +370,11 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   }
 
   text(step: Readonly<S.AddTextColumnStep>) {
-    return { ...step, text: _interpolate(this.interpolateFunc, step.text, this.context) };
+    return {
+      ...step,
+      text: _interpolate(this.interpolateFunc, step.text, this.context),
+      new_column: _interpolate(this.interpolateFunc, step.new_column, this.context),
+    };
   }
 
   todate(step: Readonly<S.ToDateStep>) {

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -382,9 +382,14 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   }
 
   top(step: Readonly<S.TopStep>) {
+    const groups = step.groups
+      ? step.groups.map(col => _interpolate(this.interpolateFunc, col, this.context))
+      : undefined;
     return {
       ...step,
       limit: Number(_interpolate(this.interpolateFunc, step.limit, this.context)),
+      rank_on: _interpolate(this.interpolateFunc, step.rank_on, this.context),
+      groups,
     };
   }
 

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -181,7 +181,10 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   }
 
   concatenate(step: Readonly<S.ConcatenateStep>) {
-    return { ...step };
+    return {
+      ...step,
+      columns: step.columns.map(col => _interpolate(this.interpolateFunc, col, this.context)),
+    };
   }
 
   convert(step: Readonly<S.ConvertStep>) {

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -92,26 +92,38 @@ describe('Pipeline interpolator', () => {
     expect(translate(pipeline)).toEqual(pipeline);
   });
 
-  it('should leave argmax steps untouched', () => {
+  it('should interpolate argmax steps', () => {
     const pipeline: Pipeline = [
       {
         name: 'argmax',
         column: '<%= foo %>',
-        groups: ['<%= egg %>', 'column3'],
+        groups: ['<%= egg %>', 'column3', '<%= foo %>'],
       },
     ];
-    expect(translate(pipeline)).toEqual(pipeline);
+    expect(translate(pipeline)).toEqual([
+      {
+        name: 'argmax',
+        column: 'bar',
+        groups: ['spam', 'column3', 'bar'],
+      },
+    ]);
   });
 
-  it('should leave argmin steps untouched', () => {
+  it('should interpolate argmin steps', () => {
     const pipeline: Pipeline = [
       {
         name: 'argmin',
         column: '<%= foo %>',
-        groups: ['<%= egg %>', 'column3'],
+        groups: ['<%= egg %>', 'column3', '<%= foo %>'],
       },
     ];
-    expect(translate(pipeline)).toEqual(pipeline);
+    expect(translate(pipeline)).toEqual([
+      {
+        name: 'argmin',
+        column: 'bar',
+        groups: ['spam', 'column3', 'bar'],
+      },
+    ]);
   });
 
   it('should leave concatenate steps untouched', () => {

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -999,18 +999,6 @@ describe('Pipeline interpolator', () => {
     expect(translate(pipeline)).toEqual(pipeline);
   });
 
-  it('should leave top steps untouched if no variable is found', () => {
-    const pipeline: Pipeline = [
-      {
-        name: 'top',
-        rank_on: '<%= foo %>',
-        sort: 'asc',
-        limit: 42,
-      },
-    ];
-    expect(translate(pipeline)).toEqual(pipeline);
-  });
-
   it('should interpolate top steps', () => {
     const pipeline: Pipeline = [
       {
@@ -1018,14 +1006,16 @@ describe('Pipeline interpolator', () => {
         rank_on: '<%= foo %>',
         sort: 'asc',
         limit: '<%= age %>',
+        groups: ['<%= foo %>', '<%= egg %>'],
       },
     ];
     expect(translate(pipeline)).toEqual([
       {
         name: 'top',
-        rank_on: '<%= foo %>',
+        rank_on: 'bar',
         sort: 'asc',
         limit: 42,
+        groups: ['bar', 'spam'],
       },
     ]);
   });

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -968,16 +968,23 @@ describe('Pipeline interpolator', () => {
     expect(translate(pipeline)).toEqual(pipeline);
   });
 
-  it('should leave split steps untouched', () => {
+  it('should interpolate split steps', () => {
     const pipeline: Pipeline = [
       {
         name: 'split',
         column: '<%= foo %>',
-        delimiter: '<%= delim %>',
+        delimiter: '<%= egg %>',
         number_cols_to_keep: 3,
       },
     ];
-    expect(translate(pipeline)).toEqual(pipeline);
+    expect(translate(pipeline)).toEqual([
+      {
+        name: 'split',
+        column: 'bar',
+        delimiter: '<%= egg %>',
+        number_cols_to_keep: 3,
+      },
+    ]);
   });
 
   it('should leave substring steps untouched', () => {

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -183,7 +183,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'text',
         text: 'bar',
-        new_column: '<%= foo %>',
+        new_column: 'bar',
       },
     ]);
   });

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -281,14 +281,14 @@ describe('Pipeline interpolator', () => {
     const pipeline: Pipeline = [
       {
         name: 'fillna',
-        column: '<%= foo %>',
+        column: 'foo',
         value: 'hola',
       },
     ];
     expect(translate(pipeline)).toEqual([
       {
         name: 'fillna',
-        column: '<%= foo %>',
+        column: 'foo',
         value: 'hola',
       },
     ]);
@@ -309,7 +309,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'filter',
         condition: {
-          column: '<%= foo %>',
+          column: 'bar',
           value: '42',
           operator: 'eq',
         },
@@ -355,7 +355,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'filter',
         condition: {
-          column: '<%= foo %>',
+          column: 'bar',
           value: '42',
           operator: 'ne',
         },
@@ -378,7 +378,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'filter',
         condition: {
-          column: '<%= foo %>',
+          column: 'bar',
           value: '42',
           operator: 'lt',
         },
@@ -401,7 +401,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'filter',
         condition: {
-          column: '<%= foo %>',
+          column: 'bar',
           value: '42',
           operator: 'le',
         },
@@ -424,7 +424,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'filter',
         condition: {
-          column: '<%= foo %>',
+          column: 'bar',
           value: '42',
           operator: 'gt',
         },
@@ -447,7 +447,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'filter',
         condition: {
-          column: '<%= foo %>',
+          column: 'bar',
           value: '42',
           operator: 'ge',
         },
@@ -470,7 +470,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'filter',
         condition: {
-          column: '<%= foo %>',
+          column: 'bar',
           value: [11, '42', 'spam', 'hola'],
           operator: 'in',
         },
@@ -493,7 +493,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'filter',
         condition: {
-          column: '<%= foo %>',
+          column: 'bar',
           value: [11, '42', 'spam', 'hola'],
           operator: 'nin',
         },
@@ -501,7 +501,7 @@ describe('Pipeline interpolator', () => {
     ]);
   });
 
-  it('should not interpolate simple filter steps / operator "isnull"', () => {
+  it('should interpolate simple filter steps / operator "isnull"', () => {
     const step: Pipeline = [
       {
         name: 'filter',
@@ -516,7 +516,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'filter',
         condition: {
-          column: '<%= foo %>',
+          column: 'bar',
           value: '<%= age %>',
           operator: 'isnull',
         },
@@ -524,7 +524,7 @@ describe('Pipeline interpolator', () => {
     ]);
   });
 
-  it('should not interpolate simple filter steps / operator "notnull"', () => {
+  it('should interpolate simple filter steps / operator "notnull"', () => {
     const step: Pipeline = [
       {
         name: 'filter',
@@ -539,7 +539,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'filter',
         condition: {
-          column: '<%= foo %>',
+          column: 'bar',
           value: '<%= age %>',
           operator: 'notnull',
         },
@@ -578,17 +578,17 @@ describe('Pipeline interpolator', () => {
         condition: {
           and: [
             {
-              column: '<%= foo %>',
+              column: 'bar',
               value: [11, '42', 'spam', 'hola'],
               operator: 'nin',
             },
             {
-              column: '<%= foo %>',
+              column: 'bar',
               value: 12,
               operator: 'eq',
             },
             {
-              column: '<%= foo %>',
+              column: 'bar',
               value: 'spam',
               operator: 'ne',
             },
@@ -635,7 +635,7 @@ describe('Pipeline interpolator', () => {
         condition: {
           and: [
             {
-              column: '<%= foo %>',
+              column: 'bar',
               value: [11, '42', 'spam', 'hola'],
               operator: 'nin',
             },
@@ -686,17 +686,17 @@ describe('Pipeline interpolator', () => {
         condition: {
           or: [
             {
-              column: '<%= foo %>',
+              column: 'bar',
               value: [11, '42', 'spam', 'hola'],
               operator: 'nin',
             },
             {
-              column: '<%= foo %>',
+              column: 'bar',
               value: 12,
               operator: 'eq',
             },
             {
-              column: '<%= foo %>',
+              column: 'bar',
               value: 'spam',
               operator: 'ne',
             },
@@ -743,7 +743,7 @@ describe('Pipeline interpolator', () => {
         condition: {
           or: [
             {
-              column: '<%= foo %>',
+              column: 'bar',
               value: [11, '42', 'spam', 'hola'],
               operator: 'nin',
             },
@@ -1173,7 +1173,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'ifthenelse',
         newColumn: '<%= foo %>',
-        if: { and: [{ column: '<%= foo %>', operator: 'eq', value: '42' }] },
+        if: { and: [{ column: 'bar', operator: 'eq', value: '42' }] },
         then: 'bar',
         else: '42',
       },
@@ -1198,10 +1198,10 @@ describe('Pipeline interpolator', () => {
       {
         name: 'ifthenelse',
         newColumn: '<%= foo %>',
-        if: { and: [{ column: '<%= foo %>', operator: 'eq', value: '42' }] },
+        if: { and: [{ column: 'bar', operator: 'eq', value: '42' }] },
         then: 'bar',
         else: {
-          if: { and: [{ column: '<%= foo %>', operator: 'eq', value: '42' }] },
+          if: { and: [{ column: 'bar', operator: 'eq', value: '42' }] },
           then: 'bar',
           else: '42',
         },

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -126,16 +126,23 @@ describe('Pipeline interpolator', () => {
     ]);
   });
 
-  it('should leave concatenate steps untouched', () => {
+  it('should interpolate concatenate steps', () => {
     const pipeline: Pipeline = [
       {
         name: 'concatenate',
-        columns: ['<%= foo %>', '<%= bar %>'],
-        separator: '',
-        new_column_name: 'new',
+        columns: ['<%= foo %>', '<%= egg %>'],
+        separator: '<%= foo %>',
+        new_column_name: '<%= foo %>',
       },
     ];
-    expect(translate(pipeline)).toEqual(pipeline);
+    expect(translate(pipeline)).toEqual([
+      {
+        name: 'concatenate',
+        columns: ['bar', 'spam'],
+        separator: '<%= foo %>',
+        new_column_name: '<%= foo %>',
+      },
+    ]);
   });
 
   it('should leave convert steps untouched', () => {


### PR DESCRIPTION
This PR extends our support for templating in several steps.
The main motivation was first to ensure that we do support templating in `templating.ts` for parameters for which we provide a UI to manage variables in the step forms components.