### PR TITLE
fix(front): updateDataset can reset the preview to an empty state when pipeline is empty

### DIFF
--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -37,11 +37,21 @@ export interface BackendService {
  * While no backend service is set, this will throw errors if we try to call its methods
  */
 export const UnsetBackendService: BackendService = {
-  listCollections() {
+  listCollections(): BackendResponse<string[]> {
+    /* istanbul ignore next */
+    if (process.env.NODE_ENV === 'test') {
+      // Act like a mock during tests
+      return Promise.resolve({ data: [] });
+    }
     /* istanbul ignore next */
     throw new Error("Can't list collections because no backend service has been set");
   },
-  executePipeline() {
+  executePipeline(): BackendResponse<DataSet> {
+    /* istanbul ignore next */
+    if (process.env.NODE_ENV === 'test') {
+      // Act like a mock during tests
+      return Promise.resolve({ data: { headers: [], data: [] } });
+    }
     /* istanbul ignore next */
     throw new Error("Can't preview data because no backend service has been set");
   },

--- a/src/lib/dataset/helpers.ts
+++ b/src/lib/dataset/helpers.ts
@@ -47,7 +47,8 @@ function localUniqueStats(dataset: DataSet) {
   const columnValuesCount: Record<string, ColumnStat> = Object.fromEntries(
     colnames.map(c => [c, {}]),
   );
-  for (const [, record] of enumerate(iterateRecords(dataset))) {
+  const allRecords = enumerate(iterateRecords(dataset)) || []; // If there is no record, the enumaration will return undefined
+  for (const [, record] of allRecords) {
     for (const [colname, value] of Object.entries(record)) {
       const colRecord = columnValuesCount[colname];
       const valueStringified = JSON.stringify(value);
@@ -147,7 +148,7 @@ export function _prepareColumnStats(uniqueStatsDataset: DataSet): [string, Colum
  * incoming statistics, override the local ones.
  *
  * @param {DataSet} dataset the dataset to update
- * @param {object} uniqueStats a mapping columnname → dataset that
+ * @param {DataSet} uniqueStats a mapping columnname → dataset that
  * supposedly come from a backend.
  *
  * @return the _new_ dataset. The original one is left untouched.

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -41,9 +41,9 @@ class Actions {
     context.dispatch('updateDataset');
   }
 
-  @loading('dataset')
   async updateDataset({ commit, getters, state }: ActionContext<VQBState, any>) {
     try {
+      commit('setLoading', { type: 'dataset', isLoading: true });
       commit('toggleRequestOnGoing', { isRequestOnGoing: true });
       // No pipeline or an empty pipeline
       if (!getters.activePipeline?.length) {
@@ -84,6 +84,7 @@ class Actions {
       throw error;
     } finally {
       commit('toggleRequestOnGoing', { isRequestOnGoing: false });
+      commit('setLoading', { type: 'dataset', isLoading: false });
     }
   }
 

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -716,7 +716,7 @@ describe('action tests', () => {
         executePipeline: jest.fn().mockResolvedValue({ data: dummyDataset }),
       });
     });
-    it('should throw an error if pipeline is empty if pipeline is empty', async () => {
+    it('should reset the preview if the pipeline is empty', async () => {
       const store = setupMockStore({
         ...buildStateWithOnePipeline([] as Pipeline),
         backendService: instantiateDummyService(),
@@ -724,9 +724,12 @@ describe('action tests', () => {
       const commitSpy = jest.spyOn(store, 'commit');
       await store.dispatch(VQBnamespace('updateDataset'));
       expect(commitSpy).toHaveBeenCalledWith(
-        VQBnamespace('logBackendMessages'),
+        VQBnamespace('setDataset'),
         {
-          backendMessages: [{ message: 'Error: pipeline should not be empty', type: 'error' }],
+          dataset: {
+            headers: [],
+            data: [],
+          },
         },
         undefined,
       );


### PR DESCRIPTION
This will avoid the horrible "pipeline is empty" when instantiating the component.