### PR TITLE
Fix formulas with variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,6 @@
   "dependencies": {
     "ajv": "^6.10.0",
     "lodash": "^4.17.11",
-    "mathjs": "^5.9.0"
+    "mathjs": "^7.3.0"
   }
 }

--- a/playground/app.js
+++ b/playground/app.js
@@ -186,31 +186,31 @@ async function buildVueApp() {
     {
       category: 'App variables',
       label: 'view',
-      identifier: 'appRequesters.view',
+      identifier: 'view',
       value: 'Product 123',
     },
     {
       category: 'App variables',
       label: 'date.month',
-      identifier: 'appRequesters.date.month',
+      identifier: 'date.month',
       value: 'Apr',
     },
     {
       category: 'App variables',
       label: 'date.year',
-      identifier: 'appRequesters.date.year',
+      identifier: 'date.year',
       value: 2020,
     },
     {
       category: 'Story variables',
       label: 'country',
-      identifier: 'requestersManager.country',
+      identifier: 'country',
       value: 'New Zealand',
     },
     {
       category: 'Story variables',
       label: 'city',
-      identifier: 'appRequesters.city',
+      identifier: 'city',
       value: 'New York',
     },
   ];
@@ -319,7 +319,7 @@ async function buildVueApp() {
         availableVariables: AVAILABLE_VARIABLES,
       });
       store.commit(VQBnamespace('setVariableDelimiters'), {
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
       });
       const collections = await mongoservice.listCollections();
       store.commit(VQBnamespace('setDomains'), { domains: collections });

--- a/playground/app.js
+++ b/playground/app.js
@@ -199,13 +199,13 @@ async function buildVueApp() {
       category: 'App variables',
       label: 'date.year',
       identifier: 'appRequesters.date.year',
-      value: '2020',
+      value: 2020,
     },
     {
       category: 'Story variables',
       label: 'country',
       identifier: 'requestersManager.country',
-      value: '2020',
+      value: 'New Zealand',
     },
     {
       category: 'Story variables',
@@ -214,6 +214,19 @@ async function buildVueApp() {
       value: 'New York',
     },
   ];
+  const VARIABLES = {
+    view: 'Product 123',
+    date: {
+      year: 2020,
+      month: 'Apr',
+    },
+    city: 'New York',
+    country: 'New Zealand',
+
+    value1: 2,
+    value2: 13,
+    groupname: 'Group 1',
+  }
 
   Vue.use(Vuex);
   const store = new Vuex.Store({
@@ -299,11 +312,7 @@ async function buildVueApp() {
         translator: TRANSLATOR,
         // based on lodash templates (ERB syntax)
         interpolateFunc: (value, context) => exampleInterpolateFunc(value, context),
-        variables: {
-          value1: 2,
-          value2: 13,
-          groupname: 'Group 1',
-        },
+        variables: VARIABLES,
       });
       // Add variables
       store.commit(VQBnamespace('setAvailableVariables'), {

--- a/src/components/convert-if-then-else-to-human-format.ts
+++ b/src/components/convert-if-then-else-to-human-format.ts
@@ -1,6 +1,7 @@
 import {
   FilterCondition,
   FilterSimpleCondition,
+  Formula,
   IfThenElseStep,
   isFilterComboAnd,
   isFilterComboOr,
@@ -94,10 +95,13 @@ function _conditionToHumanString(condition: FilterCondition, isOnTopLevel: boole
  * @param {String} prefix
  * @param {FilterCondition} condition
  */
-function _ifThenElseStepToHumanFormat(prefix: string, condition: FilterCondition | string): string {
+function _ifThenElseStepToHumanFormat(
+  prefix: string,
+  condition: FilterCondition | Formula,
+): string {
   if (!condition) {
     return prefix + EMPTY_CONDITION_SIGN;
-  } else if (typeof condition === 'string') {
+  } else if (typeof condition === 'string' || typeof condition === 'number') {
     return prefix + _valueToHumanString(condition);
   } else {
     return prefix + _conditionToHumanString(condition, true);

--- a/src/components/stepforms/IfThenElseStepForm.vue
+++ b/src/components/stepforms/IfThenElseStepForm.vue
@@ -48,7 +48,7 @@ function castIfThenElse(
 ) {
   const newObj = { ...ifThenElseObj };
   newObj.if = castFilterStepTreeValue(newObj.if, columnTypes);
-  if (typeof newObj.else !== 'string') {
+  if (typeof newObj.else === 'object') {
     // then it's a nested if...then...else object
     newObj.else = castIfThenElse(newObj.else, columnTypes);
   }

--- a/src/components/stepforms/schemas/formula.ts
+++ b/src/components/stepforms/schemas/formula.ts
@@ -8,7 +8,7 @@ export default {
       enum: ['formula'],
     },
     formula: {
-      type: 'string',
+      type: ['string', 'number'],
       minLength: 1,
       title: 'Formula',
       description: 'Formula',

--- a/src/components/stepforms/schemas/ifthenelse.ts
+++ b/src/components/stepforms/schemas/ifthenelse.ts
@@ -160,7 +160,7 @@ export default {
       additionalProperties: false,
     },
     formula: {
-      type: 'string',
+      type: ['string', 'number'],
       minLength: 1,
       title: 'Formula',
       description: 'Formula',

--- a/src/components/stepforms/widgets/IfThenElseWidget.vue
+++ b/src/components/stepforms/widgets/IfThenElseWidget.vue
@@ -119,7 +119,7 @@ import FilterEditor from '@/components/FilterEditor.vue';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import { ColumnTypeMapping } from '@/lib/dataset';
-import { FilterCondition, Formula, FormulaStep, IfThenElseStep } from '@/lib/steps';
+import { FilterCondition, Formula, IfThenElseStep } from '@/lib/steps';
 import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 import { VQBModule } from '@/store';
 

--- a/src/components/stepforms/widgets/IfThenElseWidget.vue
+++ b/src/components/stepforms/widgets/IfThenElseWidget.vue
@@ -206,6 +206,9 @@ export default class IfThenElseWidget extends Vue {
   }
 
   transformElseIfIntoElse() {
+    // This else case should never happen, "else if" being always an object
+    //but is necessary for TypeScript completeness
+    /* istanbul ignore else */
     if (typeof this.value.else === 'object') {
       this.collapsed = false;
       this.updateElseFormula(this.value.else.else);

--- a/src/components/stepforms/widgets/IfThenElseWidget.vue
+++ b/src/components/stepforms/widgets/IfThenElseWidget.vue
@@ -119,7 +119,7 @@ import FilterEditor from '@/components/FilterEditor.vue';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import { ColumnTypeMapping } from '@/lib/dataset';
-import { FilterCondition, IfThenElseStep } from '@/lib/steps';
+import { FilterCondition, Formula, FormulaStep, IfThenElseStep } from '@/lib/steps';
 import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 import { VQBModule } from '@/store';
 
@@ -183,14 +183,14 @@ export default class IfThenElseWidget extends Vue {
     });
   }
 
-  updateThenFormula(formula: string) {
+  updateThenFormula(formula: Formula) {
     this.$emit('input', {
       ...this.value,
       then: formula,
     });
   }
 
-  updateElseFormula(elseObject: Omit<IfThenElseStep, 'name' | 'newColumn'> | string) {
+  updateElseFormula(elseObject: Omit<IfThenElseStep, 'name' | 'newColumn'> | Formula) {
     this.$emit('input', {
       ...this.value,
       else: elseObject || '',
@@ -206,11 +206,11 @@ export default class IfThenElseWidget extends Vue {
   }
 
   transformElseIfIntoElse() {
-    if (typeof this.value.else === 'string') {
-      return;
-    } else {
+    if (typeof this.value.else === 'object') {
       this.collapsed = false;
       this.updateElseFormula(this.value.else.else);
+    } else {
+      return;
     }
   }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -98,3 +98,8 @@ export function keepCurrentValueIfArrayType(
 ): ValueType[] {
   return Array.isArray(value) ? value : defaultValue;
 }
+
+// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+export function escapeForUseInRegExp(string: string): string {
+  return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -187,10 +187,12 @@ export type FilterStep = {
   condition: FilterCondition;
 };
 
+export type Formula = string | number;
+
 export type FormulaStep = {
   name: 'formula';
   new_column: string;
-  formula: string;
+  formula: Formula;
 };
 
 export type FromDateStep = {
@@ -203,8 +205,8 @@ export type IfThenElseStep = {
   name: 'ifthenelse';
   newColumn: string;
   if: FilterCondition;
-  then: string;
-  else: string | Omit<IfThenElseStep, 'name' | 'newColumn'>;
+  then: Formula;
+  else: Formula | Omit<IfThenElseStep, 'name' | 'newColumn'>;
 };
 
 export type JoinStep = {

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -243,7 +243,7 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   formula(step: Readonly<S.FormulaStep>) {
     return {
       ...step,
-      formula: _interpolate(this.interpolateFunc, ' ' + step.formula, this.context),
+      formula: String(_interpolate(this.interpolateFunc, step.formula, this.context)),
     };
   }
 

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -21,7 +21,6 @@ type ConditionType = S.FilterSimpleCondition | S.FilterComboAnd | S.FilterComboO
  * @param interpolate the actual interpolate function
  * @param value the value to be interpolated
  * @param context the bag of variables
- * @param columnType if specified, the expected output type
  */
 function _interpolate(interpolate: InterpolateFunction, value: any, context: ScopeContext) {
   if (typeof value === 'string') {
@@ -86,15 +85,15 @@ function interpolateIfThenElse(
     if: interpolateFilterCondition(ifthenelse.if, interpolateFunc, context),
     then: _interpolate(interpolateFunc, ifthenelse.then, context),
   };
-  if (typeof ifthenelse.else === 'string') {
+  if (typeof ifthenelse.else === 'object') {
     return {
       ...ret,
-      else: _interpolate(interpolateFunc, ifthenelse.else, context),
+      else: interpolateIfThenElse(ifthenelse.else, interpolateFunc, context),
     };
   }
   return {
     ...ret,
-    else: interpolateIfThenElse(ifthenelse.else, interpolateFunc, context),
+    else: _interpolate(interpolateFunc, ifthenelse.else, context),
   };
 }
 
@@ -244,7 +243,7 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   formula(step: Readonly<S.FormulaStep>) {
     return {
       ...step,
-      formula: _interpolate(this.interpolateFunc, step.formula, this.context),
+      formula: _interpolate(this.interpolateFunc, ' ' + step.formula, this.context),
     };
   }
 

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -14,6 +14,8 @@
 import { OutputStep, StepMatcher, TransformStep } from '@/lib/matcher';
 import * as S from '@/lib/steps';
 
+import { VariableDelimiters } from '../variables';
+
 export interface ValidationError {
   dataPath: string;
   keyword: string;
@@ -70,6 +72,8 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
    * `label` will be displayed to the user
    */
   static label: string;
+
+  static variableDelimiters?: VariableDelimiters;
 
   /**
    * `supportedSteps` returns the list of steps supported by this translator class.

--- a/src/lib/translators/index.ts
+++ b/src/lib/translators/index.ts
@@ -6,8 +6,8 @@
  *
  */
 import { PipelineStepName } from '@/lib/steps';
-import { VariableDelimiters } from '../variables';
 
+import { VariableDelimiters } from '../variables';
 import { BaseTranslator } from './base';
 import { Mongo36Translator } from './mongo';
 import { Mongo40Translator } from './mongo4';

--- a/src/lib/translators/index.ts
+++ b/src/lib/translators/index.ts
@@ -6,6 +6,7 @@
  *
  */
 import { PipelineStepName } from '@/lib/steps';
+import { VariableDelimiters } from '../variables';
 
 import { BaseTranslator } from './base';
 import { Mongo36Translator } from './mongo';
@@ -59,3 +60,10 @@ export function availableTranslators() {
 
 registerTranslator('mongo36', Mongo36Translator);
 registerTranslator('mongo40', Mongo40Translator);
+
+/**
+ * Initialize variable delimiters for all translators
+ */
+export function setVariableDelimiters(variableDelimiters?: VariableDelimiters) {
+  BaseTranslator.variableDelimiters = variableDelimiters;
+}

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -1,6 +1,6 @@
 /** This module contains mongo specific translation operations */
 
-import _, { NumericDictionary } from 'lodash';
+import _ from 'lodash';
 import * as math from 'mathjs';
 
 import { $$, escapeForUseInRegExp } from '@/lib/helpers';
@@ -8,7 +8,6 @@ import { OutputStep, StepMatcher } from '@/lib/matcher';
 import * as S from '@/lib/steps';
 import { BaseTranslator, ValidationError } from '@/lib/translators/base';
 import { VariableDelimiters } from '@/lib/variables';
-import { Formula } from '@/lib/steps';
 
 type PropMap<T> = { [prop: string]: T };
 

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -211,7 +211,7 @@ function buildFormulaTree(
   if (variableDelimiters) {
     let indexVars = 0;
     const regexVars = new RegExp(
-      `${escapeForUseInRegExp(variableDelimiters.start)}(.*?)\\${escapeForUseInRegExp(
+      `${escapeForUseInRegExp(variableDelimiters.start)}(.*?)${escapeForUseInRegExp(
         variableDelimiters.end,
       )}`,
       'g',

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -7,6 +7,7 @@ import { MutationTree } from 'vuex';
 
 import { BackendError, BackendWarning } from '@/lib/backend-response';
 import { DomainStep, Pipeline, PipelineStepName } from '@/lib/steps';
+import { setVariableDelimiters } from '@/lib/translators';
 
 import { currentPipeline, VQBState } from './state';
 
@@ -332,6 +333,9 @@ class Mutations {
     { variableDelimiters }: Pick<VQBState, 'variableDelimiters'>,
   ) {
     state.variableDelimiters = variableDelimiters;
+
+    // Forward them to translators
+    setVariableDelimiters(variableDelimiters);
   }
 }
 

--- a/src/typings/mathjs/index.d.ts
+++ b/src/typings/mathjs/index.d.ts
@@ -11,30 +11,34 @@ declare namespace mathjs {
   /**
    * Math nodes interfaces to build formula logical trees
    */
-  interface OperatorNode {
+  class BaseNode {
+    traverse: function;
+    transform: function;
+    type: string;
+  }
+
+  class OperatorNode extends BaseNode {
     type: 'OperatorNode';
     fn: string;
     op: string;
     args: MathNode[];
-    traverse: function;
   }
 
-  interface ConstantNode {
+  class ConstantNode extends BaseNode {
+    constructor(value: number | string);
+
     type: 'ConstantNode';
-    value: number;
-    traverse: function;
+    value: number | string;
   }
 
-  interface SymbolNode {
+  class SymbolNode extends BaseNode {
     type: 'SymbolNode';
     name: string;
-    traverse: function;
   }
 
-  interface ParenthesisNode {
+  class ParenthesisNode extends BaseNode{
     type: 'ParenthesisNode';
     content: MathNode;
-    traverse: function;
   }
 
   type MathNode = OperatorNode | ConstantNode | SymbolNode | ParenthesisNode;

--- a/tests/unit/formula-step-form.spec.ts
+++ b/tests/unit/formula-step-form.spec.ts
@@ -1,6 +1,6 @@
 import FormulaStepForm from '@/components/stepforms/FormulaStepForm.vue';
 
-import { BasicStepFormTestRunner } from './utils';
+import { BasicStepFormTestRunner, setupMockStore } from './utils';
 
 describe('Formula Step Form', () => {
   const runner = new BasicStepFormTestRunner(FormulaStepForm, 'formula');
@@ -18,11 +18,41 @@ describe('Formula Step Form', () => {
     },
   ]);
 
+  runner.testValidationErrors([
+    {
+      testlabel: 'submitted formula is not valid',
+      props: {
+        initialStepValue: { name: 'formula', formula: '= 3', new_column: 'foo' },
+      },
+      errors: [{ keyword: 'parsing', dataPath: '.formula' }],
+    },
+  ]);
+
   runner.testValidate({
-    testlabel: 'submitted data is valid',
+    testlabel: 'submitted data is valid with string formula',
     props: {
       initialStepValue: { name: 'formula', formula: 'ColumnA * 2', new_column: 'foo' },
     },
+  });
+
+  runner.testValidate({
+    testlabel: 'submitted data is valid with non string formula',
+    props: {
+      initialStepValue: { name: 'formula', formula: 42, new_column: 'foo' },
+    },
+  });
+
+  runner.testValidate({
+    testlabel: 'submitted formula contains variables',
+    props: {
+      initialStepValue: { name: 'formula', formula: '<%= some_var %>', new_column: 'foo' },
+    },
+    store: setupMockStore({
+      variableDelimiters: {
+        start: '<%=',
+        end: '%>',
+      },
+    }),
   });
 
   runner.testCancel();

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -1513,6 +1513,11 @@ describe('Pipeline to mongo translator', () => {
       },
       {
         name: 'formula',
+        new_column: 'number_constant',
+        formula: 42,
+      },
+      {
+        name: 'formula',
         new_column: 'with_var',
         formula: '<%= var %>',
       },
@@ -1526,6 +1531,7 @@ describe('Pipeline to mongo translator', () => {
     expect(querySteps).toEqual([
       { $addFields: { foo: '$bar' } },
       { $addFields: { constant: 42 } },
+      { $addFields: { number_constant: 42 } },
       { $addFields: { with_var: '<%= var %>' } },
       { $addFields: { with_parentheses: '$test' } },
       { $project: { _id: 0 } },

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -1,5 +1,6 @@
 import { Pipeline } from '@/lib/steps';
-import { getTranslator } from '@/lib/translators';
+import { getTranslator, setVariableDelimiters } from '@/lib/translators';
+import { BaseTranslator } from '@/lib/translators/base';
 import { _simplifyAndCondition, _simplifyMongoPipeline, MongoStep } from '@/lib/translators/mongo';
 
 const smallMonthReplace = {
@@ -1495,6 +1496,11 @@ describe('Pipeline to mongo translator', () => {
   });
 
   it('can generate a formula step with a single column or constant', () => {
+    setVariableDelimiters({
+      start: '<%=',
+      end: '%>',
+    });
+
     const pipeline: Pipeline = [
       {
         name: 'formula',

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -1,7 +1,6 @@
 import { Pipeline } from '@/lib/steps';
 import { getTranslator, setVariableDelimiters } from '@/lib/translators';
-import { BaseTranslator } from '@/lib/translators/base';
-import { _simplifyAndCondition, _simplifyMongoPipeline, MongoStep } from '@/lib/translators/mongo';
+import { MongoStep } from '@/lib/translators/mongo';
 
 const smallMonthReplace = {
   $switch: {

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -1508,6 +1508,11 @@ describe('Pipeline to mongo translator', () => {
       },
       {
         name: 'formula',
+        new_column: 'with_var',
+        formula: '<%= var %>',
+      },
+      {
+        name: 'formula',
         new_column: 'with_parentheses',
         formula: '(test)',
       },
@@ -1516,6 +1521,7 @@ describe('Pipeline to mongo translator', () => {
     expect(querySteps).toEqual([
       { $addFields: { foo: '$bar' } },
       { $addFields: { constant: 42 } },
+      { $addFields: { with_var: '<%= var %>' } },
       { $addFields: { with_parentheses: '$test' } },
       { $project: { _id: 0 } },
     ]);

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -1,6 +1,6 @@
 import { Pipeline } from '@/lib/steps';
 import { getTranslator, setVariableDelimiters } from '@/lib/translators';
-import { MongoStep } from '@/lib/translators/mongo';
+import { _simplifyAndCondition, _simplifyMongoPipeline, MongoStep } from '@/lib/translators/mongo';
 
 const smallMonthReplace = {
   $switch: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4286,7 +4286,7 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-complex.js@2.0.11:
+complex.js@^2.0.11:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/complex.js/-/complex.js-2.0.11.tgz#09a873fbf15ffd8c18c9c2201ccef425c32b8bf1"
   integrity sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw==
@@ -4746,10 +4746,10 @@ decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
-decimal.js@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.0.tgz#39466113a9e036111d02f82489b5fd6b0b5ed231"
-  integrity sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==
+decimal.js@^10.2.0:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
+  integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -5304,7 +5304,7 @@ escape-html@^1.0.3, escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-latex@1.2.0:
+escape-latex@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/escape-latex/-/escape-latex-1.2.0.tgz#07c03818cf7dac250cce517f4fda1b001ef2bca1"
   integrity sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==
@@ -6050,7 +6050,7 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
-fraction.js@4.0.12:
+fraction.js@^4.0.12:
   version "4.0.12"
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.0.12.tgz#0526d47c65a5fb4854df78bc77f7bec708d7b8c3"
   integrity sha512-8Z1K0VTG4hzYY7kA/1sj4/r1/RWLBD3xwReT/RCrUCbzPszjNQCCsy3ktkU/eaEqX3MYa4pY37a52eiBlPMlhA==
@@ -7382,7 +7382,7 @@ iterate-value@^1.0.0:
     es-get-iterator "^1.0.2"
     iterate-iterator "^1.0.1"
 
-javascript-natural-sort@0.7.1:
+javascript-natural-sort@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
   integrity sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=
@@ -8378,19 +8378,19 @@ material-colors@^1.2.1:
   resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
   integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
 
-mathjs@^5.9.0:
-  version "5.10.3"
-  resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-5.10.3.tgz#e998885f932ea8886db8b40f7f5b199f89b427f1"
-  integrity sha512-ySjg30BC3dYjQm73ILZtwcWzFJde0VU6otkXW/57IjjuYRa3Qaf0Kb8pydEuBZYtqW2OxreAtsricrAmOj3jIw==
+mathjs@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-7.3.0.tgz#02bce1341e7b7c839f91dc9d552e23e026de5288"
+  integrity sha512-6PwW9yYyL9iDtgDYN2Dyjc2t+ZIlbGkKxm5RZk+PDv6Hc1lEtGF0axMf9mirZTKU4o31a3m2CpnC+d1hXTUo0g==
   dependencies:
-    complex.js "2.0.11"
-    decimal.js "10.2.0"
-    escape-latex "1.2.0"
-    fraction.js "4.0.12"
-    javascript-natural-sort "0.7.1"
-    seed-random "2.2.0"
-    tiny-emitter "2.1.0"
-    typed-function "1.1.0"
+    complex.js "^2.0.11"
+    decimal.js "^10.2.0"
+    escape-latex "^1.2.0"
+    fraction.js "^4.0.12"
+    javascript-natural-sort "^0.7.1"
+    seed-random "^2.2.0"
+    tiny-emitter "^2.1.0"
+    typed-function "^2.0.0"
 
 md5-file@3.1.1:
   version "3.1.1"
@@ -11081,7 +11081,7 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
-seed-random@2.2.0:
+seed-random@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/seed-random/-/seed-random-2.2.0.tgz#2a9b19e250a817099231a5b99a4daf80b7fbed54"
   integrity sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ=
@@ -12056,7 +12056,7 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tiny-emitter@2.1.0, tiny-emitter@^2.0.0:
+tiny-emitter@^2.0.0, tiny-emitter@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
@@ -12298,10 +12298,10 @@ type-is@^1.6.4, type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typed-function@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/typed-function/-/typed-function-1.1.0.tgz#ea149706e0fb42aca1791c053a6d94ccd6c4fdcb"
-  integrity sha512-TuQzwiT4DDg19beHam3E66oRXhyqlyfgjHB/5fcvsRXbfmWPJfto9B4a0TBdTrQAPGlGmXh/k7iUI+WsObgORA==
+typed-function@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/typed-function/-/typed-function-2.0.0.tgz#15ab3825845138a8b1113bd89e60cd6a435739e8"
+  integrity sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA==
 
 typed-styles@^0.0.7:
   version "0.0.7"


### PR DESCRIPTION
The formula and f/then/else steps accept Formulas that are parsed by Math.js and translated into the targeted query language.

However, as it were unaware of variables, the translation failed, trying to interpret the delimiters as if they were operators.
To avoid that, this PR make translators aware of variable delimiters so they can safely treat their content as a unique identifiers.

Also, the interpolated type of variables can be numbers, and not always strings. Hence, the formula parser must accept and understand other types than strings (only number for now), and treat the result as a standard value.

The playground variables have been updated to provide relevant examples.

Note: in formulas, identifier like `aaa` are considered to be column names. To keep a string as it is, it must be surrounded by quotes, like in the following screenshot.

![Screenshot from 2020-09-30 14-02-41](https://user-images.githubusercontent.com/932583/94683155-5551d900-0326-11eb-9f6b-0f3510907507.png)
![Screenshot from 2020-09-30 14-02-49](https://user-images.githubusercontent.com/932583/94683164-57b43300-0326-11eb-815b-16c104005787.png)

