### PR TITLE
chore(widget-checkbox): improve design on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### UNRELEASED
+
+## Changed
+
+- Checkboxes: hovered and checked states are more distinct visually
+
 ## [0.30.0] - 2020-11-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "prepublish": "rollup -c",
   "scripts": {
     "codecov": "codecov --token=8e0bf2da-c4b9-435f-958e-446849d0d60e --file=./coverage/coverage-final.json",
-    "lint": "eslint src/{components,lib,store}/**/*.{ts,vue} tests/**/*.ts",
+    "lint": "eslint --no-error-on-unmatched-pattern src/{components,lib,store}/**/*.{ts,vue} tests/**/*.ts",
     "lint:ci": "yarn lint --output-file lint-report.json --format json",
     "build": "yarn build-bundle",
     "build-bundle": "rollup -c",

--- a/src/components/stepforms/widgets/Checkbox.vue
+++ b/src/components/stepforms/widgets/Checkbox.vue
@@ -39,7 +39,7 @@ export default class CheckboxWidget extends Vue {
   &:focus,
   &:hover {
     &::after {
-      opacity: .3;
+      opacity: 0.3;
     }
   }
 
@@ -61,7 +61,7 @@ export default class CheckboxWidget extends Vue {
     margin-left: -18px;
     margin-right: 6px;
     margin-top: -3px;
-    opacity: .1;
+    opacity: 0.1;
     transform: rotate(-45deg);
     width: 12px;
   }

--- a/src/components/stepforms/widgets/Checkbox.vue
+++ b/src/components/stepforms/widgets/Checkbox.vue
@@ -39,7 +39,7 @@ export default class CheckboxWidget extends Vue {
   &:focus,
   &:hover {
     &::after {
-      opacity: 1;
+      opacity: .3;
     }
   }
 
@@ -61,7 +61,7 @@ export default class CheckboxWidget extends Vue {
     margin-left: -18px;
     margin-right: 6px;
     margin-top: -3px;
-    opacity: 0.25;
+    opacity: .1;
     transform: rotate(-45deg);
     width: 12px;
   }
@@ -75,6 +75,14 @@ export default class CheckboxWidget extends Vue {
   &::after {
     box-shadow: 3px -3px 0 0 $base-color inset;
     opacity: 1;
+  }
+
+  &:active,
+  &:focus,
+  &:hover {
+    &::after {
+      opacity: 1;
+    }
   }
 }
 


### PR DESCRIPTION
On hover, a checkbox check appear at opacity 100%
So when we uncheck a checkbox and stay on hover, that makes us think that it's already checked.

Take a loot at the video to better understand.

Before:
![demo (1)](https://user-images.githubusercontent.com/18734475/98712431-9659f600-2386-11eb-91da-534781f3e07f.gif)

After:
![demo](https://user-images.githubusercontent.com/18734475/98712415-8fcb7e80-2386-11eb-8063-b09073cbe3ec.gif)

