### PR TITLE
test(server): ensure json df serialization is done by pandas

### DIFF
--- a/server/playground.py
+++ b/server/playground.py
@@ -30,9 +30,11 @@ def after_request(response):
 @app.route('/', methods=['GET', 'POST'])
 def handle_request():
     if request.method == 'GET':
-        return json.dumps(get_available_domains())
+        return Response(json.dumps(get_available_domains()), mimetype='application/json')
     elif request.method == 'POST':
-        return execute_pipeline(request.get_json(), **request.args)
+        return Response(
+            execute_pipeline(request.get_json(), **request.args), mimetype='application/json'
+        )
 
 
 # Load all csv in playground's datastore
@@ -44,7 +46,7 @@ def get_available_domains():
     return list(DOMAINS.keys())
 
 
-def execute_pipeline(*args, **kwargs) -> dict:
+def execute_pipeline(*args, **kwargs) -> str:
     executor = PipelineExecutor(lambda domain: DOMAINS[domain])
 
     # Url parameters are only strings, these two must be understood as numbers

--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -330,6 +330,20 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.3.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.1"
 description = "Extensions to the standard Python datetime module"
@@ -403,7 +417,7 @@ watchdog = ["watchdog"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "f7747da1ab7f2cd9db117ccb6262fb8dbbf041e954d61bcee81df0b5137cf0b8"
+content-hash = "3545417ff5fe32f651836b6f275610f3678ab24178ac93dd75fd47d35e1257c5"
 
 [metadata.files]
 appdirs = [
@@ -651,6 +665,10 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
     {file = "pytest_cov-2.10.1-py2.py3-none-any.whl", hash = "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.3.1.tar.gz", hash = "sha256:a4d6d37329e4a893e77d9ffa89e838dd2b45d5dc099984cf03c703ac8411bb82"},
+    {file = "pytest_mock-3.3.1-py3-none-any.whl", hash = "sha256:024e405ad382646318c4281948aadf6fe1135632bea9cc67366ea0c4098ef5f2"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -18,6 +18,7 @@ flake8 = "^3.8.4"
 isort = "^5.6.4"
 mypy = "^0.790"
 Flask = "^1.1.2"
+pytest-mock = "^3.3.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/server/tests/test_pipeline_executor.py
+++ b/server/tests/test_pipeline_executor.py
@@ -1,10 +1,12 @@
 """
 This file contain end-to-end tests for pipeline execution
 """
+import json
 from os import path
 
 import pandas as pd
 import pytest
+from pytest_mock import MockFixture
 
 from tests.utils import assert_dataframes_equals
 from weaverbird.pipeline_executor import PipelineExecutor
@@ -18,14 +20,16 @@ def pipeline_executor():
     return PipelineExecutor(domain_retriever=lambda name: DOMAINS[name])
 
 
-def test_preview_pipeline(pipeline_executor):
-    result = pipeline_executor.preview_pipeline(
-        [
-            {'name': 'domain', 'domain': 'domain_a'},
-        ]
+def test_preview_pipeline(mocker: MockFixture, pipeline_executor):
+    df_to_json_spy = mocker.spy(pd.DataFrame, 'to_json')
+    result = json.loads(
+        pipeline_executor.preview_pipeline(
+            [
+                {'name': 'domain', 'domain': 'domain_a'},
+            ]
+        )
     )
     assert 'data' in result
-    print(result)
     assert len(result['data']) == 3  # rows
     assert len(result['data'][0]) == 3  # columns
     assert result['schema']['fields'] == [
@@ -36,6 +40,9 @@ def test_preview_pipeline(pipeline_executor):
     assert result['offset'] == 0
     assert result['limit'] == 50
     assert result['total'] == 3
+
+    # DataFrames must be exported with pandas' method to ensure NaN and dates are correctly converted
+    df_to_json_spy.assert_called_once()
 
 
 def test_preview_pipeline_limit(pipeline_executor):

--- a/server/tests/test_pipeline_executor.py
+++ b/server/tests/test_pipeline_executor.py
@@ -52,7 +52,7 @@ def test_preview_pipeline_limit(pipeline_executor):
         ],
         limit=1,
     )
-    assert result['data'] == [
+    assert json.loads(result)['data'] == [
         {'colA': 'toto', 'colB': 1, 'colC': 100}
     ]  # first row of the data frame
 
@@ -65,7 +65,7 @@ def test_preview_pipeline_limit_offset(pipeline_executor):
         limit=3,
         offset=2,
     )
-    assert result['data'] == [
+    assert json.loads(result)['data'] == [
         {'colA': 'tata', 'colB': 3, 'colC': 25}  # third row of the data frame
         # no other row after that one
     ]

--- a/server/weaverbird/pipeline_executor.py
+++ b/server/weaverbird/pipeline_executor.py
@@ -1,3 +1,4 @@
+import json
 from typing import List
 
 from pandas import DataFrame
@@ -30,21 +31,23 @@ class PipelineExecutor:
         # TODO validate and apply all other steps
         return df
 
-    def preview_pipeline(
-        self, pipeline_steps: List[dict], limit: int = 50, offset: int = 0
-    ) -> dict:
+    def preview_pipeline(self, pipeline_steps: List[dict], limit: int = 50, offset: int = 0) -> str:
         """
-        Execute a pipeline but returns only a slice of the results, determined by `limit` and `offset` parameters, as dict.
+        Execute a pipeline but returns only a slice of the results, determined by `limit` and `offset` parameters, as JSON.
 
         Return format follows the 'table' JSON table schema used by pandas (see
         https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#orient-options), with a few addition related to
         pagination.
+
+        Note: it's required to use pandas `to_json` methods, as it convert NaN and dates to an appropriate format.
         """
         df = self.execute_pipeline(pipeline_steps)
-        return {
-            'schema': build_table_schema(df, index=False),
-            'offset': offset,
-            'limit': limit,
-            'total': df.shape[0],
-            'data': df[offset : offset + limit].to_dict(orient='records'),
-        }
+        return json.dumps(
+            {
+                'schema': build_table_schema(df, index=False),
+                'offset': offset,
+                'limit': limit,
+                'total': df.shape[0],
+                'data': json.loads(df[offset : offset + limit].to_json(orient='records')),
+            }
+        )


### PR DESCRIPTION
I noticed that letting Flask serializing dataframes isn't good: we find NaN in the resulting JSON, which is invalid.
Letting pandas do the work prevents such a thing.