### PR TITLE
Replace the github action that install poetry

### DIFF
--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -34,7 +34,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Poetry
-      uses: dschep/install-poetry-action@v1.2
+      uses: abatilo/actions-poetry@v2.0.0
 
     - name: Cache Poetry virtualenv
       uses: actions/cache@v1

--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -8,10 +8,12 @@ on:
       - master
     paths:
       - 'server/**'
+      - '.github/workflows/ci-server.yml'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - 'server/**'
+      - '.github/workflows/ci-server.yml'
 
 jobs:
   run:


### PR DESCRIPTION
the github action used to install poetry during CI is deprecated. this PR replaces it with a new one