### PR TITLE
feat(package-version): display package version in documentation link

### DIFF
--- a/docs/_docs/contributing/new-step.md
+++ b/docs/_docs/contributing/new-step.md
@@ -356,7 +356,7 @@ Here is a possible template for your step:
 ```html
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="column1Input"
       v-model="editedStep.column1"

--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -19,6 +19,7 @@
             target="_blank"
             rel="noopener"
             class="documentation-help__content"
+            :data-version="version"
           >
             <i class="fas fa-question-circle" />
             <p>Need help?</p>
@@ -41,6 +42,7 @@ import { Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
 import { VQBModule } from '@/store';
 import { VQBState } from '@/store/state';
 
+import { version } from '../../package.json';
 import { STEPFORM_REGISTRY } from './formlib';
 
 @Component({
@@ -50,6 +52,8 @@ import { STEPFORM_REGISTRY } from './formlib';
   },
 })
 export default class QueryBuilder extends Vue {
+  version = version; // display the current version of the package
+
   @VQBModule.State currentStepFormName!: PipelineStepName;
   @VQBModule.State stepFormInitialValue!: object;
   @VQBModule.State stepFormDefaults!: object;

--- a/src/components/stepforms/AddTextColumnStepForm.vue
+++ b/src/components/stepforms/AddTextColumnStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <InputTextWidget
       class="newColumnInput"
       v-model="editedStep.new_column"

--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <MultiselectWidget
       class="groupbyColumnsInput"
       v-model="editedStep.on"

--- a/src/components/stepforms/AppendStepForm.vue
+++ b/src/components/stepforms/AppendStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <MultiselectWidget
       class="pipelinesInput"
       v-model="pipelines"

--- a/src/components/stepforms/ArgmaxStepForm.vue
+++ b/src/components/stepforms/ArgmaxStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="valueColumnInput"
       v-model="editedStep.column"

--- a/src/components/stepforms/ArgminStepForm.vue
+++ b/src/components/stepforms/ArgminStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="valueColumnInput"
       v-model="editedStep.column"

--- a/src/components/stepforms/ConcatenateStepForm.vue
+++ b/src/components/stepforms/ConcatenateStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ListWidget
       addFieldName="Add columns"
       class="toConcatenate"

--- a/src/components/stepforms/ConvertStepForm.vue
+++ b/src/components/stepforms/ConvertStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <MultiselectWidget
       class="columnsInput"
       v-model="editedStep.columns"

--- a/src/components/stepforms/CumSumStepForm.vue
+++ b/src/components/stepforms/CumSumStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="valueColumnInput"
       v-model="editedStep.valueColumn"

--- a/src/components/stepforms/CustomStepForm.vue
+++ b/src/components/stepforms/CustomStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <label v-if="name">{{ name }}</label>
     <CodeEditorWidget
       v-model="editedStep.query"

--- a/src/components/stepforms/DateExtractStepForm.vue
+++ b/src/components/stepforms/DateExtractStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="column"
       v-model="editedStep.column"

--- a/src/components/stepforms/DeleteColumnStepForm.vue
+++ b/src/components/stepforms/DeleteColumnStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <MultiselectWidget
       class="columnsInput"
       v-model="editedStep.columns"

--- a/src/components/stepforms/DomainStepForm.vue
+++ b/src/components/stepforms/DomainStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <AutocompleteWidget
       class="domainInput"
       v-model="editedStep.domain"

--- a/src/components/stepforms/DuplicateColumnStepForm.vue
+++ b/src/components/stepforms/DuplicateColumnStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="columnInput"
       v-model="editedStep.column"

--- a/src/components/stepforms/EvolutionStepForm.vue
+++ b/src/components/stepforms/EvolutionStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="dateColumnInput"
       v-model="editedStep.dateCol"

--- a/src/components/stepforms/FillnaStepForm.vue
+++ b/src/components/stepforms/FillnaStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       v-model="editedStep.column"
       class="columnInput"

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="filter-form">
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <div class="filter-form__info">Filter rows matching this condition:</div>
     <FilterEditor
       :filter-tree="this.editedStep.condition"

--- a/src/components/stepforms/FormulaStepForm.vue
+++ b/src/components/stepforms/FormulaStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <InputTextWidget
       class="newColumnInput"
       v-model="editedStep.new_column"

--- a/src/components/stepforms/FromDateStepForm.vue
+++ b/src/components/stepforms/FromDateStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="column"
       v-model="editedStep.column"

--- a/src/components/stepforms/IfThenElseStepForm.vue
+++ b/src/components/stepforms/IfThenElseStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="ifthenelse-form">
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <InputTextWidget
       class="newColumnInput"
       v-model="editedStep.newColumn"

--- a/src/components/stepforms/JoinStepForm.vue
+++ b/src/components/stepforms/JoinStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <AutocompleteWidget
       class="rightPipelineInput"
       v-model="rightPipeline"

--- a/src/components/stepforms/PercentageStepForm.vue
+++ b/src/components/stepforms/PercentageStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="valueColumnInput"
       v-model="editedStep.column"

--- a/src/components/stepforms/PivotStepForm.vue
+++ b/src/components/stepforms/PivotStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <MultiselectWidget
       class="indexInput"
       v-model="editedStep.index"

--- a/src/components/stepforms/RankStepForm.vue
+++ b/src/components/stepforms/RankStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="valueColInput"
       v-model="editedStep.valueCol"

--- a/src/components/stepforms/RenameStepForm.vue
+++ b/src/components/stepforms/RenameStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       v-model="editedStep.oldname"
       class="oldnameInput"

--- a/src/components/stepforms/ReplaceStepForm.vue
+++ b/src/components/stepforms/ReplaceStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="searchColumnInput"
       v-model="editedStep.search_column"

--- a/src/components/stepforms/RollupStepForm.vue
+++ b/src/components/stepforms/RollupStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <MultiselectWidget
       class="hierarchyColumnsInput"
       v-model="editedStep.hierarchy"

--- a/src/components/stepforms/SelectColumnStepForm.vue
+++ b/src/components/stepforms/SelectColumnStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <MultiselectWidget
       class="columnsInput"
       v-model="editedStep.columns"

--- a/src/components/stepforms/SortStepForm.vue
+++ b/src/components/stepforms/SortStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ListWidget
       addFieldName="Add Column"
       class="sortColumn"

--- a/src/components/stepforms/SplitStepForm.vue
+++ b/src/components/stepforms/SplitStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="columnToSplit"
       v-model="editedStep.column"

--- a/src/components/stepforms/StepForm.vue
+++ b/src/components/stepforms/StepForm.vue
@@ -13,6 +13,8 @@ import { InterpolateFunction, PipelineInterpolator, ScopeContext } from '@/lib/t
 import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
 
+import { version } from '../../../package.json';
+
 type VqbError = Partial<ErrorObject>;
 /**
  * ValidatorProxy emulates the interpolate + ajv-validation combo.
@@ -81,6 +83,8 @@ function componentProxyBoundOn(self: Vue) {
   },
 })
 export default class BaseStepForm<StepType> extends Vue {
+  version = version; // display the current version of the package
+
   @Prop({ type: Boolean, default: true })
   isStepCreation!: boolean;
 

--- a/src/components/stepforms/StepFormHeader.vue
+++ b/src/components/stepforms/StepFormHeader.vue
@@ -10,6 +10,7 @@
         :href="`https://weaverbird.toucantoco.com/docs/${props.stepName}`"
         target="_blank"
         rel="noopener"
+        :data-version="props.version"
       >
         <i class="fas fa-question-circle" />
       </a>

--- a/src/components/stepforms/SubstringStepForm.vue
+++ b/src/components/stepforms/SubstringStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="column"
       v-model="editedStep.column"

--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="column"
       v-model="editedStep.column"

--- a/src/components/stepforms/ToLowerStepForm.vue
+++ b/src/components/stepforms/ToLowerStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="columnInput"
       v-model="editedStep.column"

--- a/src/components/stepforms/ToUpperStepForm.vue
+++ b/src/components/stepforms/ToUpperStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="columnInput"
       v-model="editedStep.column"

--- a/src/components/stepforms/TopStepForm.vue
+++ b/src/components/stepforms/TopStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <InputTextWidget
       class="limitInput"
       v-model.number="editedStep.limit"

--- a/src/components/stepforms/UniqueGroupsStepForm.vue
+++ b/src/components/stepforms/UniqueGroupsStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <MultiselectWidget
       class="groupbyColumnsInput"
       v-model="editedStep.on"

--- a/src/components/stepforms/UnpivotStepForm.vue
+++ b/src/components/stepforms/UnpivotStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <MultiselectWidget
       class="keepColumnInput"
       v-model="editedStep.keep"

--- a/src/components/stepforms/WaterfallStepForm.vue
+++ b/src/components/stepforms/WaterfallStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <StepFormHeader :title="title" :stepName="this.editedStep.name" />
+    <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <ColumnPicker
       class="valueColumnInput"
       v-model="editedStep.valueColumn"

--- a/tests/unit/query-builder.spec.ts
+++ b/tests/unit/query-builder.spec.ts
@@ -5,6 +5,7 @@ import Vuex, { Store } from 'vuex';
 import QueryBuilder from '@/components/QueryBuilder.vue';
 import { VQBnamespace } from '@/store';
 
+import { version } from '../../package.json';
 import { buildStateWithOnePipeline, setupMockStore } from './utils';
 
 const localVue = createLocalVue();
@@ -15,6 +16,11 @@ describe('Query Builder', () => {
     const wrapper = shallowMount(QueryBuilder, { store: setupMockStore(), localVue });
     expect(wrapper.exists()).toBeTruthy();
     expect(wrapper.vm.$store.state.isEditingStep).toBeFalsy();
+  });
+
+  it('should display the current version of the package', () => {
+    const wrapper = shallowMount(QueryBuilder, { store: setupMockStore(), localVue });
+    expect(wrapper.find('.documentation-help__content').attributes('data-version')).toBe(version);
   });
 
   it('should display an empty state is no pipeline is selected', () => {


### PR DESCRIPTION
Add a data-version attributes in documentation link to get current version of the package

1. Add it in queryBuilder
2. Add it in edited steps ( can be removed if unecessary )

![version](https://user-images.githubusercontent.com/59559689/92009761-47ba2b00-ed49-11ea-8e2d-a0cb35291d99.png)
