### PR TITLE
fix(multiinput-text): display dropdown without be overlapped by next input

### DIFF
--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -153,7 +153,7 @@ export default class MultiInputTextWidget extends Vue {
   isolation: isolate;
 
   &.multiselect--active {
-    z-index: 0;
+    z-index: 1;
   }
 }
 
@@ -183,6 +183,9 @@ export default class MultiInputTextWidget extends Vue {
 .multiselect--active {
   & > .multiselect__tags {
     @extend %form-widget__field--focused;
+  }
+  + .widget-variable__toggle {
+    z-index: 1; //keep variable toggle button display even when dropdown is opened
   }
 }
 .multiselect__option {

--- a/src/components/stepforms/widgets/MultiVariableInput.vue
+++ b/src/components/stepforms/widgets/MultiVariableInput.vue
@@ -88,6 +88,5 @@ export default class MultiVariableInput extends Vue {
 .widget-multi-variable-input {
   position: relative;
   width: 100%;
-  z-index: 1;
 }
 </style>


### PR DESCRIPTION
Due to https://github.com/ToucanToco/weaverbird/pull/655 to fix overlapped input in filter condition, we created a bug.
Now in other step, as multi variable has a z-index 1. The dropdown are overlapped by the next input.

To fix it, we need to add a z-index only on the **active** multiinputtext ( added a z-index to variable toggler to display button even when multiinputtext is active).

Before:
![before](https://user-images.githubusercontent.com/59559689/96444383-795e5700-120e-11eb-922e-57f7b3c4e4fd.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/96444396-7c594780-120e-11eb-9891-20fe6914ecfb.gif)
