### PR TITLE
fix(resizable-directive): should not sort the columns options

### DIFF
--- a/src/directives/resizable/ResizableTable.ts
+++ b/src/directives/resizable/ResizableTable.ts
@@ -45,7 +45,7 @@ export default class ResizableTable {
   // reset cols handlers if cols has been updated
   // resize cols handlers height if rows has been updated
   update(options: ResizableTableOptions): void {
-    if (!isEqual(this.options.columns.sort(), options.columns.sort())) {
+    if (!isEqual(this.options.columns, options.columns)) {
       this.updateCols(options);
     } else if (this.table.offsetHeight !== this.colHandlers[0].options.height) {
       this.updateRows();


### PR DESCRIPTION
**What did you wizard :mage_woman: : ?**

It sorted the columns options to verify if columns are still the same or if we need to rerender the resizable table directive.
The thing is that we don't need to roll it :rofl: . So i sorted the columns in the ui (oupsssi).

Did a quick fix to avoid columns to get crazy.

Before:
![before](https://user-images.githubusercontent.com/59559689/96593294-9fa4f500-12e9-11eb-853a-7698df02fc04.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/96593311-a469a900-12e9-11eb-8097-949ad249fbd0.gif)
