### PR TITLE
docs: missing slash is breaking a link on project website nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,20 @@ generate the corresponding documentation in the `dist/docs` directory.
 
 > The web documentation is powered by [Jekyll](https://jekyllrb.com).
 
-> You can find all the sources into the `doc-build` folder.
+> You can find all the sources into the `docs` folder.
 
 > To build and locally launch the documentation you need Ruby and gem before starting, then:
 
 ```bash
+# install ruby
+sudo apt install ruby ruby-dev
+
 # install bundler
 gem install bundler
 
 # run jekyll and a local server with dependencies :
+cd docs
+bundle install
 bundle exec jekyll serve
 ```
 

--- a/docs/_docs/tech/ui-components.md
+++ b/docs/_docs/tech/ui-components.md
@@ -1,6 +1,6 @@
 ---
 title: UI components
-permalink: /docs/ui-components
+permalink: /docs/ui-components/
 ---
 
 # UI components


### PR DESCRIPTION
The "UI components" is currently unreachable from the nav of the project website.
Probably the most interesting page of this website for someone who want to start using this project/contributing to it :grimacing: 

![image](https://user-images.githubusercontent.com/3978482/99990615-54807500-2db4-11eb-9a2d-e49e54e89021.png)
