### PR TITLE
Hide unsupported steps from actions toolbar and menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Changed
 
 - Checkboxes: hovered and checked states are more distinct visually
+- Hide actions corresponding to steps that are not supported by the current translator
 
 ## [0.30.0] - 2020-11-12
 

--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -4,16 +4,37 @@
       <transition name="slide-left" mode="out-in">
         <div v-if="visiblePanel == 1">
           <div class="action-menu__panel">
-            <div class="action-menu__option" @click="openStep('rename')">Rename column</div>
-            <div class="action-menu__option" @click="openStep('duplicate')">Duplicate column</div>
-            <div class="action-menu__option" @click="createDeleteColumnStep">Delete column</div>
+            <div
+              class="action-menu__option"
+              v-if="isStepSupported('rename')"
+              @click="openStep('rename')"
+            >
+              Rename column
+            </div>
+            <div
+              class="action-menu__option"
+              v-if="isStepSupported('duplicate')"
+              @click="openStep('duplicate')"
+            >
+              Duplicate column
+            </div>
+            <div
+              class="action-menu__option"
+              v-if="isStepSupported('delete')"
+              @click="createDeleteColumnStep"
+            >
+              Delete column
+            </div>
             <div
               class="action-menu__option action-menu__option--top-bordered"
               @click="visiblePanel = 2"
             >
               Other operations
             </div>
-            <div class="action-menu__option--top-bordered">
+            <div
+              class="action-menu__option--top-bordered"
+              v-if="isStepSupported('filter') && isStepSupported('uniquegroups')"
+            >
               <ListUniqueValues
                 v-if="currentUnique"
                 :options="currentUnique.values"
@@ -40,15 +61,44 @@
             </div>
             <div
               class="action-menu__option action-menu__option--top-bordered"
+              v-if="isStepSupported('filter')"
               @click="openStep('filter')"
             >
               Filter values
             </div>
-            <div class="action-menu__option" @click="openStep('fillna')">Fill null values</div>
-            <div class="action-menu__option" @click="openStep('replace')">Replace values</div>
-            <div class="action-menu__option" @click="openStep('sort')">Sort values</div>
-            <div class="action-menu__option" @click="createUniqueGroupsStep">Get unique values</div>
-            <div class="action-menu__option" @click="openStep('statistics')">
+            <div
+              class="action-menu__option"
+              v-if="isStepSupported('fillna')"
+              @click="openStep('fillna')"
+            >
+              Fill null values
+            </div>
+            <div
+              class="action-menu__option"
+              v-if="isStepSupported('replace')"
+              @click="openStep('replace')"
+            >
+              Replace values
+            </div>
+            <div
+              class="action-menu__option"
+              v-if="isStepSupported('sort')"
+              @click="openStep('sort')"
+            >
+              Sort values
+            </div>
+            <div
+              class="action-menu__option"
+              v-if="isStepSupported('uniquegroups')"
+              @click="createUniqueGroupsStep"
+            >
+              Get unique values
+            </div>
+            <div
+              class="action-menu__option"
+              v-if="isStepSupported('statistics')"
+              @click="openStep('statistics')"
+            >
               Compute Statistics
             </div>
           </div>
@@ -100,9 +150,14 @@ export default class ActionMenu extends Vue {
   @VQBModule.Getter isEditingStep!: boolean;
   @VQBModule.Getter pipeline!: Pipeline;
   @VQBModule.Getter columnHeaders!: Pipeline;
+  @VQBModule.Getter unsupportedSteps!: PipelineStepName[];
 
   get currentUnique() {
     return (this.columnHeaders.find(hdr => hdr.name === this.columnName) as DataSetColumn).uniques;
+  }
+
+  get isStepSupported() {
+    return (stepName: PipelineStepName): boolean => !this.unsupportedSteps.includes(stepName);
   }
 
   @VQBModule.Mutation selectStep!: MutationCallbacks['selectStep'];

--- a/src/components/ActionToolbar.vue
+++ b/src/components/ActionToolbar.vue
@@ -19,13 +19,13 @@
 </template>
 <script lang="ts">
 import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 
 import { PipelineStepName } from '@/lib/steps';
 import { VQBModule } from '@/store';
 
 import ActionToolbarButton from './ActionToolbarButton.vue';
-import { ButtonDef } from './constants';
+import { ACTION_CATEGORIES, ButtonDef, CATEGORY_BUTTONS } from './constants';
 import SearchBar from './SearchBar.vue';
 
 @Component({
@@ -36,8 +36,8 @@ import SearchBar from './SearchBar.vue';
   },
 })
 export default class ActionToolbar extends Vue {
-  @Prop(Array) readonly buttons!: ButtonDef[];
   @VQBModule.State selectedColumns!: string[];
+  @VQBModule.Getter unsupportedSteps!: PipelineStepName[];
 
   isActiveActionToolbarButton = -1;
 
@@ -49,8 +49,17 @@ export default class ActionToolbar extends Vue {
     this.isActiveActionToolbarButton = index;
   }
 
+  // Filter buttons that contains at least one supported step
+  get supportedButtons(): ButtonDef[] {
+    return CATEGORY_BUTTONS.filter(categoryButton =>
+      ACTION_CATEGORIES[categoryButton.category].some(
+        action => !this.unsupportedSteps.includes(action.name),
+      ),
+    );
+  }
+
   get formattedButtons() {
-    return this.buttons.map((d, index) => {
+    return this.supportedButtons.map((d, index) => {
       let isActionToolbarMenuOpened = false;
 
       if (index === this.isActiveActionToolbarButton) {

--- a/src/components/ActionToolbarButton.vue
+++ b/src/components/ActionToolbarButton.vue
@@ -63,6 +63,7 @@ export default class ActionToolbarButton extends Vue {
   @VQBModule.Getter isEditingStep!: boolean;
   @VQBModule.Getter pipeline!: S.Pipeline;
   @VQBModule.Getter selectedColumns!: string[];
+  @VQBModule.Getter unsupportedSteps!: S.PipelineStepName[];
 
   @VQBModule.Mutation selectStep!: MutationCallbacks['selectStep'];
   @VQBModule.Mutation setPipeline!: MutationCallbacks['setPipeline'];
@@ -104,8 +105,11 @@ export default class ActionToolbarButton extends Vue {
     this.selectStep({ index });
   }
 
+  // Filter out unsupported steps
   get items() {
-    return ACTION_CATEGORIES[this.category];
+    return ACTION_CATEGORIES[this.category].filter(
+      action => !this.unsupportedSteps.includes(action.name),
+    );
   }
 }
 </script>

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="data-viewer" v-if="pipeline">
-    <ActionToolbar :buttons="buttons" @actionClicked="openStepForm" />
+    <ActionToolbar @actionClicked="openStepForm" />
     <div v-if="isLoading.dataset" class="data-viewer-loader-spinner" />
     <div v-if="!isEmpty && !isLoading.dataset" class="data-viewer-container">
       <div class="data-viewer-table-container">
@@ -81,7 +81,6 @@ import { VQBModule } from '@/store';
 
 import ActionMenu from './ActionMenu.vue';
 import ActionToolbar from './ActionToolbar.vue';
-import { CATEGORY_BUTTONS } from './constants';
 import DataTypesMenu from './DataTypesMenu.vue';
 import DataViewerCell from './DataViewerCell.vue';
 
@@ -148,10 +147,6 @@ export default class DataViewer extends Vue {
 
   get columnNames(): string[] {
     return this.formattedColumns.map(({ name }: { name: string }) => name);
-  }
-
-  get buttons() {
-    return CATEGORY_BUTTONS;
   }
 
   get iconClass() {

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -18,9 +18,8 @@
 import Multiselect from 'vue-multiselect';
 import { Component, Vue } from 'vue-property-decorator';
 
-import { getTranslator } from '@/lib/translators';
+import { PipelineStepName } from '@/lib/steps';
 
-import { PipelineStepName } from '../lib/steps';
 import { VQBModule } from '../store';
 import { SEARCH_ACTION } from './constants';
 
@@ -32,12 +31,12 @@ import { SEARCH_ACTION } from './constants';
 })
 export default class SearchBar extends Vue {
   @VQBModule.Getter translator!: string;
+  @VQBModule.Getter unsupportedSteps!: PipelineStepName[];
 
   get actionOptions() {
-    const unsupportedSteps = getTranslator(this.translator).unsupportedSteps;
     return SEARCH_ACTION.map(e => ({
       ...e,
-      actions: e.actions.filter(a => !unsupportedSteps.includes(a.name)),
+      actions: e.actions.filter(a => !this.unsupportedSteps.includes(a.name)),
     }));
   }
 

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -4,6 +4,7 @@
 import _ from 'lodash';
 import { GetterTree } from 'vuex';
 
+import { getTranslator } from '@/lib/translators';
 import { getPipelineNamesReferencing } from '@/store/utils/dereference-pipeline';
 
 import { activePipeline, currentPipeline, inactivePipeline, VQBState } from './state';
@@ -129,6 +130,10 @@ const getters: GetterTree<VQBState, any> = {
    * Return the app translator name
    */
   translator: (state: VQBState) => state.translator,
+  /**
+   * Return the unsupported steps by the current translator
+   */
+  unsupportedSteps: (state: VQBState) => getTranslator(state.translator).unsupportedSteps,
 };
 
 export default getters;

--- a/tests/unit/action-toolbar-button.spec.ts
+++ b/tests/unit/action-toolbar-button.spec.ts
@@ -69,6 +69,7 @@ describe('ActionToolbarButton not active', () => {
     const wrapper = mount(ActionToolbarButton, {
       propsData: { category: 'add', label: 'toto', icon: 'plop' },
       localVue,
+      store: setupMockStore(),
     });
     expect(wrapper.find('.action-toolbar__btn-txt').text()).toEqual('toto');
     expect(wrapper.find('.fa-plop').exists()).toBeTruthy();
@@ -78,6 +79,7 @@ describe('ActionToolbarButton not active', () => {
     const wrapper = mount(ActionToolbarButton, {
       propsData: { category: 'add' },
       localVue,
+      store: setupMockStore(),
     });
     expect(wrapper.find(Popover).vm.$props.visible).toBeFalsy();
   });
@@ -88,6 +90,7 @@ describe('ActionToolbarButton active', () => {
     const wrapper = mount(ActionToolbarButton, {
       propsData: { isActive: true, category: 'add' },
       localVue,
+      store: setupMockStore(),
     });
     expect(wrapper.exists()).toBeTruthy();
     assertMenuEmitsExpected(wrapper, ['text', 'formula', 'ifthenelse', 'custom']);
@@ -97,6 +100,7 @@ describe('ActionToolbarButton active', () => {
     const wrapper = mount(ActionToolbarButton, {
       propsData: { isActive: true, category: 'filter' },
       localVue,
+      store: setupMockStore(),
     });
     expect(wrapper.exists()).toBeTruthy();
     assertMenuEmitsExpected(wrapper, ['delete', 'select', 'filter', 'top', 'argmax', 'argmin']);
@@ -106,6 +110,7 @@ describe('ActionToolbarButton active', () => {
     const wrapper = mount(ActionToolbarButton, {
       propsData: { isActive: true, category: 'compute' },
       localVue,
+      store: setupMockStore(),
     });
     expect(wrapper.exists()).toBeTruthy();
     assertMenuEmitsExpected(wrapper, [
@@ -136,6 +141,25 @@ describe('ActionToolbarButton active', () => {
       'substring',
       '!lowercase',
       '!uppercase',
+    ]);
+  });
+
+  it('should not display unsupported steps', () => {
+    // the pandas translator doesn't support custom steps
+    const store = setupMockStore(
+      buildStateWithOnePipeline([], { selectedColumns: ['foo'], translator: 'pandas' }),
+    );
+    const wrapper = mount(ActionToolbarButton, {
+      propsData: { isActive: true, category: 'add' },
+      localVue,
+      store,
+    });
+    expect(wrapper.exists()).toBeTruthy();
+    assertMenuEmitsExpected(wrapper, [
+      'text',
+      'formula',
+      'ifthenelse',
+      // not 'custom'
     ]);
   });
 
@@ -175,6 +199,7 @@ describe('ActionToolbarButton active', () => {
     const wrapper = mount(ActionToolbarButton, {
       propsData: { isActive: true, category: 'aggregate' },
       localVue,
+      store: setupMockStore(),
     });
     expect(wrapper.exists()).toBeTruthy();
     assertMenuEmitsExpected(wrapper, ['aggregate', 'totals', 'rollup', 'uniquegroups']);
@@ -184,6 +209,7 @@ describe('ActionToolbarButton active', () => {
     const wrapper = mount(ActionToolbarButton, {
       propsData: { isActive: true, category: 'reshape' },
       localVue,
+      store: setupMockStore(),
     });
     expect(wrapper.exists()).toBeTruthy();
     assertMenuEmitsExpected(wrapper, ['pivot', 'unpivot', 'waterfall']);
@@ -193,6 +219,7 @@ describe('ActionToolbarButton active', () => {
     const wrapper = mount(ActionToolbarButton, {
       propsData: { isActive: true, category: 'combine' },
       localVue,
+      store: setupMockStore(),
     });
     expect(wrapper.exists()).toBeTruthy();
     assertMenuEmitsExpected(wrapper, ['append', 'join']);

--- a/tests/unit/action-toolbar.spec.ts
+++ b/tests/unit/action-toolbar.spec.ts
@@ -16,8 +16,8 @@ describe('ActionToolbar', () => {
       propsData: {
         buttons: CATEGORY_BUTTONS,
       },
-      store: setupMockStore({}),
       localVue,
+      store: setupMockStore({}),
     });
     const actionButtons = wrapper.findAll(ActionToolbarButton);
     expect(actionButtons.length).toEqual(8);
@@ -50,6 +50,8 @@ describe('ActionToolbar', () => {
           },
         ],
       },
+      localVue,
+      store: setupMockStore(),
     });
     const actionButtons = wrapper.findAll('action-toolbar-button-stub');
     const button = actionButtons.at(0);
@@ -67,6 +69,8 @@ describe('ActionToolbar', () => {
           },
         ],
       },
+      localVue,
+      store: setupMockStore(),
     });
     const actionButtons = wrapper.findAll('action-toolbar-button-stub');
     const button = actionButtons.at(0);
@@ -92,6 +96,8 @@ describe('ActionToolbar', () => {
           },
         ],
       },
+      localVue,
+      store: setupMockStore(),
     });
     const actionButtons = wrapper.findAll('action-toolbar-button-stub');
     const button1 = actionButtons.at(0);
@@ -115,6 +121,8 @@ describe('ActionToolbar', () => {
           },
         ],
       },
+      localVue,
+      store: setupMockStore(),
     });
     const searchBar = wrapper.findAll('search-bar-stub');
     expect(searchBar.exists()).toBeTruthy();

--- a/tests/unit/search-bar.spec.ts
+++ b/tests/unit/search-bar.spec.ts
@@ -16,7 +16,7 @@ describe('SearchBar', () => {
     expect(multiselect.length).toEqual(1);
   });
 
-  it('should have the right options for mong36 translator', () => {
+  it('should have the right options for mongo36 translator', () => {
     const store = setupMockStore({ translator: 'mongo36' });
     const wrapper = shallowMount(SearchBar, {
       store,
@@ -26,53 +26,11 @@ describe('SearchBar', () => {
     const multiselectOptions = new Set(
       multiselect.props('options').flatMap((e: ActionCategories) => e.actions.map(e => e.name)),
     );
-    const expectedOptions = new Set([
-      'delete',
-      'select',
-      'filter',
-      'top',
-      'argmax',
-      'argmin',
-      'dateextract',
-      'formula',
-      'percentage',
-      'aggregate',
-      'todate',
-      'fromdate',
-      'pivot',
-      'unpivot',
-      'concatenate',
-      'split',
-      'statistics',
-      'substring',
-      'text',
-      'lowercase',
-      'uppercase',
-      'duplicate',
-      'fillna',
-      'rename',
-      'replace',
-      'sort',
-      'append',
-      'join',
-      'custom',
-      'uniquegroups',
-      'rollup',
-      'evolution',
-      'cumsum',
-      'ifthenelse',
-      'rank',
-      'waterfall',
-      'totals',
-      'addmissingdates',
-      'movingaverage',
-      'duration',
-    ]);
-    expect(multiselectOptions).toEqual(expectedOptions);
+    expect(multiselectOptions).not.toContain('cast');
   });
 
-  it('should have the right options for mongo40 translator', () => {
-    const store = setupMockStore({ translator: 'mongo40' });
+  it('should have the right options for pandas translator', () => {
+    const store = setupMockStore({ translator: 'pandas' });
     const wrapper = shallowMount(SearchBar, {
       store,
       localVue,
@@ -81,50 +39,7 @@ describe('SearchBar', () => {
     const multiselectOptions = new Set(
       multiselect.props('options').flatMap((e: ActionCategories) => e.actions.map(e => e.name)),
     );
-    const expectedOptions = new Set([
-      'delete',
-      'select',
-      'filter',
-      'top',
-      'argmax',
-      'argmin',
-      'dateextract',
-      'formula',
-      'percentage',
-      'aggregate',
-      'todate',
-      'fromdate',
-      'pivot',
-      'unpivot',
-      'concatenate',
-      'split',
-      'statistics',
-      'substring',
-      'text',
-      'lowercase',
-      'uppercase',
-      'duplicate',
-      'fillna',
-      'rename',
-      'replace',
-      'sort',
-      'convert',
-      'append',
-      'join',
-      'custom',
-      'uniquegroups',
-      'rollup',
-      'evolution',
-      'cumsum',
-      'ifthenelse',
-      'rank',
-      'waterfall',
-      'totals',
-      'addmissingdates',
-      'movingaverage',
-      'duration',
-    ]);
-    expect(multiselectOptions).toEqual(expectedOptions);
+    expect(multiselectOptions).not.toContain('custom');
   });
 
   it('should display the right option into multiselect', () => {

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -342,6 +342,13 @@ describe('getter tests', () => {
       expect(getters.translator(state, {}, {}, {})).toEqual('mongo40');
     });
   });
+
+  describe('unsupportedSteps', () => {
+    it('should return the list of steps not supported by the translator', () => {
+      const state = buildState({ translator: 'mongo36' });
+      expect(getters.unsupportedSteps(state, {}, {}, {})).toEqual(['convert']);
+    });
+  });
 });
 
 describe('mutation tests', () => {


### PR DESCRIPTION
Depending on the current translator:

| pandas | mongo40|
|--|--|
| ![Screenshot from 2020-11-20 11-00-14](https://user-images.githubusercontent.com/932583/99787690-59c59180-2b20-11eb-8432-90392aa0143b.png) | ![Screenshot from 2020-11-20 11-00-10](https://user-images.githubusercontent.com/932583/99787691-5a5e2800-2b20-11eb-9ea3-9a329d3cc7e9.png) |
| ![Screenshot from 2020-11-20 10-59-43](https://user-images.githubusercontent.com/932583/99787736-6813ad80-2b20-11eb-8b46-c0c5a11307a5.png) | ![Screenshot from 2020-11-20 10-59-46](https://user-images.githubusercontent.com/932583/99787734-677b1700-2b20-11eb-9890-fd3a2c7bed2d.png)  |
| ![Screenshot from 2020-11-20 10-19-43](https://user-images.githubusercontent.com/932583/99787816-824d8b80-2b20-11eb-98fe-a9798fc3032c.png)| ![Screenshot from 2020-11-20 10-19-48](https://user-images.githubusercontent.com/932583/99787815-81b4f500-2b20-11eb-93cf-2fb43ed35069.png) |
