### PR TITLE
text step: fix mongo translation and add test

### DIFF
--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -1638,7 +1638,9 @@ const mapper: Partial<StepMatcher<MongoStep>> = {
   sort: transformSort,
   statistics: transformStatistics,
   substring: transformSubstring,
-  text: step => ({ $addFields: { [step.new_column]: step.text } }),
+  text: (step: Readonly<S.AddTextColumnStep>) => ({
+    $addFields: { [step.new_column]: { $literal: step.text } },
+  }),
   todate: (step: Readonly<S.ToDateStep>) => ({
     $addFields: { [step.column]: { $dateFromString: { dateString: $$(step.column) } } },
   }),

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -4163,4 +4163,19 @@ describe('Pipeline to mongo translator', () => {
       { $project: { _id: 0 } },
     ]);
   });
+
+  it('can generate text steps', () => {
+    const pipeline: Pipeline = [
+      {
+        name: 'text',
+        new_column: 'TEXT',
+        text: 'plop',
+      },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      { $addFields: { TEXT: { $literal: 'plop' } } },
+      { $project: { _id: 0 } },
+    ]);
+  });
 });


### PR DESCRIPTION
We were not using the `$literal` operator to force mongo to interpret the string as text, which can cause issues to literal write labels such as '$label' interpreted as a field by mongo otherwise.