### PR TITLE
fix(advanced-variable): clean unused props and circular dependencies

### DIFF
--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -8,7 +8,6 @@
           :columnNamesProp="columnNames"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
-          :advanced-variable-delimiters="advancedVariableDelimiters"
           :data-path="slotProps.dataPath"
           :errors="errors"
           :multi-variable="multiVariable"
@@ -57,9 +56,6 @@ export default class FilterEditor extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
-
-  @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Boolean, default: true })
   multiVariable!: boolean; // display multiInputText as multiVariableInput

--- a/src/components/stepforms/AddTextColumnStepForm.vue
+++ b/src/components/stepforms/AddTextColumnStepForm.vue
@@ -11,7 +11,6 @@
       :warning="duplicateColumnName"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <InputTextWidget
       class="textInput"
@@ -22,7 +21,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -50,8 +48,6 @@ export default class AddTextColumnStepForm extends BaseStepForm<AddTextColumnSte
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'text', new_column: '', text: '' }) })
   initialStepValue!: AddTextColumnStep;

--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -12,7 +12,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <ListWidget
       addFieldName="Add aggregation"
@@ -26,7 +25,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -57,8 +55,6 @@ export default class AggregateStepForm extends BaseStepForm<AggregationStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'aggregate', on: [], aggregations: [] }) })
   initialStepValue!: AggregationStep;

--- a/src/components/stepforms/ArgmaxStepForm.vue
+++ b/src/components/stepforms/ArgmaxStepForm.vue
@@ -10,7 +10,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <MultiselectWidget
       class="groupbyColumnsInput"
@@ -22,7 +21,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -52,8 +50,6 @@ export default class ArgmaxStepForm extends BaseStepForm<ArgmaxStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'argmax', column: '' }) })
   initialStepValue!: ArgmaxStep;

--- a/src/components/stepforms/ArgminStepForm.vue
+++ b/src/components/stepforms/ArgminStepForm.vue
@@ -10,7 +10,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <MultiselectWidget
       class="groupbyColumnsInput"
@@ -22,7 +21,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -52,8 +50,6 @@ export default class ArgminStepForm extends BaseStepForm<ArgminStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'argmin', column: '' }) })
   initialStepValue!: ArgminStep;

--- a/src/components/stepforms/ColumnPicker.vue
+++ b/src/components/stepforms/ColumnPicker.vue
@@ -9,7 +9,6 @@
     :errors="errors"
     :available-variables="availableVariables"
     :variable-delimiters="variableDelimiters"
-    :advanced-variable-delimiters="advancedVariableDelimiters"
   />
 </template>
 
@@ -45,9 +44,6 @@ export default class ColumnPicker extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
-
-  @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
 
   // Whether the column data of ColumnPicker should react to a change of
   // selected column

--- a/src/components/stepforms/ConcatenateStepForm.vue
+++ b/src/components/stepforms/ConcatenateStepForm.vue
@@ -14,7 +14,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <InputTextWidget
       class="separator"
@@ -62,8 +61,6 @@ export default class ConcatenateStepForm extends BaseStepForm<ConcatenateStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/CumSumStepForm.vue
+++ b/src/components/stepforms/CumSumStepForm.vue
@@ -11,7 +11,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <ColumnPicker
       class="referenceColumnInput"
@@ -32,7 +31,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <InputTextWidget
       class="newColumnInput"
@@ -74,8 +72,6 @@ export default class CumSumStepForm extends BaseStepForm<CumSumStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'cumsum', valueColumn: '', referenceColumn: '' }) })
   initialStepValue!: CumSumStep;

--- a/src/components/stepforms/EvolutionStepForm.vue
+++ b/src/components/stepforms/EvolutionStepForm.vue
@@ -20,7 +20,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <AutocompleteWidget
       class="evolutionType"
@@ -96,8 +95,6 @@ export default class EvolutionStepForm extends BaseStepForm<EvolutionStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -7,7 +7,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
       @filterTreeUpdated="updateFilterTree"
     />
     <StepFormButtonbar />
@@ -49,8 +48,6 @@ export default class FilterStepForm extends BaseStepForm<FilterStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   readonly title: string = 'Filter';
 

--- a/src/components/stepforms/FormulaStepForm.vue
+++ b/src/components/stepforms/FormulaStepForm.vue
@@ -11,7 +11,6 @@
       :warning="duplicateColumnName"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <InputTextWidget
       class="formulaInput"
@@ -49,8 +48,6 @@ export default class FormulaStepForm extends BaseStepForm<FormulaStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'formula', new_column: '', formula: '' }) })
   initialStepValue!: FormulaStep;

--- a/src/components/stepforms/IfThenElseStepForm.vue
+++ b/src/components/stepforms/IfThenElseStepForm.vue
@@ -16,7 +16,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
       @input="updateIfThenElse"
     />
     <StepFormButtonbar />
@@ -68,8 +67,6 @@ export default class IfThenElseStepForm extends BaseStepForm<IfThenElseStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/RankStepForm.vue
+++ b/src/components/stepforms/RankStepForm.vue
@@ -11,7 +11,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <AutocompleteWidget
       class="orderInput"
@@ -37,7 +36,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <InputTextWidget
       class="newColumnNameInput"
@@ -79,8 +77,6 @@ export default class RankStepForm extends BaseStepForm<RankStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/SplitStepForm.vue
+++ b/src/components/stepforms/SplitStepForm.vue
@@ -10,7 +10,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <InputTextWidget
       class="delimiter"
@@ -57,8 +56,6 @@ export default class SplitStepForm extends BaseStepForm<SplitStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/TopStepForm.vue
+++ b/src/components/stepforms/TopStepForm.vue
@@ -20,7 +20,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <AutocompleteWidget
       class="sortOrderInput"
@@ -41,7 +40,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -75,8 +73,6 @@ export default class TopStepForm extends BaseStepForm<TopStep> {
   @VQBModule.State availableVariables!: VariablesBucket;
 
   @VQBModule.State variableDelimiters!: VariableDelimiters;
-
-  @VQBModule.State advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'top', rank_on: '', sort: 'asc' }) })
   initialStepValue!: TopStep;

--- a/src/components/stepforms/widgets/Aggregation.vue
+++ b/src/components/stepforms/widgets/Aggregation.vue
@@ -10,7 +10,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <AutocompleteWidget
       class="aggregationFunctionInput"
@@ -54,9 +53,6 @@ export default class AggregationWidget extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
-
-  @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
 
   @VQBModule.Getter columnNames!: string[];
 

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -52,6 +52,7 @@ import VariableInput from './VariableInput.vue';
   name: 'autocomplete-widget',
   components: {
     Multiselect,
+    VariableInput,
   },
 })
 export default class AutocompleteWidget extends Mixins(FormWidget) {
@@ -84,11 +85,6 @@ export default class AutocompleteWidget extends Mixins(FormWidget) {
 
   @Prop()
   advancedVariableDelimiters!: VariableDelimiters;
-
-  // See https://vuejs.org/v2/guide/components.html#Circular-References-Between-Components
-  beforeCreate() {
-    this.$options.components['VariableInput'] = VariableInput;
-  }
 
   updateValue(newValue?: string | object) {
     this.$emit('input', newValue);

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -5,7 +5,6 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
       :has-arrow="true"
       @input="updateValue"
     >
@@ -82,9 +81,6 @@ export default class AutocompleteWidget extends Mixins(FormWidget) {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
-
-  @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
 
   updateValue(newValue?: string | object) {
     this.$emit('input', newValue);

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -6,7 +6,6 @@
         :value="value.column"
         :available-variables="availableVariables"
         :variable-delimiters="variableDelimiters"
-        :advanced-variable-delimiters="advancedVariableDelimiters"
         :options="columnNames"
         @input="updateStepColumn"
         placeholder="Column"
@@ -33,7 +32,6 @@
       :value="value.value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
       :placeholder="placeholder"
       :data-path="`${dataPath}.value`"
       :errors="errors"
@@ -120,9 +118,6 @@ export default class FilterSimpleConditionWidget extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
-
-  @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
 
   readonly operators: OperatorOption[] = [
     { operator: 'eq', label: 'equals', inputWidget: InputTextWidget },

--- a/src/components/stepforms/widgets/IfThenElseWidget.vue
+++ b/src/components/stepforms/widgets/IfThenElseWidget.vue
@@ -29,7 +29,6 @@
           :data-path="`${dataPath}.if`"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
-          :advanced-variable-delimiters="advancedVariableDelimiters"
           @filterTreeUpdated="updateFilterTree"
         />
       </div>
@@ -57,7 +56,6 @@
           :errors="errors"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
-          :advanced-variable-delimiters="advancedVariableDelimiters"
           @input="updateThenFormula"
         />
       </div>
@@ -83,7 +81,6 @@
             :errors="errors"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
-            :advanced-variable-delimiters="advancedVariableDelimiters"
             @input="updateElseFormula"
           />
         </div>
@@ -96,7 +93,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
       @input="updateElseFormula"
       @deletedElseIf="transformElseIfIntoElse"
     />
@@ -141,9 +137,6 @@ export default class IfThenElseWidget extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
-
-  @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/widgets/InputNumber.vue
+++ b/src/components/stepforms/widgets/InputNumber.vue
@@ -10,7 +10,6 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
       :has-arrow="true"
       @input="updateValue"
     >
@@ -76,9 +75,6 @@ export default class InputNumberWidget extends Mixins(FormWidget) {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
-
-  @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
 
   isFocused = false;
 

--- a/src/components/stepforms/widgets/InputText.vue
+++ b/src/components/stepforms/widgets/InputText.vue
@@ -11,7 +11,6 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
       @input="updateValue"
     >
       <input
@@ -65,9 +64,6 @@ export default class InputTextWidget extends Mixins(FormWidget) {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
-
-  @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
 
   updateValue(newValue?: string) {
     this.$emit('input', newValue);

--- a/src/components/stepforms/widgets/InputText.vue
+++ b/src/components/stepforms/widgets/InputText.vue
@@ -45,6 +45,7 @@ import VariableInput from './VariableInput.vue';
 
 @Component({
   name: 'input-text-widget',
+  components: { VariableInput },
 })
 export default class InputTextWidget extends Mixins(FormWidget) {
   @Prop({ type: String, default: '' })
@@ -67,11 +68,6 @@ export default class InputTextWidget extends Mixins(FormWidget) {
 
   @Prop()
   advancedVariableDelimiters!: VariableDelimiters;
-
-  // See https://vuejs.org/v2/guide/components.html#Circular-References-Between-Components
-  beforeCreate() {
-    this.$options.components['VariableInput'] = VariableInput;
-  }
 
   updateValue(newValue?: string) {
     this.$emit('input', newValue);

--- a/src/components/stepforms/widgets/JoinColumns.vue
+++ b/src/components/stepforms/widgets/JoinColumns.vue
@@ -9,7 +9,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
     <InputTextWidget
       class="rightOn"
@@ -19,7 +18,6 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
     />
   </div>
 </template>
@@ -58,9 +56,6 @@ export default class JoinColumns extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
-
-  @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
 
   @VQBModule.Getter columnNames!: string[];
 

--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -13,7 +13,6 @@
             :value="child.value"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
-            :advanced-variable-delimiters="advancedVariableDelimiters"
             @input="updateChildValue($event, index)"
             :data-path="`${dataPath}[${index}]`"
             :errors="errors"
@@ -96,9 +95,6 @@ export default class ListWidget extends Mixins(FormWidget) {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
-
-  @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
 
   get children() {
     const valueCopy = [...this.value];

--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -5,7 +5,6 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
       @input="updateValue"
     >
       <multiselect
@@ -81,9 +80,6 @@ export default class MultiInputTextWidget extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
-
-  @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ default: true })
   multiVariable!: boolean;

--- a/src/components/stepforms/widgets/MultiVariableInput.vue
+++ b/src/components/stepforms/widgets/MultiVariableInput.vue
@@ -3,7 +3,6 @@
     <VariableInputBase
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
       :has-arrow="hasArrow"
       :is-multiple="true"
       :value="value"
@@ -31,14 +30,11 @@ export default class MultiVariableInput extends Vue {
   @Prop({ type: Array, default: () => [] })
   value!: any[];
 
-  @Prop({ default: () => [] })
+  @Prop()
   availableVariables!: VariablesBucket;
 
-  @Prop({ default: () => ({ start: '{{', end: '}}' }) })
-  variableDelimiters!: VariableDelimiters;
-
   @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
+  variableDelimiters!: VariableDelimiters;
 
   @Prop({ default: false })
   hasArrow?: boolean; //move variable-chooser button to the left if parent has an expand arrow

--- a/src/components/stepforms/widgets/MultiVariableInput.vue
+++ b/src/components/stepforms/widgets/MultiVariableInput.vue
@@ -25,6 +25,7 @@ import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
  */
 @Component({
   name: 'multi-variable-input',
+  components: { VariableInputBase },
 })
 export default class MultiVariableInput extends Vue {
   @Prop({ type: Array, default: () => [] })
@@ -41,11 +42,6 @@ export default class MultiVariableInput extends Vue {
 
   @Prop({ default: false })
   hasArrow?: boolean; //move variable-chooser button to the left if parent has an expand arrow
-
-  // See https://vuejs.org/v2/guide/components.html#Circular-References-Between-Components
-  beforeCreate() {
-    this.$options.components['VariableInputBase'] = VariableInputBase;
-  }
 
   /**
    * Toggle value in array

--- a/src/components/stepforms/widgets/Multiselect.vue
+++ b/src/components/stepforms/widgets/Multiselect.vue
@@ -6,7 +6,6 @@
       :value="stringValue"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
       :has-arrow="true"
       @input="updateStringValue"
     >
@@ -36,7 +35,6 @@
             v-if="isVariable(option)"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
-            :advanced-variable-delimiters="advancedVariableDelimiters"
             :value="customLabel(option)"
             @removed="remove(option)"
           />
@@ -104,9 +102,6 @@ export default class MultiselectWidget extends Mixins(FormWidget) {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
-
-  @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
 
   editedValue: string[] | object[] = [];
 

--- a/src/components/stepforms/widgets/VariableInput.vue
+++ b/src/components/stepforms/widgets/VariableInput.vue
@@ -38,6 +38,7 @@ import { extractVariableIdentifier, VariableDelimiters, VariablesBucket } from '
   name: 'variable-input',
   components: {
     VariableTag,
+    VariableInputBase,
   },
 })
 export default class VariableInput extends Vue {
@@ -55,11 +56,6 @@ export default class VariableInput extends Vue {
 
   @Prop({ default: false })
   hasArrow?: boolean; //move variable-chooser button to the left if parent has an expand arrow
-
-  // See https://vuejs.org/v2/guide/components.html#Circular-References-Between-Components
-  beforeCreate() {
-    this.$options.components['VariableInputBase'] = VariableInputBase;
-  }
 
   /**
    * Verify if we need to display the slot or the variableTag

--- a/src/components/stepforms/widgets/VariableInput.vue
+++ b/src/components/stepforms/widgets/VariableInput.vue
@@ -14,7 +14,6 @@
       v-else
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
-      :advanced-variable-delimiters="advancedVariableDelimiters"
       :has-arrow="hasArrow"
       @input="chooseVariable"
     >
@@ -45,14 +44,11 @@ export default class VariableInput extends Vue {
   @Prop()
   value!: any;
 
-  @Prop({ default: () => [] })
+  @Prop()
   availableVariables!: VariablesBucket;
 
-  @Prop({ default: () => ({ start: '{{', end: '}}' }) })
-  variableDelimiters!: VariableDelimiters;
-
   @Prop()
-  advancedVariableDelimiters!: VariableDelimiters;
+  variableDelimiters!: VariableDelimiters;
 
   @Prop({ default: false })
   hasArrow?: boolean; //move variable-chooser button to the left if parent has an expand arrow

--- a/src/components/stepforms/widgets/VariableInputs/AdvancedVariableModal.vue
+++ b/src/components/stepforms/widgets/VariableInputs/AdvancedVariableModal.vue
@@ -8,29 +8,12 @@
           <div class="vqb-modal__title">Custom Variable</div>
         </div>
         <div class="vqb-modal__section">
-          <InputTextWidget
-            class="nameInput"
-            v-model="variable.name"
-            name="Variable name"
-            placeholder
-            data-path=".name"
-            :errors="errors"
-          />
           <CodeEditorWidget
             class="codeInput"
-            v-model="variable.code"
+            v-model="value"
             placeholder="Write your custom variable here"
             :errors="errors"
             data-path=".code"
-          />
-          <AutocompleteWidget
-            class="typeInput"
-            v-model="variable.type"
-            name="Return result as"
-            :options="types"
-            placeholder
-            data-path=".type"
-            :errors="errors"
           />
         </div>
         <div class="vqb-modal__footer">
@@ -50,34 +33,22 @@
 import { ErrorObject } from 'ajv';
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
-import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import CodeEditorWidget from '@/components/stepforms/widgets/CodeEditorWidget.vue';
-import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 /**
  * This component allow to add an advanced variable
  */
 @Component({
   name: 'advanced-variable-modal',
-  components: {
-    CodeEditorWidget,
-    InputTextWidget,
-  },
+  components: { CodeEditorWidget },
 })
 export default class AdvancedVariableModal extends Vue {
-  variable = { type: 'text', name: '', code: '' };
+  value = '';
 
   @Prop({ type: Array, default: () => [] })
   errors!: ErrorObject[];
 
   @Prop({ default: false })
   isOpened!: boolean;
-
-  readonly types = ['text', 'number'];
-
-  // See https://vuejs.org/v2/guide/components.html#Circular-References-Between-Components
-  beforeCreate() {
-    this.$options.components['AutocompleteWidget'] = AutocompleteWidget;
-  }
 
   close() {
     this.$emit('closed');
@@ -147,7 +118,6 @@ export default class AdvancedVariableModal extends Vue {
   border-top-right-radius: 20px;
   display: flex;
   padding: 20px 30px;
-  box-shadow: inset 0 -1px 0 0 #f5f5f5;
 }
 
 .vqb-modal__title {
@@ -156,11 +126,6 @@ export default class AdvancedVariableModal extends Vue {
   line-height: 20px;
   color: #4c4c4c;
   font-weight: 700;
-}
-
-.vqb-modal__section {
-  box-shadow: inset 0 -1px 0 0 #f5f5f5;
-  padding: 25px 0;
 }
 
 .vqb-modal__text {
@@ -207,18 +172,9 @@ strong.vqb-modal__text {
   border: none;
 }
 
-.nameInput {
-  padding: 0 30px;
-  /deep/ .widget-input-text__label label {
-    text-transform: uppercase;
-    color: #6a6a6a;
-    font-weight: 600;
-    font-size: 12px;
-  }
-}
-
 .codeInput {
   height: 200px;
+  margin: 0;
 
   /deep/ .view-lines,
   /deep/ .margin {
@@ -227,24 +183,6 @@ strong.vqb-modal__text {
 
   /deep/ .glyph-margin {
     background: #eeeeee;
-  }
-}
-
-.typeInput {
-  flex-direction: row;
-  align-items: center;
-  margin-bottom: 0;
-  padding: 0 30px;
-
-  /deep/ .widget-autocomplete__label {
-    flex: 0 auto;
-    padding-right: 20px;
-  }
-
-  /deep/ .widget-input-variable {
-    width: auto;
-    flex: 0 auto;
-    min-width: 120px;
   }
 }
 </style>

--- a/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
@@ -29,7 +29,7 @@
           <span class="widget-variable-chooser__option-value">{{ availableVariable.value }}</span>
         </div>
       </div>
-      <div v-if="isAdvanced" class="widget-advanced-variable" @click="addAdvancedVariable">
+      <div class="widget-advanced-variable" @click="addAdvancedVariable">
         Advanced variable
       </div>
     </div>
@@ -41,7 +41,7 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import { POPOVER_ALIGN } from '@/components/constants';
 import Popover from '@/components/Popover.vue';
-import { VariableDelimiters, VariablesBucket, VariablesCategory } from '@/lib/variables';
+import { VariablesBucket, VariablesCategory } from '@/lib/variables';
 
 /**
  * This component list all the available variables to use as value in VariableInputs
@@ -54,17 +54,11 @@ export default class VariableChooser extends Vue {
   @Prop({ default: false })
   isMultiple!: boolean;
 
-  @Prop({ default: false })
-  isAdvanced!: boolean;
-
   @Prop({ default: () => [] })
   selectedVariables!: string[];
 
   @Prop({ default: () => [] })
   availableVariables!: VariablesBucket;
-
-  @Prop({ default: () => ({ start: '{{', end: '}}' }) })
-  variableDelimiters!: VariableDelimiters;
 
   @Prop({ default: false })
   isOpened!: boolean;

--- a/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
@@ -23,7 +23,6 @@
       :available-variables="availableVariables"
       :is-opened="isChoosingVariable"
       :is-multiple="isMultiple"
-      :is-advanced="advancedVariableDelimiters"
       :value="value"
       :selected-variables="selectedVariables"
       @addAdvancedVariable="openAdvancedVariableModal"
@@ -63,14 +62,11 @@ export default class VariableInputBase extends Vue {
   @Prop({ default: () => [] })
   value!: string[];
 
-  @Prop({ default: () => [] })
+  @Prop()
   availableVariables!: VariablesBucket;
 
   @Prop({ default: () => ({ start: '{{', end: '}}' }) })
   variableDelimiters!: VariableDelimiters;
-
-  @Prop({ default: null })
-  advancedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ default: false })
   hasArrow!: boolean;
@@ -93,10 +89,7 @@ export default class VariableInputBase extends Vue {
    * Determine whether to authorize or not the selection of a variable
    */
   get canBeVariable() {
-    return (
-      (this.availableVariables && this.availableVariables.length > 0) ||
-      this.advancedVariableDelimiters
-    );
+    return this.availableVariables;
   }
 
   startChoosingVariable() {

--- a/src/components/stepforms/widgets/VariableInputs/VariableTag.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableTag.vue
@@ -31,9 +31,9 @@ Vue.use(VTooltip);
  * This component display a variable based on a human readable format and allow to delete it
  */
 @Component({
-  name: 'variable-input',
+  name: 'variable-tag',
 })
-export default class VariableInput extends Vue {
+export default class VariableTag extends Vue {
   @Prop()
   value!: string;
 

--- a/src/components/stepforms/widgets/VariableInputs/VariableTag.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableTag.vue
@@ -40,7 +40,7 @@ export default class VariableTag extends Vue {
   @Prop({ default: () => [] })
   availableVariables!: VariablesBucket;
 
-  @Prop({ default: () => ({ start: '{{', end: '}}' }) })
+  @Prop()
   variableDelimiters!: VariableDelimiters;
 
   /**

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -81,13 +81,7 @@ type VariableDelimitersMutation = {
   payload: Pick<VQBState, 'variableDelimiters'>;
 };
 
-type AdvancedVariableDelimitersMutation = {
-  type: 'setAdvancedVariableDelimiters';
-  payload: Pick<VQBState, 'advancedVariableDelimiters'>;
-};
-
 export type StateMutation =
-  | AdvancedVariableDelimitersMutation
   | AvailableVariablesMutation
   | BackendMessageMutation
   | DatasetMutation
@@ -338,16 +332,6 @@ class Mutations {
     { variableDelimiters }: Pick<VQBState, 'variableDelimiters'>,
   ) {
     state.variableDelimiters = variableDelimiters;
-  }
-
-  /**
-   * set the variable delimiters for templating advanced variables.
-   */
-  setAdvancedVariableDelimiters(
-    state: VQBState,
-    { advancedVariableDelimiters }: Pick<VQBState, 'advancedVariableDelimiters'>,
-  ) {
-    state.advancedVariableDelimiters = advancedVariableDelimiters;
   }
 }
 

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -108,7 +108,6 @@ export interface VQBState {
    * variable delimiter for templating
    */
   variableDelimiters?: VariableDelimiters;
-  advancedVariableDelimiters?: VariableDelimiters;
 }
 
 /**

--- a/stories/variable.js
+++ b/stories/variable.js
@@ -214,40 +214,12 @@ stories.add('wrapping a InputNumber', () => ({
   },
 }));
 
-stories.add('wrapping a widget with advanced variable', () => ({
-  template: `
-    <div>
-      <Multiselect 
-        v-model="value" 
-        :available-variables="availableVariables"
-        :variable-delimiters="variableDelimiters"
-        :advanced-variable-delimiters="advancedVariableDelimiters"
-        :options="options"
-      />
-      <pre>{{ value }}</pre>
-    </div>
-  `,
-
-  components: { Multiselect },
-
-  data() {
-    return {
-      value: undefined,
-      options: ['foo', 'bar', 'helloworld'],
-      availableVariables: SAMPLE_VARIABLES,
-      variableDelimiters: { start: '{{', end: '}}' },
-      advancedVariableDelimiters: { start: '<<<', end: '>>>' },
-    };
-  },
-}));
-
 stories.add('wrapping a widget with advanced variable and no variables', () => ({
   template: `
     <div>
       <Multiselect 
         v-model="value" 
         :variable-delimiters="variableDelimiters"
-        :advanced-variable-delimiters="advancedVariableDelimiters"
         :options="options"
       />
       <pre>{{ value }}</pre>
@@ -260,8 +232,7 @@ stories.add('wrapping a widget with advanced variable and no variables', () => (
     return {
       value: undefined,
       options: ['foo', 'bar', 'helloworld'],
-      variableDelimiters: { start: '{{', end: '}}' },
-      advancedVariableDelimiters: { start: '<<<', end: '>>>' },
+      availableVariables: [],
     };
   },
 }));

--- a/tests/unit/advanced-variable-modal.spec.ts
+++ b/tests/unit/advanced-variable-modal.spec.ts
@@ -44,14 +44,6 @@ describe('Variable Chooser', () => {
     it('should have a code editor input', () => {
       expect(wrapper.find('CodeEditorWidget-stub').exists()).toBe(true);
     });
-
-    it('should have a name input', () => {
-      expect(wrapper.find('InputTextWidget-stub').exists()).toBe(true);
-    });
-
-    it('should have a type input', () => {
-      expect(wrapper.find('AutocompleteWidget-stub').exists()).toBe(true);
-    });
   });
 
   describe('when clicking on the close button', () => {

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -913,13 +913,4 @@ describe('action tests', () => {
       expect(state.variableDelimiters).toEqual(variableDelimiters);
     });
   });
-
-  describe('setAdvancedVariableDelimiters', function() {
-    it('set advanced variable delimiters', () => {
-      const state = buildState({});
-      const advancedVariableDelimiters = { start: '{{', end: '}}' };
-      mutations.setAdvancedVariableDelimiters(state, { advancedVariableDelimiters });
-      expect(state.advancedVariableDelimiters).toEqual(advancedVariableDelimiters);
-    });
-  });
 });

--- a/tests/unit/variable-chooser.spec.ts
+++ b/tests/unit/variable-chooser.spec.ts
@@ -81,10 +81,6 @@ describe('Variable Chooser', () => {
   });
 
   describe('when is advanced', () => {
-    beforeEach(() => {
-      wrapper.setProps({ isAdvanced: true });
-    });
-
     it('should display an "Advanced variable" option ...', () => {
       expect(wrapper.find('.widget-advanced-variable').exists()).toBe(true);
     });

--- a/tests/unit/variable-input-base.spec.ts
+++ b/tests/unit/variable-input-base.spec.ts
@@ -69,7 +69,7 @@ describe('Variable Input', () => {
     describe('when there is no available variables', () => {
       beforeEach(async () => {
         wrapper.setProps({
-          availableVariables: [],
+          availableVariables: null,
         });
         await wrapper.vm.$nextTick();
       });
@@ -78,8 +78,8 @@ describe('Variable Input', () => {
         expect(wrapper.find('.widget-variable__toggle').exists()).toBe(false);
       });
 
-      it('... except if advanced variable is allowed', async () => {
-        wrapper.setProps({ advancedVariableDelimiters: { start: '{{', end: '}}' } });
+      it('... except if availableVariables is not null', async () => {
+        wrapper.setProps({ availableVariables: [] });
         await wrapper.vm.$nextTick();
         expect(wrapper.find('.widget-variable__toggle').exists()).toBe(true);
       });

--- a/tests/unit/variable-input.spec.ts
+++ b/tests/unit/variable-input.spec.ts
@@ -78,6 +78,7 @@ describe('Variable Input', () => {
     beforeEach(async () => {
       wrapper.setProps({
         value: '{{ hummus }}',
+        variableDelimiters: { start: '{{', end: '}}' },
       });
       await wrapper.vm.$nextTick();
     });


### PR DESCRIPTION
As other PRS has been closed we remove previous work for advancedVariableDelimiters and circularDepencies issues