### PR TITLE
feat(server): rename step

### DIFF
--- a/server/tests/steps/test_rename.py
+++ b/server/tests/steps/test_rename.py
@@ -1,0 +1,23 @@
+import pytest
+from pandas import DataFrame
+
+from tests.utils import assert_dataframes_equals
+from weaverbird.steps import RenameStep
+
+
+@pytest.fixture
+def sample_df():
+    return DataFrame({'NAME': ['foo', 'bar'], 'AGE': [42, 43], 'SCORE': [100, 200]})
+
+
+def test_rename(sample_df: DataFrame):
+    df_result = RenameStep(
+        name='rename',
+        to_rename=[
+            ['NAME', 'name'],
+            ['AGE', 'age'],
+        ],
+    ).execute(sample_df, domain_retriever=None)
+
+    expected_result = DataFrame({'name': ['foo', 'bar'], 'age': [42, 43], 'SCORE': [100, 200]})
+    assert_dataframes_equals(df_result, expected_result)

--- a/server/tests/test_pipeline_executor.py
+++ b/server/tests/test_pipeline_executor.py
@@ -39,3 +39,19 @@ def test_filter(pipeline_executor):
         df,
         pd.DataFrame({'colA': ['tutu'], 'colB': [2], 'colC': [50]}),
     )
+
+
+def test_rename(pipeline_executor):
+    df = pipeline_executor.execute_pipeline(
+        [
+            {'name': 'domain', 'domain': 'domain_a'},
+            {'name': 'rename', 'toRename': [['colA', 'col_a'], ['colB', 'col_b']]},
+        ]
+    )
+
+    assert_dataframes_equals(
+        df,
+        pd.DataFrame(
+            {'col_a': ['toto', 'tutu', 'tata'], 'col_b': [1, 2, 3], 'colC': [100, 50, 25]}
+        ),
+    )

--- a/server/weaverbird/pipeline.py
+++ b/server/weaverbird/pipeline.py
@@ -2,9 +2,9 @@ from typing import List, Union
 
 from pydantic import BaseModel
 
-from weaverbird.steps import DomainStep, FilterStep
+from weaverbird.steps import DomainStep, FilterStep, RenameStep
 
-PipelineStep = Union[DomainStep, FilterStep]
+PipelineStep = Union[DomainStep, FilterStep, RenameStep]
 
 
 class Pipeline(BaseModel):

--- a/server/weaverbird/steps/__init__.py
+++ b/server/weaverbird/steps/__init__.py
@@ -1,3 +1,4 @@
 from .base import BaseStep
 from .domain import DomainStep
 from .filter import FilterStep
+from .rename import RenameStep

--- a/server/weaverbird/steps/rename.py
+++ b/server/weaverbird/steps/rename.py
@@ -1,0 +1,17 @@
+from typing import List, Tuple
+
+from pandas import DataFrame
+from pydantic import Field
+
+from weaverbird.steps.base import BaseStep
+
+
+class RenameStep(BaseStep):
+    name = Field('rename', const=True)
+    to_rename: List[Tuple[str, str]] = Field(..., alias='toRename')
+
+    class Config:
+        allow_population_by_field_name = True
+
+    def execute(self, df: DataFrame, domain_retriever) -> DataFrame:
+        return df.rename(columns=dict(self.to_rename))


### PR DESCRIPTION
Add rename step in pandas backend.

:information_source:  I only implemented the new syntax (`toRename`), not the legacy one (`oldname` / `newname`).