### PR TITLE
fix(server): fix percentage step

### DIFF
--- a/server/tests/steps/test_percentage.py
+++ b/server/tests/steps/test_percentage.py
@@ -6,7 +6,7 @@ from weaverbird.steps.percentage import PercentageStep
 
 def test_simple_percentage():
     sample_df = pd.DataFrame({'values': [10, 50, 25, 15]})
-    step = PercentageStep(name='percentage', column='values', newColumnName='result')
+    step = PercentageStep(name='percentage', column='values', new_column_name='result')
     result = step.execute(sample_df)
     expected_df = pd.DataFrame({'values': [10, 50, 25, 15], 'result': [10.0, 50.0, 25.0, 15.0]})
 
@@ -17,7 +17,7 @@ def test_percentage_with_groups():
     sample_df = pd.DataFrame({'a_bool': [True, False, True, False], 'values': [50, 25, 50, 75]})
 
     step = PercentageStep(
-        name='percentage', column='values', group=['a_bool'], newColumnName='result'
+        name='percentage', column='values', group=['a_bool'], new_column_name='result'
     )
     result = step.execute(sample_df)
     expected_df = pd.DataFrame(

--- a/server/weaverbird/steps/percentage.py
+++ b/server/weaverbird/steps/percentage.py
@@ -1,6 +1,5 @@
 from typing import List
 
-import pydantic
 from pandas import DataFrame
 from pydantic import Field
 
@@ -14,10 +13,8 @@ class PercentageStep(BaseStep):
     group: List[ColumnName] = Field(default=[])
     new_column_name: ColumnName = Field(alias='newColumnName', default=None)
 
-    # we use the validator to have a default value
-    @pydantic.validator('new_column_name', pre=True, always=True)
-    def default_ts_created(cls, v, *, values):
-        return v or f'{values["column"]}_PCT'
+    class Config:
+        allow_population_by_field_name = True
 
     def execute(
         self,
@@ -25,8 +22,10 @@ class PercentageStep(BaseStep):
         domain_retriever: DomainRetriever = None,
         execute_pipeline: PipelineExecutor = None,
     ) -> DataFrame:
+        new_column_name = self.new_column_name or f'{self.column}_PCT'
+
         if len(self.group) > 0:
             sums = df.groupby(self.group)[self.column].transform('sum')
         else:
             sums = df[self.column].sum()
-        return df.assign(**{self.new_column_name: df[self.column] / sums * 100})
+        return df.assign(**{new_column_name: df[self.column] / sums * 100})


### PR DESCRIPTION
We had a weird error when using a pivot step : 

```
  File "/home/fred/tctc/weaverbird/server/weaverbird/steps/percentage.py", line 20, in default_ts_created
    return v or f'{values["column"]}_PCT'
KeyError: 'column'
```

this error is solved by using a fallback for `new_column_name` without a validator, the way I did in some other steps