### PR TITLE
test(front): fix coverage of an excluded catch block

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -70,6 +70,7 @@ class Actions {
       }
       return response;
     } catch (error) {
+      /* istanbul ignore next */
       const response = { error: [{ type: 'error', message: error.toString() }] };
       // Avoid spamming tests results with errors, but could be useful in production
       /* istanbul ignore next */


### PR DESCRIPTION
Sorry to have broken it in the first place :/
Too bad we can't ignore a complete catch block