### PR TITLE
feat(server): add convert step

### DIFF
--- a/server/tests/steps/test_convert.py
+++ b/server/tests/steps/test_convert.py
@@ -1,22 +1,33 @@
+import pytest
 from pandas import DataFrame
 
 from tests.utils import assert_dataframes_equals
 from weaverbird.steps import ConvertStep
 
 
-def test_convert_to_float():
-    df_result = ConvertStep(name='convert', columns=['value'], data_type='float').execute(
-        DataFrame({'value': [41, '42', 43.5, '43.6', None, 'meh']})
-    )
+@pytest.fixture
+def sample_df() -> DataFrame:
+    return DataFrame({'value': [41, '42', 43.5, '43.6', None, 'meh']})
+
+
+def test_convert_to_float(sample_df: DataFrame):
+    df_result = ConvertStep(name='convert', columns=['value'], data_type='float').execute(sample_df)
 
     expected_result = DataFrame({'value': [41.0, 42.0, 43.5, 43.6, None, None]})
     assert_dataframes_equals(df_result, expected_result)
 
 
-def test_convert_to_int():
+def test_convert_to_integer(sample_df: DataFrame):
     df_result = ConvertStep(name='convert', columns=['value'], data_type='integer').execute(
-        DataFrame({'value': [41, '42', 43.5, '43.6', None, 'meh']})
+        sample_df
     )
 
     expected_result = DataFrame({'value': [41, 42, 43, 43, None, None]})
+    assert_dataframes_equals(df_result, expected_result)
+
+
+def test_convert_to_text(sample_df: DataFrame):
+    df_result = ConvertStep(name='convert', columns=['value'], data_type='text').execute(sample_df)
+
+    expected_result = DataFrame({'value': ['41', '42', '43.5', '43.6', 'nan', 'meh']})
     assert_dataframes_equals(df_result, expected_result)

--- a/server/tests/steps/test_convert.py
+++ b/server/tests/steps/test_convert.py
@@ -61,3 +61,13 @@ def test_convert_to_datetime():
         }
     )
     assert_dataframes_equals(df_result, expected_result)
+
+
+def test_convert_to_bool():
+    input_df = DataFrame({'value': ['plop', 0, 0.0, 1, '', None]})
+    df_result = ConvertStep(name='convert', columns=['value'], data_type='boolean').execute(
+        input_df
+    )
+
+    expected_result = DataFrame({'value': [True, False, False, True, False, False]})
+    assert_dataframes_equals(df_result, expected_result)

--- a/server/tests/steps/test_convert.py
+++ b/server/tests/steps/test_convert.py
@@ -1,5 +1,5 @@
 import pytest
-from pandas import DataFrame
+from pandas import DataFrame, Timestamp
 
 from tests.utils import assert_dataframes_equals
 from weaverbird.steps import ConvertStep
@@ -30,4 +30,34 @@ def test_convert_to_text(sample_df: DataFrame):
     df_result = ConvertStep(name='convert', columns=['value'], data_type='text').execute(sample_df)
 
     expected_result = DataFrame({'value': ['41', '42', '43.5', '43.6', 'nan', 'meh']})
+    assert_dataframes_equals(df_result, expected_result)
+
+
+def test_convert_to_datetime():
+    input_df = DataFrame(
+        {
+            'value': [
+                '2020',
+                '2020-11-02',
+                '11/02/2020',
+                '2020-11-02T15:30',
+                1604331000000000000,
+                'meh',
+            ]
+        }
+    )
+    df_result = ConvertStep(name='convert', columns=['value'], data_type='date').execute(input_df)
+
+    expected_result = DataFrame(
+        {
+            'value': [
+                Timestamp(year=2020, month=1, day=1),
+                Timestamp(year=2020, month=11, day=2),
+                Timestamp(year=2020, month=11, day=2),
+                Timestamp(year=2020, month=11, day=2, hour=15, minute=30),
+                Timestamp(year=2020, month=11, day=2, hour=15, minute=30),
+                None,
+            ]
+        }
+    )
     assert_dataframes_equals(df_result, expected_result)

--- a/server/tests/steps/test_convert.py
+++ b/server/tests/steps/test_convert.py
@@ -1,0 +1,22 @@
+from pandas import DataFrame
+
+from tests.utils import assert_dataframes_equals
+from weaverbird.steps import ConvertStep
+
+
+def test_convert_to_float():
+    df_result = ConvertStep(name='convert', columns=['value'], data_type='float').execute(
+        DataFrame({'value': [41, '42', 43.5, '43.6', None, 'meh']})
+    )
+
+    expected_result = DataFrame({'value': [41.0, 42.0, 43.5, 43.6, None, None]})
+    assert_dataframes_equals(df_result, expected_result)
+
+
+def test_convert_to_int():
+    df_result = ConvertStep(name='convert', columns=['value'], data_type='integer').execute(
+        DataFrame({'value': [41, '42', 43.5, '43.6', None, 'meh']})
+    )
+
+    expected_result = DataFrame({'value': [41, 42, 43, 43, None, None]})
+    assert_dataframes_equals(df_result, expected_result)

--- a/server/weaverbird/pipeline.py
+++ b/server/weaverbird/pipeline.py
@@ -5,13 +5,16 @@ from pydantic import BaseModel
 from weaverbird.steps import (
     AppendStep,
     ConcatenateStep,
+    ConvertStep,
     DomainStep,
     FilterStep,
     JoinStep,
     RenameStep,
 )
 
-PipelineStep = Union[AppendStep, ConcatenateStep, DomainStep, FilterStep, JoinStep, RenameStep]
+PipelineStep = Union[
+    AppendStep, ConcatenateStep, ConvertStep, DomainStep, FilterStep, JoinStep, RenameStep
+]
 
 
 class Pipeline(BaseModel):

--- a/server/weaverbird/steps/__init__.py
+++ b/server/weaverbird/steps/__init__.py
@@ -1,6 +1,7 @@
 from .append import AppendStep
 from .base import BaseStep
 from .concatenate import ConcatenateStep
+from .convert import ConvertStep
 from .domain import DomainStep
 from .filter import FilterStep
 from .join import JoinStep

--- a/server/weaverbird/steps/convert.py
+++ b/server/weaverbird/steps/convert.py
@@ -20,9 +20,14 @@ def cast_to_int(s: Series) -> Series:
     return s_integer.append(s_nan).sort_index()
 
 
+def cast_to_str(s: Series) -> Series:
+    return s.astype(str)
+
+
 CAST_FUNCTIONS = {
     'integer': cast_to_int,
     'float': cast_to_float,
+    'text': cast_to_str,
 }
 
 

--- a/server/weaverbird/steps/convert.py
+++ b/server/weaverbird/steps/convert.py
@@ -1,6 +1,6 @@
 from typing import List, Literal
 
-from pandas import DataFrame, Series, to_numeric
+from pandas import DataFrame, Series, to_datetime, to_numeric
 from pydantic import Field
 
 from weaverbird.steps.base import BaseStep
@@ -24,10 +24,15 @@ def cast_to_str(s: Series) -> Series:
     return s.astype(str)
 
 
+def cast_to_datetime(s: Series) -> Series:
+    return to_datetime(s, errors='coerce')  # cast errors will result in NaT values
+
+
 CAST_FUNCTIONS = {
     'integer': cast_to_int,
     'float': cast_to_float,
     'text': cast_to_str,
+    'date': cast_to_datetime,
 }
 
 

--- a/server/weaverbird/steps/convert.py
+++ b/server/weaverbird/steps/convert.py
@@ -28,11 +28,16 @@ def cast_to_datetime(s: Series) -> Series:
     return to_datetime(s, errors='coerce')  # cast errors will result in NaT values
 
 
+def cast_to_bool(s: Series) -> Series:
+    return s.astype(bool)
+
+
 CAST_FUNCTIONS = {
     'integer': cast_to_int,
     'float': cast_to_float,
     'text': cast_to_str,
     'date': cast_to_datetime,
+    'boolean': cast_to_bool,
 }
 
 

--- a/server/weaverbird/steps/convert.py
+++ b/server/weaverbird/steps/convert.py
@@ -1,0 +1,37 @@
+from typing import List, Literal
+
+from pandas import DataFrame, Series, to_numeric
+from pydantic import Field
+
+from weaverbird.steps.base import BaseStep
+
+ColumnName = str
+
+
+def cast_to_float(s: Series) -> Series:
+    return to_numeric(s, errors='coerce')  # cast errors will result in NaN values
+
+
+def cast_to_int(s: Series) -> Series:
+    s = cast_to_float(s)
+    # Since .astype(int) would fail on NaN values, treat them separately:
+    s_integer = s[s.notna()].astype(int)
+    s_nan = s[s.isna()]
+    return s_integer.append(s_nan).sort_index()
+
+
+CAST_FUNCTIONS = {
+    'integer': cast_to_int,
+    'float': cast_to_float,
+}
+
+
+class ConvertStep(BaseStep):
+    name = Field('convert', const=True)
+    columns: List[ColumnName]
+    data_type: Literal['integer', 'float', 'text', 'date', 'boolean']
+
+    def execute(self, df: DataFrame, domain_retriever=None, execute_pipeline=None) -> DataFrame:
+        cast_function = CAST_FUNCTIONS[self.data_type]
+        transformed_columns = {col_name: cast_function(df[col_name]) for col_name in self.columns}
+        return df.assign(**transformed_columns)

--- a/src/lib/translators/pandas.ts
+++ b/src/lib/translators/pandas.ts
@@ -22,6 +22,10 @@ export class PandasTranslator extends BaseTranslator {
     return step;
   }
 
+  convert(step: Readonly<S.ConvertStep>) {
+    return step;
+  }
+
   domain(step: Readonly<S.DomainStep>) {
     return step;
   }


### PR DESCRIPTION
:warning: pandas cast can slightly differ from mongo's cast. For example, any string evaluates to `true` in mongo, whereas in pandas an empty string evaluates to `false`. I chose to keep pandas's cast for simplicity / performance (and because those are edge cases).