### PR TITLE
fix(helpers): handle "long" as number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
     "url": "https://github.com/ToucanToco/weaverbird/issues",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 # sonar.projectName=weaverbird
-sonar.projectVersion=0.33.0
+sonar.projectVersion=0.33.1
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./src

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -186,6 +186,8 @@ export default class DataViewer extends Vue {
         return 'ABC';
       case 'integer':
         return '123';
+      case 'long':
+        return '123';
       case 'float':
         return '1.2';
       case 'date':

--- a/src/lib/dataset/index.ts
+++ b/src/lib/dataset/index.ts
@@ -4,7 +4,14 @@
 import { ColumnValueStat } from './helpers';
 import { PaginationContext } from './pagination';
 
-export type DataSetColumnType = 'integer' | 'float' | 'boolean' | 'string' | 'date' | 'object';
+export type DataSetColumnType =
+  | 'integer'
+  | 'float'
+  | 'long'
+  | 'boolean'
+  | 'string'
+  | 'date'
+  | 'object';
 export type ColumnTypeMapping = {
   [col: string]: DataSetColumnType | undefined;
 };

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -27,7 +27,7 @@ function isBooleanString(string: string): boolean {
  * @returns a boolean to determine if the value can be connverted to a number
  */
 export function castFromString(value: string, type: DataSetColumnType) {
-  if ((type === 'integer' || type === 'float') && value !== null && !isNaN(Number(value))) {
+  if (['integer', 'float', 'long'].includes(type) && value !== null && !isNaN(Number(value))) {
     return Number(value);
   } else if (type === 'boolean' && isBooleanString(value)) {
     return value === 'true' || value === 'True' || value === 'TRUE' || value === '1';

--- a/tests/unit/data-viewer.spec.ts
+++ b/tests/unit/data-viewer.spec.ts
@@ -187,11 +187,12 @@ describe('Data Viewer', () => {
             headers: [
               { name: 'columnA', type: 'string' },
               { name: 'columnB', type: 'integer' },
-              { name: 'columnC', type: 'float' },
-              { name: 'columnD', type: 'date' },
-              { name: 'columnE', type: 'object' },
-              { name: 'columnF', type: 'boolean' },
-              { name: 'columnG', type: undefined },
+              { name: 'columnC', type: 'long' },
+              { name: 'columnD', type: 'float' },
+              { name: 'columnE', type: 'date' },
+              { name: 'columnF', type: 'object' },
+              { name: 'columnG', type: 'boolean' },
+              { name: 'columnH', type: undefined },
             ],
             data: [['value1', 42, 3.14, date, { obj: 'value' }, true]],
             paginationContext: {
@@ -207,21 +208,22 @@ describe('Data Viewer', () => {
       const headerIconsWrapper = wrapper.findAll('.data-viewer__header-icon');
       expect(headerIconsWrapper.at(0).text()).toEqual('ABC');
       expect(headerIconsWrapper.at(1).text()).toEqual('123');
-      expect(headerIconsWrapper.at(2).text()).toEqual('1.2');
+      expect(headerIconsWrapper.at(2).text()).toEqual('123');
+      expect(headerIconsWrapper.at(3).text()).toEqual('1.2');
       expect(
         headerIconsWrapper
-          .at(3)
+          .at(4)
           .find('i')
           .classes(),
       ).toEqual(['fas', 'fa-calendar-alt']);
-      expect(headerIconsWrapper.at(4).text()).toEqual('{ }');
+      expect(headerIconsWrapper.at(5).text()).toEqual('{ }');
       expect(
         headerIconsWrapper
-          .at(5)
+          .at(6)
           .find('i')
           .classes(),
       ).toEqual(['fas', 'fa-check']);
-      expect(headerIconsWrapper.at(6).text()).toEqual('???');
+      expect(headerIconsWrapper.at(7).text()).toEqual('???');
     });
 
     it('should have a action menu for each column', async () => {


### PR DESCRIPTION
Sometimes the backend sends `long` as a dataset column type. It should be handled as an integer.

More context https://toucantoco.slack.com/archives/CSB3AEZPB/p1606816746228100