### PR TITLE
fix(load-all-values): keep action menu open

### DIFF
--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -58,6 +58,7 @@
   <div class="data-viewer data-viewer--no-pipeline" v-else />
 </template>
 <script lang="ts">
+import _ from 'lodash';
 import Vue from 'vue';
 import { Component, Watch } from 'vue-property-decorator';
 
@@ -210,9 +211,19 @@ export default class DataViewer extends Vue {
    * It makes sense to close them when the headers change.
    */
   @Watch('columnHeaders')
-  onSelectedColumnsChange() {
-    this.closeMenu();
-    this.closeDataTypeMenu();
+  onSelectedColumnsChange(before: any, after: any) {
+    // we compare old header to new header
+    const columnsDifferences: DataSetColumn[] = _.differenceWith(before, after, _.isEqual);
+    // if the difference is only on one column with same name that active one ...
+    const isModifyingTheSameColumn =
+      columnsDifferences.length === 1 &&
+      columnsDifferences[0].name === this.activeActionMenuColumnName;
+    // ... we won't close the menu because we are just editing a col (ex: loadAllValues )
+    if (!isModifyingTheSameColumn) {
+      // but we close it if changing the headers
+      this.closeMenu();
+      this.closeDataTypeMenu();
+    }
   }
 }
 </script>


### PR DESCRIPTION
Due to previous fix, we closed the action menu in any cases including when loading all values we should verify if the headers as change or if the current selected column is being modified ( don't close the action menu in this case ).

Before:
![before](https://user-images.githubusercontent.com/59559689/92483008-94d64b00-f1e8-11ea-9196-f70b38000b6d.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/92483017-9869d200-f1e8-11ea-9341-43404eeac0ce.gif)
