### PR TITLE
pivot step: allow empty index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - pivot step: support variables interpolation
+- pivot step: allow for empty index parameter
 
 ## [0.28.1] - 2020-10-20
 

--- a/src/components/stepforms/schemas/pivot.ts
+++ b/src/components/stepforms/schemas/pivot.ts
@@ -9,7 +9,6 @@ export default {
     },
     index: {
       type: 'array',
-      minItems: 1,
       items: {
         type: 'string',
         minLength: 1,

--- a/tests/unit/pivot-step-form.spec.ts
+++ b/tests/unit/pivot-step-form.spec.ts
@@ -28,7 +28,6 @@ describe('Pivot Step Form', () => {
       testlabel: 'submitted data is not valid',
       errors: [
         { keyword: 'minLength', dataPath: '.column_to_pivot' },
-        { keyword: 'minItems', dataPath: '.index' },
         { keyword: 'minLength', dataPath: '.value_column' },
       ],
     },


### PR DESCRIPTION
Before this PR, users were forced to specify at least 1 column in the index parameter, which is actually not expected in frequent cases, but lead users to create first a temporary column with the same value in all rows to be able to apply the step afterwards.

After this PR, we accept empty index.