### PR TITLE
fillna: change retrocompatibility implementation

### DIFF
--- a/docs/_docs/tech/steps.md
+++ b/docs/_docs/tech/steps.md
@@ -977,21 +977,30 @@ Replace null values by a given value in specified columns.
 ```javascript
 {
     name: 'fillna',
-    column: ["foo"],
-    value: "bar"
+    columns: ["foo", "bar"],
+    value: 0
 }
 ```
-
-**Deprecation note:**
-
-The `column` parameter can be a simple string as when the step was first created,
-only one column could be specified. Simple strings are supported only for
-retrocompatibility purposes.
 
 **This step is supported by the following backends:**
 
 - Mongo 4.0
 - Mongo 3.6
+
+**Deprecation note:**
+
+The `column` (in the singular) parameter is deprecated and is supported only for
+retrocompatibility purposes.
+
+An old-fashioned step looks like this:
+
+```javascript
+{
+    name: 'fillna',
+    column: 'foo',
+    value: 0
+}
+```
 
 #### Example
 
@@ -1011,7 +1020,7 @@ retrocompatibility purposes.
 ```javascript
 {
   name: 'fillna',
-  column: ["Value", "KPI"],
+  columns: ["Value", "KPI"],
   value: 0
 }
 ```
@@ -1761,6 +1770,11 @@ The `toRename` parameter takes as input a list of 2-elements lists in the form
 }
 ```
 
+**This step is supported by the following backends:**
+
+- Mongo 4.0
+- Mongo 3.6
+
 **Deprecation note:**
 
 The `oldname` and `newnname` parameters are deprecated and are supported only for
@@ -1776,15 +1790,10 @@ So an old-fashioned step looks like this:
 ```javascript
 {
     name: 'rename',
-    oldname: 'old-column-name', // optional and deprecated
-    newname: 'new-column-name'  // optional and deprecated
+    oldname: 'old-column-name',
+    newname: 'new-column-name'
 }
 ```
-
-**This step is supported by the following backends:**
-
-- Mongo 4.0
-- Mongo 3.6
 
 #### Example:
 

--- a/src/components/stepforms/FillnaStepForm.vue
+++ b/src/components/stepforms/FillnaStepForm.vue
@@ -3,11 +3,11 @@
     <StepFormHeader :title="title" :stepName="editedStep.name" :version="version" />
     <MultiselectWidget
       class="columnInput"
-      v-model="editedStep.column"
+      v-model="editedStep.columns"
       name="Replace null values in..."
       :options="columnNames"
       placeholder="Select columns"
-      data-path=".column"
+      data-path=".columns"
       :errors="errors"
     />
     <InputTextWidget
@@ -57,10 +57,10 @@ export default class FillnaStepForm extends BaseStepForm<FillnaStep> {
   editedStep = {
     ...this.initialStepValue,
     ...this.stepFormDefaults,
-    column:
-      typeof this.initialStepValue.column === 'string'
-        ? [this.initialStepValue.column]
-        : this.initialStepValue.column,
+    columns: this.initialStepValue.column
+      ? [this.initialStepValue.column]
+      : this.initialStepValue.columns,
+    column: undefined,
   };
 
   get stepSelectedColumn() {
@@ -71,21 +71,11 @@ export default class FillnaStepForm extends BaseStepForm<FillnaStep> {
     if (colname === null) {
       throw new Error('should not try to set null on fillna "column" field');
     }
-    // if (
-    //   (typeof this.editedStep.column === 'string' && this.editedStep.column === '') ||
-    //   this.editedStep.column[0] === ''
-    // ) {
-    //   this.editedStep.column = [colname];
-    // }
-    this.editedStep.column = [colname];
+    this.editedStep.columns = [colname];
   }
 
   submit() {
-    // if (typeof this.editedStep.column === 'string') {
-    //   // For retrocompatibility purposes
-    //   this.editedStep.column = [this.editedStep.column];
-    // }
-    const type = this.columnTypes[this.editedStep.column[0]];
+    const type = this.columnTypes[this.editedStep.columns[0]];
     if (type !== undefined) {
       this.editedStep.value = castFromString(this.editedStep.value as string, type);
     }

--- a/src/components/stepforms/schemas/fillna.ts
+++ b/src/components/stepforms/schemas/fillna.ts
@@ -8,25 +8,22 @@ export default {
       enum: ['fillna'],
     },
     column: {
-      anyOf: [
-        {
-          type: 'string',
-          minLength: 1,
-          title: 'Column in which to fill null values',
-          description: 'Column in which to fill null values',
-          attrs: { placeholder: 'Enter a column' },
-        },
-        {
-          type: 'array',
-          items: {
-            type: 'string',
-            minLength: 1,
-          },
-          title: 'Columns in which to fill null values',
-          description: 'Columns in which to fill null values',
-          attrs: { placeholder: 'Select a column' },
-        },
-      ],
+      // Supported for retrocompatibility only
+      type: 'string',
+      minLength: 1,
+      title: 'Column in which to fill null values',
+      description: 'Column in which to fill null values',
+      attrs: { placeholder: 'Enter a column' },
+    },
+    columns: {
+      type: 'array',
+      items: {
+        type: 'string',
+        minLength: 1,
+      },
+      title: 'Columns in which to fill null values',
+      description: 'Columns in which to fill null values',
+      attrs: { placeholder: 'Select a column' },
     },
     value: {
       type: ['string', 'number', 'boolean'],
@@ -38,6 +35,6 @@ export default {
       },
     },
   },
-  required: ['name', 'column', 'value'],
+  required: ['name', 'columns', 'value'],
   additionalProperties: false,
 };

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -159,7 +159,10 @@ class StepLabeller implements StepMatcher<string> {
   }
 
   fillna(step: Readonly<S.FillnaStep>) {
-    return `Replace null values in "${step.column}" with ${step.value}`;
+    if (step.column) {
+      return `Replace null values in "${step.column}" with ${step.value}`;
+    }
+    return `Replace null values in ${formatMulticol(step.columns)} with ${step.value}`;
   }
 
   filter(step: Readonly<S.FilterStep>) {

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -140,7 +140,8 @@ export type EvolutionStep = {
 
 export type FillnaStep = {
   name: 'fillna';
-  column: string | string[];
+  column?: string; // supported for retrocompatibility only
+  columns: string[];
   value: PrimitiveType;
 };
 

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -547,11 +547,11 @@ function transformEvolution(step: Readonly<S.EvolutionStep>): MongoStep {
 /** transform a 'fillna' step into corresponding mongo steps */
 function transformFillna(step: Readonly<S.FillnaStep>): MongoStep {
   let cols: string[] = [];
-  if (typeof step.column === 'string') {
+  if (step.column) {
     // For retrocompatibility with old configurations
     cols = [step.column];
   } else {
-    cols = [...step.column];
+    cols = [...step.columns];
   }
 
   const addFields = Object.fromEntries(cols.map(x => [x, { $ifNull: [$$(x), step.value] }]));

--- a/tests/unit/fillna-step-form.spec.ts
+++ b/tests/unit/fillna-step-form.spec.ts
@@ -20,7 +20,7 @@ describe('Fillna Step Form', () => {
         },
       }),
       data: {
-        editedStep: { name: 'fillna', column: 'columnA', value: { foo: 'bar' } },
+        editedStep: { name: 'fillna', columns: ['columnA'], value: { foo: 'bar' } },
       },
       errors: [{ dataPath: '.value', keyword: 'type' }],
     },
@@ -34,7 +34,7 @@ describe('Fillna Step Form', () => {
       },
     }),
     props: {
-      initialStepValue: { name: 'fillna', column: ['foo', 'toto'], value: 'bar' },
+      initialStepValue: { name: 'fillna', columns: ['foo', 'toto'], value: 'bar' },
     },
   });
 
@@ -53,12 +53,12 @@ describe('Fillna Step Form', () => {
       propsData: {
         initialStepValue: {
           name: 'fillna',
-          column: [''],
+          columns: [''],
         },
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.vm.$data.editedStep.column).toEqual(['toto']);
+    expect(wrapper.vm.$data.editedStep.columns).toEqual(['toto']);
   });
 
   it('should return an error if trying to set a null column', async () => {
@@ -74,7 +74,7 @@ describe('Fillna Step Form', () => {
         propsData: {
           initialStepValue: {
             name: 'fillna',
-            column: [''],
+            columns: [''],
           },
         },
       });
@@ -92,17 +92,27 @@ describe('Fillna Step Form', () => {
           initialStepValue: {
             name: 'fillna',
             column: 'hello',
+            value: 0,
           },
         },
       },
     );
     await wrapper.vm.$nextTick();
-    expect(wrapper.vm.$data.editedStep.column).toEqual(['hello']);
+    expect(wrapper.vm.$data.editedStep.column).toBeUndefined;
+    expect(wrapper.vm.$data.editedStep.columns).toBeDefined;
+    expect(wrapper.vm.$data.editedStep.columns).toEqual(['hello']);
+  });
+
+  it('should pass down the value prop to widget multiselect', async () => {
+    const wrapper = runner.shallowMount();
+    wrapper.setData({ editedStep: { columns: ['foo'], value: '' } });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('multiselectwidget-stub').props('value')).toEqual(['foo']);
   });
 
   it('should pass down the value prop to widget value prop', async () => {
     const wrapper = runner.shallowMount();
-    wrapper.setData({ editedStep: { column: '', value: 'foo' } });
+    wrapper.setData({ editedStep: { columns: [''], value: 'foo' } });
     await wrapper.vm.$nextTick();
     expect(wrapper.find('inputtextwidget-stub').props('value')).toEqual('foo');
   });
@@ -117,14 +127,14 @@ describe('Fillna Step Form', () => {
       },
       {
         data: {
-          editedStep: { name: 'fillna', column: ['columnA'], value: '42' },
+          editedStep: { name: 'fillna', columns: ['columnA'], value: '42' },
         },
       },
     );
     wrapper.find('.widget-form-action__button--validate').trigger('click');
     expect(wrapper.vm.$data.errors).toBeNull();
     expect(wrapper.emitted()).toEqual({
-      formSaved: [[{ name: 'fillna', column: ['columnA'], value: 42 }]],
+      formSaved: [[{ name: 'fillna', columns: ['columnA'], value: 42 }]],
     });
   });
 
@@ -138,14 +148,14 @@ describe('Fillna Step Form', () => {
       },
       {
         data: {
-          editedStep: { name: 'fillna', column: ['columnA'], value: '42.3' },
+          editedStep: { name: 'fillna', columns: ['columnA'], value: '42.3' },
         },
       },
     );
     wrapper.find('.widget-form-action__button--validate').trigger('click');
     expect(wrapper.vm.$data.errors).toBeNull();
     expect(wrapper.emitted()).toEqual({
-      formSaved: [[{ name: 'fillna', column: ['columnA'], value: 42.3 }]],
+      formSaved: [[{ name: 'fillna', columns: ['columnA'], value: 42.3 }]],
     });
   });
 
@@ -159,18 +169,18 @@ describe('Fillna Step Form', () => {
       },
       {
         data: {
-          editedStep: { name: 'fillna', column: ['columnA'], value: 'true' },
+          editedStep: { name: 'fillna', columns: ['columnA'], value: 'true' },
         },
       },
     );
     wrapper.find('.widget-form-action__button--validate').trigger('click');
-    wrapper.setData({ editedStep: { name: 'fillna', column: ['columnA'], value: 'false' } });
+    wrapper.setData({ editedStep: { name: 'fillna', columns: ['columnA'], value: 'false' } });
     wrapper.find('.widget-form-action__button--validate').trigger('click');
     expect(wrapper.vm.$data.errors).toBeNull();
     expect(wrapper.emitted()).toEqual({
       formSaved: [
-        [{ name: 'fillna', column: ['columnA'], value: true }],
-        [{ name: 'fillna', column: ['columnA'], value: false }],
+        [{ name: 'fillna', columns: ['columnA'], value: true }],
+        [{ name: 'fillna', columns: ['columnA'], value: false }],
       ],
     });
   });
@@ -187,13 +197,13 @@ describe('Fillna Step Form', () => {
         },
       },
       {
-        data: { editedStep: { name: 'fillna', column: ['foo'], value: '<%= foo %>' } },
+        data: { editedStep: { name: 'fillna', columns: ['foo'], value: '<%= foo %>' } },
       },
     );
     wrapper.find('.widget-form-action__button--validate').trigger('click');
     expect(wrapper.vm.$data.errors).toBeNull();
     expect(wrapper.emitted()).toEqual({
-      formSaved: [[{ name: 'fillna', column: ['foo'], value: '<%= foo %>' }]],
+      formSaved: [[{ name: 'fillna', columns: ['foo'], value: '<%= foo %>' }]],
     });
   });
 });

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -130,8 +130,19 @@ describe('Labeller', () => {
   it('generates label for fillna steps', () => {
     const step: S.FillnaStep = {
       name: 'fillna',
+      columns: ['column1', 'column2'],
+      value: '20',
+    };
+    expect(hrl(step)).toEqual('Replace null values in "column1", "column2" with 20');
+  });
+
+  it('generates label for fillna steps old-fashioned', () => {
+    // Test for retrocompatibility
+    const step: S.FillnaStep = {
+      name: 'fillna',
       column: 'column1',
       value: '20',
+      columns: [],
     };
     expect(hrl(step)).toEqual('Replace null values in "column1" with 20');
   });

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -1207,6 +1207,7 @@ describe('Pipeline to mongo translator', () => {
         name: 'fillna',
         column: 'foo',
         value: 'bar',
+        columns: [],
       },
     ];
     const querySteps = mongo36translator.translate(pipeline);
@@ -1220,7 +1221,7 @@ describe('Pipeline to mongo translator', () => {
     const pipeline: Pipeline = [
       {
         name: 'fillna',
-        column: ['foo', 'toto', 'tata'],
+        columns: ['foo', 'toto', 'tata'],
         value: 'bar',
       },
     ];

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -253,14 +253,14 @@ describe('Pipeline interpolator', () => {
     const pipeline: Pipeline = [
       {
         name: 'fillna',
-        column: '<%= foo %>',
+        columns: ['<%= foo %>'],
         value: '<%= age %>',
       },
     ];
     expect(translate(pipeline)).toEqual([
       {
         name: 'fillna',
-        column: '<%= foo %>',
+        columns: ['<%= foo %>'],
         value: 42,
       },
     ]);
@@ -270,14 +270,14 @@ describe('Pipeline interpolator', () => {
     const pipeline: Pipeline = [
       {
         name: 'fillna',
-        column: 'column1',
+        columns: ['column1'],
         value: '<%= age %>',
       },
     ];
     expect(translate(pipeline, defaultContext)).toEqual([
       {
         name: 'fillna',
-        column: 'column1',
+        columns: ['column1'],
         value: 42,
       },
     ]);
@@ -287,14 +287,14 @@ describe('Pipeline interpolator', () => {
     const pipeline: Pipeline = [
       {
         name: 'fillna',
-        column: 'foo',
+        columns: ['foo'],
         value: 'hola',
       },
     ];
     expect(translate(pipeline)).toEqual([
       {
         name: 'fillna',
-        column: 'foo',
+        columns: ['foo'],
         value: 'hola',
       },
     ]);


### PR DESCRIPTION
Before this PR, we updated the `column` parameter to support array of strings as well as a simple string (to fill null values in several columns at once).
But at this end, we target to keep only a `columns` (in the plural) parameter which can only be a list of strings creates a mandatory `columns` parameter for the new, preferred configuration, while still supporting retrocompatibility with the deprecated `column` parameter. 