### PR TITLE
feat(variables): allow to flatmap array variable when contained in an other array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### UNRELEASED
 
+### Added
+- FilterStep: enable filtering with array variables in in/notin comparison
+
 ## Changed
 
 - Checkboxes: hovered and checked states are more distinct visually

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -509,7 +509,7 @@ const aloneVarsRegExp = new RegExp('^' + (_.templateSettings.interpolate as RegE
  *
  * It's based on lodash templates (which looks like embedded Ruby, but executes JavaScript),
  * with two important twists designed to avoid type-induced headaches to final users:
- * 1. If a variable is provided "alone", i.e. with no surrounding characters, then it returns the variable value untouched and not coerced to a string. 
+ * 1. If a variable is provided "alone", i.e. with no surrounding characters, then it returns the variable value untouched and not coerced to a string.
  * Examples:
  * - `exampleInterpolateFunc('<%= count %>', { count: 42 })` returns `42`
  * - `exampleInterpolateFunc('<%= 2 > 1 %>', {})` returns `true`

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -508,13 +508,16 @@ const aloneVarsRegExp = new RegExp('^' + (_.templateSettings.interpolate as RegE
  * A simple interpolate function, provided as an example.
  *
  * It's based on lodash templates (which looks like embedded Ruby, but executes JavaScript),
- * with an important twist: if a variable is provided "alone", i.e. with no surrounding
- * characters, then it returns the variable value untouched and not coerced to a string.
- *
+ * with two important twists designed to avoid type-induced headaches to final users:
+ * 1. If a variable is provided "alone", i.e. with no surrounding characters, then it returns the variable value untouched and not coerced to a string. 
  * Examples:
  * - `exampleInterpolateFunc('<%= count %>', { count: 42 })` returns `42`
  * - `exampleInterpolateFunc('<%= 2 > 1 %>', {})` returns `true`
  * - `exampleInterpolateFunc('There is <%= count %> bananas', { count: 42 })` returns `'There is 42 bananas'`
+ *
+ * 2. Inside arrays, variables that are also arrays are expanded
+ * Examples:
+ * - `exampleInterpolateFunc(['<%= roles %>'], { group: ['crewmate', 'impostor'] })` returns `['crewmate', 'impostor']` (and not `[['crewmate', 'impostor']]`)
  */
 export const exampleInterpolateFunc: InterpolateFunction = function(
   value: string | any[],
@@ -526,7 +529,7 @@ export const exampleInterpolateFunc: InterpolateFunction = function(
       `with(context) { return ${(value.match(aloneVarsRegExp) as string[])[1]} }`,
     )(context);
   } else if (Array.isArray(value)) {
-    // TODO: make doc
+    // Expand variables that are also arrays into their parent array
     return value.reduce((values, v) => {
       if (typeof v === 'string') {
         const templatedValue = exampleInterpolateFunc(v, context);

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -137,7 +137,7 @@ export function emptyState(): VQBState {
     isRequestOnGoing: false,
     variables: {},
     translator: 'mongo40',
-    interpolateFunc: (x: string, _context: ScopeContext) => x,
+    interpolateFunc: (x: string | any[], _context: ScopeContext) => x,
   };
 }
 

--- a/tests/unit/plugins.spec.ts
+++ b/tests/unit/plugins.spec.ts
@@ -1,12 +1,11 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
-import _ from 'lodash';
 import Vuex, { Store } from 'vuex';
 
 import PipelineComponent from '@/components/Pipeline.vue';
 import { DataSet } from '@/lib/dataset/';
 import { Pipeline } from '@/lib/steps';
-import { ScopeContext } from '@/lib/templating';
+import { exampleInterpolateFunc } from '@/lib/templating';
 import { VQBnamespace } from '@/store';
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 import { BackendService, backendService, servicePluginFactory } from '@/store/backend-plugin';
@@ -15,11 +14,6 @@ import { buildStateWithOnePipeline, setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
-
-function lodashInterpolate(value: string, context: ScopeContext) {
-  const compiled = _.template(value);
-  return compiled(context);
-}
 
 class DummyService implements BackendService {
   listCollections(_store: Store<any>) {
@@ -394,7 +388,7 @@ describe('backend service plugin tests', () => {
           who: 'john',
           what: 'king',
         },
-        interpolateFunc: lodashInterpolate,
+        interpolateFunc: exampleInterpolateFunc,
       }),
       [servicePluginFactory(service)],
     );
@@ -425,7 +419,7 @@ describe('backend service plugin tests', () => {
     const store = setupMockStore(
       buildStateWithOnePipeline(pipeline, {
         variables: {},
-        interpolateFunc: lodashInterpolate,
+        interpolateFunc: exampleInterpolateFunc,
       }),
       [servicePluginFactory(service)],
     );

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -6,6 +6,7 @@ describe('Pipeline interpolator', () => {
     foo: 'bar',
     egg: 'spam',
     age: 42,
+    array: [1, 2],
   };
 
   function translate(pipeline: Pipeline, context = defaultContext) {
@@ -602,6 +603,29 @@ describe('Pipeline interpolator', () => {
           column: 'bar',
           value: [11, 42, 'spam', 'hola'],
           operator: 'nin',
+        },
+      },
+    ]);
+  });
+
+  it('interpolates simple filter steps / operator "in" or "nin" with array variables flatten', () => {
+    const step: Pipeline = [
+      {
+        name: 'filter',
+        condition: {
+          column: '<%= foo %>',
+          value: [11, '<%= array %>', '<%= egg %>', 'hola'],
+          operator: 'in',
+        },
+      },
+    ];
+    expect(translate(step)).toEqual([
+      {
+        name: 'filter',
+        condition: {
+          column: 'bar',
+          value: [11, 1, 2, 'spam', 'hola'],
+          operator: 'in',
         },
       },
     ]);


### PR DESCRIPTION
For now when we use an array variable:
```[ <%= my_awesome_array %>, <%= my_awesome_string %> ]```
in an array (for step filer, $in, $nin for example ), we got:
```[ [ 'first_value',  'second_value'], 'other_value' ]```
while we want to flat this variable array:
```[ 'first_value',  'second_value', 'other_value' ]```

We need to flatmap array variables only. See exampleInterpolateFunc.
The logic will be reproduce in any projects needed