### PR TITLE
fix(fillna-step): use undefined as column default and add error when columns length is < 1

### DIFF
--- a/src/components/stepforms/FillnaStepForm.vue
+++ b/src/components/stepforms/FillnaStepForm.vue
@@ -45,7 +45,10 @@ import MultiselectWidget from './widgets/Multiselect.vue';
 export default class FillnaStepForm extends BaseStepForm<FillnaStep> {
   stepname: PipelineStepName = 'fillna';
 
-  @Prop({ type: Object, default: () => ({ name: 'fillna', column: [''], value: '' }) })
+  @Prop({
+    type: Object,
+    default: () => ({ name: 'fillna', column: undefined, value: '', columns: [] }),
+  })
   initialStepValue!: FillnaStep;
 
   @VQBModule.Getter columnTypes!: ColumnTypeMapping;

--- a/src/components/stepforms/schemas/fillna.ts
+++ b/src/components/stepforms/schemas/fillna.ts
@@ -21,6 +21,7 @@ export default {
         type: 'string',
         minLength: 1,
       },
+      minItems: 1,
       title: 'Columns in which to fill null values',
       description: 'Columns in which to fill null values',
       attrs: { placeholder: 'Select a column' },

--- a/tests/unit/fillna-step-form.spec.ts
+++ b/tests/unit/fillna-step-form.spec.ts
@@ -26,6 +26,22 @@ describe('Fillna Step Form', () => {
     },
   ]);
 
+  runner.testValidationErrors([
+    {
+      testlabel: 'should NOT have fewer than 1 items',
+      store: setupMockStore({
+        dataset: {
+          headers: [{ name: 'columnA' }],
+          data: [[null]],
+        },
+      }),
+      data: {
+        editedStep: { name: 'fillna', columns: [], value: 'bar' },
+      },
+      errors: [{ dataPath: '.columns', keyword: 'minItems' }],
+    },
+  ]);
+
   runner.testValidate({
     store: setupMockStore({
       dataset: {
@@ -102,7 +118,6 @@ describe('Fillna Step Form', () => {
     expect(wrapper.vm.$data.editedStep.columns).toBeDefined;
     expect(wrapper.vm.$data.editedStep.columns).toEqual(['hello']);
   });
-
   it('should pass down the value prop to widget multiselect', async () => {
     const wrapper = runner.shallowMount();
     wrapper.setData({ editedStep: { columns: ['foo'], value: '' } });


### PR DESCRIPTION
In previous PR: https://github.com/ToucanToco/weaverbird/pull/648,
We setted the column default value in filterStep equal to 
```
['']
```
So it displayed the value in multiselect as a selected column (because we considered that column was always a string so we included it into an array ).
We need to use undefined as default

Also added a minItems validation to schema and tests to validate that columns has at least one item selected

Before:
![before](https://user-images.githubusercontent.com/59559689/100603598-a3bf2c00-3305-11eb-8974-2b7a93318970.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/100603609-a752b300-3305-11eb-8dd5-ceae00d416cd.gif)
