### PR TITLE
fix: remove autocast in templating

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -10,6 +10,7 @@ const {
   servicePluginFactory,
   registerModule,
   setAvailableCodeEditors,
+  exampleInterpolateFunc,
 } = vqb;
 
 const TRANSLATOR = 'mongo40';
@@ -296,19 +297,8 @@ async function buildVueApp() {
         },
         currentDomain: 'sales',
         translator: TRANSLATOR,
-        // use lodash interpolate
-        interpolateFunc: (value, context) => {
-          if (typeof(value) === 'string' && value.match(new RegExp('^' + _.templateSettings.interpolate.source + '$'))) {
-            let result;
-            with (context) {
-              // Unsafe! but fine for this simple playground
-              result = eval(value.match(new RegExp('^' + _.templateSettings.interpolate.source + '$'))[0]);
-            }
-            return result;
-          } else {
-            return _.template(value)(context);
-          }
-        },
+        // based on lodash templates (ERB syntax)
+        interpolateFunc: (value, context) => exampleInterpolateFunc(value, context),
         variables: {
           value1: 2,
           value2: 13,

--- a/playground/app.js
+++ b/playground/app.js
@@ -297,7 +297,18 @@ async function buildVueApp() {
         currentDomain: 'sales',
         translator: TRANSLATOR,
         // use lodash interpolate
-        interpolateFunc: (value, context) => _.template(value)(context),
+        interpolateFunc: (value, context) => {
+          if (typeof(value) === 'string' && value.match(new RegExp('^' + _.templateSettings.interpolate.source + '$'))) {
+            let result;
+            with (context) {
+              // Unsafe! but fine for this simple playground
+              result = eval(value.match(new RegExp('^' + _.templateSettings.interpolate.source + '$'))[0]);
+            }
+            return result;
+          } else {
+            return _.template(value)(context);
+          }
+        },
         variables: {
           value1: 2,
           value2: 13,

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -398,3 +398,31 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
     return callback.bind(this)(step);
   }
 }
+
+const aloneVarsRegExp = new RegExp('^' + (_.templateSettings.interpolate as RegExp).source + '$');
+
+/**
+ * A simple interpolate function, provided as an example.
+ *
+ * It's based on lodash templates (which looks like embedded Ruby, but executes JavaScript),
+ * with an important twist: if a variable is provided "alone", i.e. with no surrounding
+ * characters, then it returns the variable value untouched and not coerced to a string.
+ *
+ * Examples:
+ * - `exampleInterpolateFunc('<%= count %>', { count: 42 })` returns `42`
+ * - `exampleInterpolateFunc('<%= 2 > 1 %>', {})` returns `true`
+ * - `exampleInterpolateFunc('There is <%= count %> bananas', { count: 42 })` returns `'There is 42 bananas'`
+ */
+export const exampleInterpolateFunc: InterpolateFunction = function(
+  value: string,
+  context: ScopeContext,
+) {
+  if (typeof value === 'string' && value.match(aloneVarsRegExp)) {
+    return Function(
+      'context',
+      `with(context) { return ${(value.match(aloneVarsRegExp) as string[])[1]} }`,
+    )(context);
+  } else {
+    return _.template(value)(context);
+  }
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,3 +36,6 @@ export {
   // Utility components
   FilterEditor,
 };
+
+// export helpers/utils
+export { exampleInterpolateFunc } from '@/lib/templating';

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -1,8 +1,6 @@
 /**
  * define what the application state looks like.
  */
-import _fromPairs from 'lodash/fromPairs';
-
 import { BackendError, BackendWarning } from '@/lib/backend-response';
 import { DataSet } from '@/lib/dataset';
 import { Pipeline, PipelineStepName } from '@/lib/steps';
@@ -199,8 +197,7 @@ export function preparePipeline(pipeline: Pipeline, state: VQBState) {
     pipeline = dereferencePipelines(pipeline, pipelines);
   }
   if (interpolateFunc && variables && Object.keys(variables).length) {
-    const columnTypes = _fromPairs(state.dataset.headers.map(col => [col.name, col.type]));
-    const interpolator = new PipelineInterpolator(interpolateFunc, variables, columnTypes);
+    const interpolator = new PipelineInterpolator(interpolateFunc, variables);
     pipeline = interpolator.interpolate(pipeline);
   }
   return pipeline;

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 
-import { ColumnTypeMapping } from '@/lib/dataset';
 import { Pipeline } from '@/lib/steps';
 import { PipelineInterpolator, ScopeContext } from '@/lib/templating';
 
@@ -16,12 +15,8 @@ describe('Pipeline interpolator', () => {
     age: 42,
   };
 
-  function translate(
-    pipeline: Pipeline,
-    context = defaultContext,
-    columnTypes?: ColumnTypeMapping,
-  ) {
-    const pipelineInterpolator = new PipelineInterpolator(interpolate, context, columnTypes);
+  function translate(pipeline: Pipeline, context = defaultContext) {
+    const pipelineInterpolator = new PipelineInterpolator(interpolate, context);
     return pipelineInterpolator.interpolate(pipeline);
   }
 
@@ -286,11 +281,7 @@ describe('Pipeline interpolator', () => {
         value: '<%= age %>',
       },
     ];
-    expect(
-      translate(pipeline, defaultContext, {
-        column1: 'integer',
-      }),
-    ).toEqual([
+    expect(translate(pipeline, defaultContext)).toEqual([
       {
         name: 'fillna',
         column: 'column1',
@@ -350,7 +341,7 @@ describe('Pipeline interpolator', () => {
         },
       },
     ];
-    expect(translate(step, defaultContext, { foo: 'integer' })).toEqual([
+    expect(translate(step, defaultContext)).toEqual([
       {
         name: 'filter',
         condition: {
@@ -645,13 +636,7 @@ describe('Pipeline interpolator', () => {
         },
       },
     ];
-    expect(
-      translate(
-        step,
-        { ...defaultContext, truth: 'true' },
-        { column1: 'integer', column2: 'boolean' },
-      ),
-    ).toEqual([
+    expect(translate(step, { ...defaultContext, truth: 'true' })).toEqual([
       {
         name: 'filter',
         condition: {
@@ -753,13 +738,7 @@ describe('Pipeline interpolator', () => {
         },
       },
     ];
-    expect(
-      translate(
-        step,
-        { ...defaultContext, truth: 'true' },
-        { column1: 'integer', column2: 'boolean' },
-      ),
-    ).toEqual([
+    expect(translate(step, { ...defaultContext, truth: 'true' })).toEqual([
       {
         name: 'filter',
         condition: {
@@ -922,7 +901,7 @@ describe('Pipeline interpolator', () => {
         ],
       },
     ];
-    expect(translate(pipeline, defaultContext, { column1: 'integer' })).toEqual([
+    expect(translate(pipeline, defaultContext)).toEqual([
       {
         name: 'replace',
         search_column: 'column1',

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -1,12 +1,5 @@
-import _ from 'lodash';
-
 import { Pipeline } from '@/lib/steps';
-import { PipelineInterpolator, ScopeContext } from '@/lib/templating';
-
-function interpolate(value: string, context: ScopeContext) {
-  const compiled = _.template(value);
-  return compiled(context);
-}
+import { exampleInterpolateFunc, PipelineInterpolator, ScopeContext } from '@/lib/templating';
 
 describe('Pipeline interpolator', () => {
   const defaultContext: ScopeContext = {
@@ -16,7 +9,7 @@ describe('Pipeline interpolator', () => {
   };
 
   function translate(pipeline: Pipeline, context = defaultContext) {
-    const pipelineInterpolator = new PipelineInterpolator(interpolate, context);
+    const pipelineInterpolator = new PipelineInterpolator(exampleInterpolateFunc, context);
     return pipelineInterpolator.interpolate(pipeline);
   }
 
@@ -268,7 +261,7 @@ describe('Pipeline interpolator', () => {
       {
         name: 'fillna',
         column: '<%= foo %>',
-        value: '42',
+        value: 42,
       },
     ]);
   });
@@ -323,7 +316,7 @@ describe('Pipeline interpolator', () => {
         name: 'filter',
         condition: {
           column: 'bar',
-          value: '42',
+          value: 42,
           operator: 'eq',
         },
       },
@@ -369,7 +362,7 @@ describe('Pipeline interpolator', () => {
         name: 'filter',
         condition: {
           column: 'bar',
-          value: '42',
+          value: 42,
           operator: 'ne',
         },
       },
@@ -392,7 +385,7 @@ describe('Pipeline interpolator', () => {
         name: 'filter',
         condition: {
           column: 'bar',
-          value: '42',
+          value: 42,
           operator: 'lt',
         },
       },
@@ -415,7 +408,7 @@ describe('Pipeline interpolator', () => {
         name: 'filter',
         condition: {
           column: 'bar',
-          value: '42',
+          value: 42,
           operator: 'le',
         },
       },
@@ -438,7 +431,7 @@ describe('Pipeline interpolator', () => {
         name: 'filter',
         condition: {
           column: 'bar',
-          value: '42',
+          value: 42,
           operator: 'gt',
         },
       },
@@ -461,7 +454,7 @@ describe('Pipeline interpolator', () => {
         name: 'filter',
         condition: {
           column: 'bar',
-          value: '42',
+          value: 42,
           operator: 'ge',
         },
       },
@@ -484,7 +477,7 @@ describe('Pipeline interpolator', () => {
         name: 'filter',
         condition: {
           column: 'bar',
-          value: [11, '42', 'spam', 'hola'],
+          value: [11, 42, 'spam', 'hola'],
           operator: 'in',
         },
       },
@@ -507,7 +500,7 @@ describe('Pipeline interpolator', () => {
         name: 'filter',
         condition: {
           column: 'bar',
-          value: [11, '42', 'spam', 'hola'],
+          value: [11, 42, 'spam', 'hola'],
           operator: 'nin',
         },
       },
@@ -592,7 +585,7 @@ describe('Pipeline interpolator', () => {
           and: [
             {
               column: 'bar',
-              value: [11, '42', 'spam', 'hola'],
+              value: [11, 42, 'spam', 'hola'],
               operator: 'nin',
             },
             {
@@ -636,14 +629,14 @@ describe('Pipeline interpolator', () => {
         },
       },
     ];
-    expect(translate(step, { ...defaultContext, truth: 'true' })).toEqual([
+    expect(translate(step, { ...defaultContext, truth: true })).toEqual([
       {
         name: 'filter',
         condition: {
           and: [
             {
               column: 'bar',
-              value: [11, '42', 'spam', 'hola'],
+              value: [11, 42, 'spam', 'hola'],
               operator: 'nin',
             },
             {
@@ -694,7 +687,7 @@ describe('Pipeline interpolator', () => {
           or: [
             {
               column: 'bar',
-              value: [11, '42', 'spam', 'hola'],
+              value: [11, 42, 'spam', 'hola'],
               operator: 'nin',
             },
             {
@@ -738,14 +731,14 @@ describe('Pipeline interpolator', () => {
         },
       },
     ];
-    expect(translate(step, { ...defaultContext, truth: 'true' })).toEqual([
+    expect(translate(step, { ...defaultContext, truth: true })).toEqual([
       {
         name: 'filter',
         condition: {
           or: [
             {
               column: 'bar',
-              value: [11, '42', 'spam', 'hola'],
+              value: [11, 42, 'spam', 'hola'],
               operator: 'nin',
             },
             {
@@ -873,7 +866,7 @@ describe('Pipeline interpolator', () => {
         name: 'replace',
         search_column: '<%= age %>',
         to_replace: [
-          ['<%= age %>', '12'],
+          ['<%= age %>', 12],
           ['what?', '<%= age %>'],
         ],
       },
@@ -883,8 +876,8 @@ describe('Pipeline interpolator', () => {
         name: 'replace',
         search_column: '<%= age %>',
         to_replace: [
-          ['42', '12'],
-          ['what?', '42'],
+          [42, 12],
+          ['what?', 42],
         ],
       },
     ]);
@@ -896,8 +889,8 @@ describe('Pipeline interpolator', () => {
         name: 'replace',
         search_column: 'column1',
         to_replace: [
-          ['<%= age %>', '12'],
-          ['13', '<%= age %>'],
+          ['<%= age %>', 12],
+          [13, '<%= age %>'],
         ],
       },
     ];
@@ -1170,9 +1163,9 @@ describe('Pipeline interpolator', () => {
       {
         name: 'ifthenelse',
         newColumn: '<%= foo %>',
-        if: { and: [{ column: 'bar', operator: 'eq', value: '42' }] },
+        if: { and: [{ column: 'bar', operator: 'eq', value: 42 }] },
         then: 'bar',
-        else: '42',
+        else: 42,
       },
     ]);
   });
@@ -1195,12 +1188,12 @@ describe('Pipeline interpolator', () => {
       {
         name: 'ifthenelse',
         newColumn: '<%= foo %>',
-        if: { and: [{ column: 'bar', operator: 'eq', value: '42' }] },
+        if: { and: [{ column: 'bar', operator: 'eq', value: 42 }] },
         then: 'bar',
         else: {
-          if: { and: [{ column: 'bar', operator: 'eq', value: '42' }] },
+          if: { and: [{ column: 'bar', operator: 'eq', value: 42 }] },
           then: 'bar',
-          else: '42',
+          else: 42,
         },
       },
     ]);


### PR DESCRIPTION
This was a not-so-good idea:
- same mechanism wasn't implement in hosts apps => created incoherences
between queries in the weaverbird preview, and what was actually
converted after in the host app
- column types can change during the pipeline => depending on the step
you come from, the interpolated pipeline is not always the same

Solution for this problem is to implement carefully the interpolator
function so that types are kept if a variable is declared alone in its
string. Such implem has landed in Tucana (main weaverbird host app for
now), so the auto-casting is not relevant anymore.