### PR TITLE
feat(advanced-variable): update an advanced variable

### DIFF
--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -5,6 +5,7 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :edited-advanced-variable="editedAdvancedVariable"
       @input="updateValue"
     >
       <multiselect
@@ -32,6 +33,7 @@
             :variable-delimiters="variableDelimiters"
             :value="option"
             @removed="remove(option)"
+            @edited="editAdvancedVariable"
           />
           <span class="multiselect__tag widget-multiinputtext__tag" @click.prevent.stop="" v-else>
             <span v-html="option" />
@@ -66,6 +68,8 @@ import VariableInput from './VariableInput.vue';
   },
 })
 export default class MultiInputTextWidget extends Vue {
+  editedAdvancedVariable = '';
+
   @Prop({ type: String, default: '' })
   name!: string;
 
@@ -116,6 +120,13 @@ export default class MultiInputTextWidget extends Vue {
   isVariable(value: string) {
     const identifier = extractVariableIdentifier(value, this.variableDelimiters);
     return identifier != null;
+  }
+
+  /*
+  Select the advanced variable to edit
+  */
+  editAdvancedVariable(value: string) {
+    this.editedAdvancedVariable = value;
   }
 }
 </script>

--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -6,6 +6,7 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :edited-advanced-variable="editedAdvancedVariable"
+      @resetEditedAdvancedVariable="resetEditedAdvancedVariable"
       @input="updateValue"
     >
       <multiselect
@@ -127,6 +128,13 @@ export default class MultiInputTextWidget extends Vue {
   */
   editAdvancedVariable(value: string) {
     this.editedAdvancedVariable = value;
+  }
+
+  /*
+  Reset the advanced variable to edit
+  */
+  resetEditedAdvancedVariable() {
+    this.editedAdvancedVariable = '';
   }
 }
 </script>

--- a/src/components/stepforms/widgets/MultiVariableInput.vue
+++ b/src/components/stepforms/widgets/MultiVariableInput.vue
@@ -8,6 +8,7 @@
       :value="value"
       :edited-advanced-variable="editedAdvancedVariable"
       @chooseAdvancedVariable="chooseAdvancedVariable"
+      @resetEditedAdvancedVariable="resetEditedAdvancedVariable"
       @input="toggleVariable"
     >
       <slot />
@@ -72,6 +73,13 @@ export default class MultiVariableInput extends Vue {
     } else {
       this.$emit('input', [...values, value]);
     }
+  }
+
+  /*
+  Reset the advanced variable to edit
+  */
+  resetEditedAdvancedVariable() {
+    this.$emit('resetEditedAdvancedVariable');
   }
 }
 </script>

--- a/src/components/stepforms/widgets/MultiVariableInput.vue
+++ b/src/components/stepforms/widgets/MultiVariableInput.vue
@@ -7,7 +7,7 @@
       :is-multiple="true"
       :value="value"
       :edited-advanced-variable="editedAdvancedVariable"
-      @chooseAdvancedVariable="toggleVariable"
+      @chooseAdvancedVariable="chooseAdvancedVariable"
       @input="toggleVariable"
     >
       <slot />
@@ -55,6 +55,22 @@ export default class MultiVariableInput extends Vue {
       );
     } else {
       this.$emit('input', [...this.value, value]);
+    }
+  }
+
+  /**
+   * Add advanced variable to value or edit it if editAdvancedVariable value is provided
+   */
+  chooseAdvancedVariable(value: string) {
+    // remove potential duplicated value
+    const values = [...this.value].filter(v => v !== value);
+
+    const index = values.indexOf(this.editedAdvancedVariable);
+    if (index !== -1) {
+      values.splice(index, 1, value);
+      this.$emit('input', values);
+    } else {
+      this.$emit('input', [...values, value]);
     }
   }
 }

--- a/src/components/stepforms/widgets/MultiVariableInput.vue
+++ b/src/components/stepforms/widgets/MultiVariableInput.vue
@@ -6,6 +6,7 @@
       :has-arrow="hasArrow"
       :is-multiple="true"
       :value="value"
+      :edited-advanced-variable="editedAdvancedVariable"
       @chooseAdvancedVariable="toggleVariable"
       @input="toggleVariable"
     >
@@ -36,6 +37,9 @@ export default class MultiVariableInput extends Vue {
 
   @Prop()
   variableDelimiters!: VariableDelimiters;
+
+  @Prop({ default: () => '' })
+  editedAdvancedVariable!: string;
 
   @Prop({ default: false })
   hasArrow?: boolean; //move variable-chooser button to the left if parent has an expand arrow

--- a/src/components/stepforms/widgets/Multiselect.vue
+++ b/src/components/stepforms/widgets/Multiselect.vue
@@ -8,6 +8,7 @@
       :variable-delimiters="variableDelimiters"
       :has-arrow="true"
       :edited-advanced-variable="editedAdvancedVariable"
+      @resetEditedAdvancedVariable="resetEditedAdvancedVariable"
       @input="updateStringValue"
     >
       <multiselect
@@ -175,6 +176,13 @@ export default class MultiselectWidget extends Mixins(FormWidget) {
   */
   editAdvancedVariable(value: string) {
     this.editedAdvancedVariable = value;
+  }
+
+  /*
+  Reset the advanced variable to edit
+  */
+  resetEditedAdvancedVariable() {
+    this.editedAdvancedVariable = '';
   }
 }
 </script>

--- a/src/components/stepforms/widgets/Multiselect.vue
+++ b/src/components/stepforms/widgets/Multiselect.vue
@@ -7,6 +7,7 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :has-arrow="true"
+      :edited-advanced-variable="editedAdvancedVariable"
       @input="updateStringValue"
     >
       <multiselect
@@ -37,6 +38,7 @@
             :variable-delimiters="variableDelimiters"
             :value="customLabel(option)"
             @removed="remove(option)"
+            @edited="editAdvancedVariable"
           />
           <span class="multiselect__tag widget-multiselect__tag" v-else>
             <span v-html="customLabel(option)" />
@@ -76,6 +78,8 @@ import MultiVariableInput from './MultiVariableInput.vue';
   },
 })
 export default class MultiselectWidget extends Mixins(FormWidget) {
+  editedAdvancedVariable = '';
+
   @Prop({ type: String, default: '' })
   name!: string;
 
@@ -164,6 +168,13 @@ export default class MultiselectWidget extends Mixins(FormWidget) {
     } else {
       return option;
     }
+  }
+
+  /*
+  Select the advanced variable to edit
+  */
+  editAdvancedVariable(value: string) {
+    this.editedAdvancedVariable = value;
   }
 }
 </script>

--- a/src/components/stepforms/widgets/VariableInput.vue
+++ b/src/components/stepforms/widgets/VariableInput.vue
@@ -17,6 +17,7 @@
       :has-arrow="hasArrow"
       :edited-advanced-variable="editedAdvancedVariable"
       @chooseAdvancedVariable="chooseVariable"
+      @resetEditedAdvancedVariable="resetEditedAdvancedVariable"
       @input="chooseVariable"
     >
       <slot v-if="!isVariable" />
@@ -79,8 +80,18 @@ export default class VariableInput extends Vue {
     this.$emit('input', undefined);
   }
 
+  /*
+  Select the advanced variable to edit
+  */
   editAdvancedVariable(value: string) {
     this.editedAdvancedVariable = value;
+  }
+
+  /*
+  Reset the advanced variable to edit
+  */
+  resetEditedAdvancedVariable() {
+    this.editedAdvancedVariable = '';
   }
 }
 </script>

--- a/src/components/stepforms/widgets/VariableInput.vue
+++ b/src/components/stepforms/widgets/VariableInput.vue
@@ -7,18 +7,19 @@
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
           @removed="dismissVariable"
+          @edited="editAdvancedVariable"
         />
       </div>
     </div>
     <VariableInputBase
-      v-else
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :has-arrow="hasArrow"
+      :edited-advanced-variable="editedAdvancedVariable"
       @chooseAdvancedVariable="chooseVariable"
       @input="chooseVariable"
     >
-      <slot />
+      <slot v-if="!isVariable" />
     </VariableInputBase>
   </div>
 </template>
@@ -42,6 +43,8 @@ import { extractVariableIdentifier, VariableDelimiters, VariablesBucket } from '
   },
 })
 export default class VariableInput extends Vue {
+  editedAdvancedVariable = '';
+
   @Prop()
   value!: any;
 
@@ -74,6 +77,10 @@ export default class VariableInput extends Vue {
    */
   dismissVariable() {
     this.$emit('input', undefined);
+  }
+
+  editAdvancedVariable(value: string) {
+    this.editedAdvancedVariable = value;
   }
 }
 </script>

--- a/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
@@ -31,6 +31,8 @@
     />
     <AdvancedVariableModal
       :is-opened="isAdvancedVariableModalOpened"
+      :variable="editedAdvancedVariable"
+      :variable-delimiters="variableDelimiters"
       @input="chooseAdvancedVariable"
       @closed="closeAdvancedVariableModal"
     />
@@ -38,7 +40,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
 import { extractVariableIdentifier, VariableDelimiters, VariablesBucket } from '@/lib/variables';
 
@@ -69,12 +71,20 @@ export default class VariableInputBase extends Vue {
   @Prop({ default: () => ({ start: '{{', end: '}}' }) })
   variableDelimiters!: VariableDelimiters;
 
+  @Prop({ default: () => '' })
+  editedAdvancedVariable!: string;
+
   @Prop({ default: false })
   hasArrow!: boolean;
 
   isChoosingVariable = false;
 
   isAdvancedVariableModalOpened = false;
+
+  @Watch('editedAdvancedVariable')
+  editAdvancedVariable() {
+    if (this.editedAdvancedVariable) this.openAdvancedVariableModal();
+  }
 
   /**
    * Find variables in value array

--- a/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
@@ -118,6 +118,7 @@ export default class VariableInputBase extends Vue {
 
   closeAdvancedVariableModal() {
     this.isAdvancedVariableModalOpened = false;
+    this.$emit('resetEditedAdvancedVariable');
   }
 
   /**

--- a/src/components/stepforms/widgets/VariableInputs/VariableTag.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableTag.vue
@@ -10,7 +10,12 @@
     }"
   >
     <span class="widget-variable__tag-icon">{}</span>
-    <span class="widget-variable__tag-name">{{ variableLabel }}</span>
+    <span
+      class="widget-variable__tag-name"
+      @keypress.enter.prevent="editAdvancedVariable"
+      @mousedown.prevent="editAdvancedVariable"
+      >{{ variableLabel }}</span
+    >
     <i
       class="widget-variable__tag-close fa fa-times"
       tabindex="1"
@@ -86,6 +91,12 @@ export default class VariableTag extends Vue {
 
   removeVariableTag() {
     this.$emit('removed');
+  }
+
+  editAdvancedVariable() {
+    if (this.isAdvancedVariable) {
+      this.$emit('edited', this.value);
+    }
   }
 }
 </script>

--- a/stories/variable.js
+++ b/stories/variable.js
@@ -183,7 +183,7 @@ stories.add('wrapping a List', () => ({
         v-model="value"
         :widget="widget"
         :available-variables="availableVariables"
-        :variable-delimiters="variableDelimiters
+        :variable-delimiters="variableDelimiters"
         :automatic-new-field="false"
         defaultItem=""
       ></List>
@@ -210,7 +210,7 @@ stories.add('wrapping a InputNumber', () => ({
       <InputNumber 
         v-model="value" 
         :available-variables="availableVariables" 
-        :variable-delimiters="variableDelimiters
+        :variable-delimiters="variableDelimiters"
       />
       <pre>{{ value }}</pre>
     </div>
@@ -235,6 +235,7 @@ stories.add('wrapping a widget with advanced variable and no variables', () => (
       <Multiselect 
         v-model="value" 
         :variable-delimiters="variableDelimiters"
+        :available-variables="availableVariables"
         :options="options"
       />
       <pre>{{ value }}</pre>
@@ -247,6 +248,7 @@ stories.add('wrapping a widget with advanced variable and no variables', () => (
     return {
       value: undefined,
       options: ['foo', 'bar', 'helloworld'],
+      availableVariables: [],
       variableDelimiters: { start: '{{', end: '}}' },
     };
   },

--- a/tests/unit/multi-input-text-widget.spec.ts
+++ b/tests/unit/multi-input-text-widget.spec.ts
@@ -181,4 +181,24 @@ describe('Widget MultiInputText', () => {
       expect(wrapper.find('.widget-multiinputtext__tag').exists()).toBe(false);
     });
   });
+
+  describe('when editing an advanced variable', () => {
+    let wrapper: any;
+    beforeEach(() => {
+      wrapper = mount(MultiInputTextWidget, {
+        propsData: {
+          availableVariables: [],
+          multiVariable: true,
+          value: ['{{ var1 }}'],
+          variableDelimiters: { start: '{{', end: '}}' },
+        },
+      });
+    });
+    it('should select the advanced variable to edit', async () => {
+      const tag = wrapper.findAll(VariableTag).at(0);
+      tag.vm.$emit('edited', '{{ a }}');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find(MultiVariableInput).props().editedAdvancedVariable).toBe('{{ a }}');
+    });
+  });
 });

--- a/tests/unit/multi-input-text-widget.spec.ts
+++ b/tests/unit/multi-input-text-widget.spec.ts
@@ -200,5 +200,11 @@ describe('Widget MultiInputText', () => {
       await wrapper.vm.$nextTick();
       expect(wrapper.find(MultiVariableInput).props().editedAdvancedVariable).toBe('{{ a }}');
     });
+    it('should reset the advanced variable to edit when modal close', async () => {
+      wrapper.setData({ editedAdvancedVariable: '{{ a }}' });
+      wrapper.find(MultiVariableInput).vm.$emit('resetEditedAdvancedVariable');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find(MultiVariableInput).props().editedAdvancedVariable).toBe('');
+    });
   });
 });

--- a/tests/unit/multi-variable-input.spec.ts
+++ b/tests/unit/multi-variable-input.spec.ts
@@ -59,6 +59,7 @@ describe('Variable Input', () => {
 
   describe('when choosing an advanced variable', () => {
     it('should add the value to the list ...', async () => {
+      wrapper.setProps({ editedAdvancedVariable: '', value: [] });
       wrapper
         .find('VariableInputBase-stub')
         .vm.$emit('chooseAdvancedVariable', '{{ appRequesters.view }}');
@@ -67,14 +68,27 @@ describe('Variable Input', () => {
       expect(wrapper.emitted('input')[0][0]).toEqual(['{{ appRequesters.view }}']);
     });
 
-    it('... or remove it if already in', async () => {
-      wrapper.setProps({ value: ['{{ appRequesters.view }}'] });
+    it('... remove duplicated values ...', async () => {
+      wrapper.setProps({ editedAdvancedVariable: '', value: ['{{ appRequesters.view }}'] });
       wrapper
         .find('VariableInputBase-stub')
         .vm.$emit('chooseAdvancedVariable', '{{ appRequesters.view }}');
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted('input')).toHaveLength(1);
-      expect(wrapper.emitted('input')[0][0]).toEqual([]);
+      expect(wrapper.emitted('input')[0][0]).toEqual(['{{ appRequesters.view }}']);
+    });
+
+    it('... or update it if an advanced variable is edited', async () => {
+      wrapper.setProps({
+        editedAdvancedVariable: '{{ appRequesters.view }}',
+        value: ['{{ appRequesters.view }}'],
+      });
+      wrapper
+        .find('VariableInputBase-stub')
+        .vm.$emit('chooseAdvancedVariable', '{{ appRequesters.view | number }}');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.emitted('input')).toHaveLength(1);
+      expect(wrapper.emitted('input')[0][0]).toEqual(['{{ appRequesters.view | number }}']);
     });
   });
 });

--- a/tests/unit/multi-variable-input.spec.ts
+++ b/tests/unit/multi-variable-input.spec.ts
@@ -90,5 +90,10 @@ describe('Variable Input', () => {
       expect(wrapper.emitted('input')).toHaveLength(1);
       expect(wrapper.emitted('input')[0][0]).toEqual(['{{ appRequesters.view | number }}']);
     });
+    it('should reset the advanced variable to edit when modal close', async () => {
+      wrapper.find('VariableInputBase-stub').vm.$emit('resetEditedAdvancedVariable');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.emitted('resetEditedAdvancedVariable')).toHaveLength(1);
+    });
   });
 });

--- a/tests/unit/multiselect-widget.spec.ts
+++ b/tests/unit/multiselect-widget.spec.ts
@@ -153,4 +153,22 @@ describe('Widget Multiselect', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted().input[0][0]).toStrictEqual([{ name: 'a' }]);
   });
+
+  describe('when editing an advanced variable', () => {
+    let wrapper: any;
+    beforeEach(() => {
+      wrapper = mount(MultiSelectWidget, {
+        propsData: {
+          value: ['{{ var1 }}'],
+          variableDelimiters: { start: '{{', end: '}}' },
+        },
+      });
+    });
+    it('should select the advanced variable to edit', async () => {
+      const tag = wrapper.findAll(VariableTag).at(0);
+      tag.vm.$emit('edited', '{{ a }}');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find(MultiVariableInput).props().editedAdvancedVariable).toBe('{{ a }}');
+    });
+  });
 });

--- a/tests/unit/multiselect-widget.spec.ts
+++ b/tests/unit/multiselect-widget.spec.ts
@@ -170,5 +170,11 @@ describe('Widget Multiselect', () => {
       await wrapper.vm.$nextTick();
       expect(wrapper.find(MultiVariableInput).props().editedAdvancedVariable).toBe('{{ a }}');
     });
+    it('should reset the advanced variable to edit when modal close', async () => {
+      wrapper.setData({ editedAdvancedVariable: '{{ a }}' });
+      wrapper.find(MultiVariableInput).vm.$emit('resetEditedAdvancedVariable');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find(MultiVariableInput).props().editedAdvancedVariable).toBe('');
+    });
   });
 });

--- a/tests/unit/variable-input-base.spec.ts
+++ b/tests/unit/variable-input-base.spec.ts
@@ -169,17 +169,30 @@ describe('Variable Input', () => {
         it('should open the advanced variable modal', () => {
           expect(wrapper.find('AdvancedVariableModal-stub').props().isOpened).toBe(true);
         });
+      });
 
-        it('... and close it on closed emit', async () => {
+      describe('when closing the advanced variable modal', () => {
+        beforeEach(async () => {
           wrapper.find('AdvancedVariableModal-stub').vm.$emit('closed');
           await wrapper.vm.$nextTick();
+        });
+
+        it('should close the modal', () => {
           expect(wrapper.find('AdvancedVariableModal-stub').props().isOpened).toBe(false);
         });
 
-        it('it should emit the value with delimiters and close the modal on input', async () => {
+        it('should reset the selected advanced variable to edit', () => {
+          expect(wrapper.emitted('resetEditedAdvancedVariable')).toHaveLength(1);
+        });
+      });
+
+      describe('when saving an advanced variable', () => {
+        beforeEach(async () => {
           wrapper.find('AdvancedVariableModal-stub').vm.$emit('input', 'Test');
           await wrapper.vm.$nextTick();
-          expect(wrapper.find('AdvancedVariableModal-stub').props().isOpened).toBe(false);
+        });
+
+        it('should emit the new value with delimiters', () => {
           expect(wrapper.emitted('chooseAdvancedVariable')).toHaveLength(1);
           expect(wrapper.emitted('chooseAdvancedVariable')[0]).toEqual(['{{ Test }}']);
         });

--- a/tests/unit/variable-input-base.spec.ts
+++ b/tests/unit/variable-input-base.spec.ts
@@ -195,4 +195,12 @@ describe('Variable Input', () => {
       expect(wrapper.find('.widget-variable__toggle--parent-arrow').exists()).toBe(true);
     });
   });
+
+  describe('when selecting an advanced variable to edit', () => {
+    it('should open the advanced variable modal', async () => {
+      wrapper.setProps({ editedAdvancedVariable: '{{ a }}' });
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('AdvancedVariableModal-stub').props().isOpened).toBe(true);
+    });
+  });
 });

--- a/tests/unit/variable-input.spec.ts
+++ b/tests/unit/variable-input.spec.ts
@@ -133,4 +133,11 @@ describe('Variable Input', () => {
     expect(wrapper.emitted('input')).toHaveLength(1);
     expect(wrapper.emitted('input')[0]).toEqual(['{{ a }}']);
   });
+
+  it('should reset the advanced variable to edit when modal close', async () => {
+    wrapper.setData({ editedAdvancedVariable: '{{ a }}' });
+    wrapper.find('VariableInputBase-stub').vm.$emit('resetEditedAdvancedVariable');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('VariableInputBase-stub').props().editedAdvancedVariable).toBe('');
+  });
 });

--- a/tests/unit/variable-input.spec.ts
+++ b/tests/unit/variable-input.spec.ts
@@ -84,7 +84,7 @@ describe('Variable Input', () => {
     });
 
     it('should not display the regular input slot', () => {
-      expect(wrapper.find('VariableInputBase-stub').exists()).toBe(false);
+      expect(wrapper.find("input[type='text']").exists()).toBe(false);
     });
 
     it('should display the tag of the variable', () => {
@@ -102,6 +102,21 @@ describe('Variable Input', () => {
         expect(wrapper.emitted('input')).toHaveLength(1);
         expect(wrapper.emitted('input')[0]).toEqual([undefined]);
       });
+    });
+  });
+
+  describe('when editing an advanced variable', () => {
+    beforeEach(async () => {
+      wrapper.setProps({
+        value: '{{ a }}',
+        variableDelimiters: { start: '{{', end: '}}' },
+      });
+      await wrapper.vm.$nextTick();
+    });
+    it('should select the advanced variable to edit', async () => {
+      wrapper.find('VariableTag-stub').vm.$emit('edited', '{{ a }}');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find('VariableInputBase-stub').props().editedAdvancedVariable).toBe('{{ a }}');
     });
   });
 

--- a/tests/unit/variable-tag.spec.ts
+++ b/tests/unit/variable-tag.spec.ts
@@ -75,6 +75,12 @@ describe('Variable Tag', () => {
     expect(wrapper.emitted().removed).toBeTruthy();
   });
 
+  it('should do nothing when clicking on the name', async () => {
+    wrapper.find('.widget-variable__tag-name').trigger('mousedown');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted().edited).toBeFalsy();
+  });
+
   describe('if the variable is an advanced variable', () => {
     beforeEach(() => {
       wrapper.setProps({
@@ -90,6 +96,11 @@ describe('Variable Tag', () => {
     });
     it('should have specific style', () => {
       expect(wrapper.classes()).toContain('widget-variable__tag--advanced');
+    });
+    it('should edit advanced variable when clicking on the name', async () => {
+      wrapper.find('.widget-variable__tag-name').trigger('mousedown');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.emitted().edited).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
Update advanced variable by clicking on a tag
Disable save when value is not updated in advanced variable modal
Replace advanced variable value rather than toggle it in multiVariableInput
Reset selected advanced variable to edit when saving or closing the advanced variable modal