### PR TITLE
feat(variable-chooser): display a tooltip with value when hovering a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED
+
+### Changed
+- Display a tooltip with value when hovering a variable in variables dropdown
+
 ## [0.26.0] - 2020-09-23
 
 ### Changed

--- a/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
@@ -101,8 +101,8 @@ export default class VariableChooser extends Vue {
   /**
   Return a readable value to display as tooltip
   **/
-  readableValue(value: any) {
-    return typeof value === 'string' ? value : JSON.stringify(value);
+  readableValue(value: any): string {
+    return JSON.stringify(value);
   }
 
   /**

--- a/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
@@ -23,7 +23,7 @@
           v-tooltip="{
             targetClasses: 'has-weaverbird__tooltip',
             classes: 'weaverbird__tooltip',
-            content: readableValue(availableVariable.value),
+            content: makeValueReadable(availableVariable.value),
             placement: 'bottom-center',
           }"
           @click="chooseVariable(availableVariable.identifier)"
@@ -101,7 +101,7 @@ export default class VariableChooser extends Vue {
   /**
   Return a readable value to display as tooltip
   **/
-  readableValue(value: any): string {
+  makeValueReadable(value: any): string {
     return JSON.stringify(value);
   }
 

--- a/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
@@ -20,6 +20,12 @@
           :class="{ 'widget-variable-chooser__option--selected': availableVariable.selected }"
           v-for="availableVariable in category.variables"
           :key="availableVariable.identifier"
+          v-tooltip="{
+            targetClasses: 'has-weaverbird__tooltip',
+            classes: 'weaverbird__tooltip',
+            content: readableValue(availableVariable.value),
+            placement: 'bottom-center',
+          }"
           @click="chooseVariable(availableVariable.identifier)"
         >
           <div class="widget-variable-chooser__option-container">
@@ -37,12 +43,14 @@
 </template>
 
 <script lang="ts">
+import VTooltip from 'v-tooltip';
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import { POPOVER_ALIGN } from '@/components/constants';
 import Popover from '@/components/Popover.vue';
 import { VariablesBucket, VariablesCategory } from '@/lib/variables';
 
+Vue.use(VTooltip);
 /**
  * This component list all the available variables to use as value in VariableInputs
  */
@@ -88,6 +96,13 @@ export default class VariableChooser extends Vue {
       }
       return categories;
     }, []);
+  }
+
+  /**
+  Return a readable value to display as tooltip
+  **/
+  readableValue(value: any) {
+    return typeof value === 'string' ? value : JSON.stringify(value);
   }
 
   /**
@@ -160,6 +175,7 @@ export default class VariableChooser extends Vue {
   }
   display: flex;
   justify-content: space-between;
+  align-items: center;
   cursor: pointer;
 }
 

--- a/tests/unit/variable-chooser.spec.ts
+++ b/tests/unit/variable-chooser.spec.ts
@@ -1,4 +1,5 @@
 import { shallowMount, Wrapper } from '@vue/test-utils';
+import { VTooltip } from 'v-tooltip';
 
 import VariableChooser from '@/components/stepforms/widgets/VariableInputs/VariableChooser.vue';
 
@@ -8,6 +9,9 @@ describe('Variable Chooser', () => {
   beforeEach(() => {
     wrapper = shallowMount(VariableChooser, {
       sync: false,
+      directives: {
+        tooltip: VTooltip,
+      },
       propsData: {
         isOpened: false,
         availableVariables: [
@@ -88,11 +92,11 @@ describe('Variable Chooser', () => {
     });
 
     it('should display readable value in tooltip', () => {
-      expect((wrapper.vm as any).readableValue([])).toStrictEqual('[]');
-      expect((wrapper.vm as any).readableValue([1, 2])).toStrictEqual('[1,2]');
-      expect((wrapper.vm as any).readableValue(1)).toStrictEqual('1');
-      expect((wrapper.vm as any).readableValue('1')).toStrictEqual('"1"');
-      expect((wrapper.vm as any).readableValue(undefined)).toStrictEqual(undefined);
+      expect((wrapper.vm as any).makeValueReadable([])).toStrictEqual('[]');
+      expect((wrapper.vm as any).makeValueReadable([1, 2])).toStrictEqual('[1,2]');
+      expect((wrapper.vm as any).makeValueReadable(1)).toStrictEqual('1');
+      expect((wrapper.vm as any).makeValueReadable('1')).toStrictEqual('"1"');
+      expect((wrapper.vm as any).makeValueReadable(undefined)).toStrictEqual(undefined);
     });
   });
 

--- a/tests/unit/variable-chooser.spec.ts
+++ b/tests/unit/variable-chooser.spec.ts
@@ -90,6 +90,9 @@ describe('Variable Chooser', () => {
     it('should display readable value in tooltip', () => {
       expect((wrapper.vm as any).readableValue([])).toStrictEqual('[]');
       expect((wrapper.vm as any).readableValue([1, 2])).toStrictEqual('[1,2]');
+      expect((wrapper.vm as any).readableValue(1)).toStrictEqual('1');
+      expect((wrapper.vm as any).readableValue('1')).toStrictEqual('"1"');
+      expect((wrapper.vm as any).readableValue(undefined)).toStrictEqual(undefined);
     });
   });
 

--- a/tests/unit/variable-chooser.spec.ts
+++ b/tests/unit/variable-chooser.spec.ts
@@ -80,6 +80,19 @@ describe('Variable Chooser', () => {
     });
   });
 
+  describe('tooltip', () => {
+    it('should display a value tooltip for each variable', () => {
+      wrapper.findAll('.widget-variable-chooser__option').wrappers.forEach(w => {
+        expect(w.classes()).toContain('has-weaverbird__tooltip');
+      });
+    });
+
+    it('should display readable value in tooltip', () => {
+      expect((wrapper.vm as any).readableValue([])).toStrictEqual('[]');
+      expect((wrapper.vm as any).readableValue([1, 2])).toStrictEqual('[1,2]');
+    });
+  });
+
   describe('when is advanced', () => {
     it('should display an "Advanced variable" option ...', () => {
       expect(wrapper.find('.widget-advanced-variable').exists()).toBe(true);


### PR DESCRIPTION
Display a tooltip when hovering an option in variable chooser:

![hover](https://user-images.githubusercontent.com/59559689/94545153-780fbf00-024c-11eb-90be-aa8f9b6057f0.gif)
