### PR TITLE
fix(filter-condition): dont cast undefined value when add group or condition

### DIFF
--- a/src/components/ConditionsEditor/ConditionsEditor.vue
+++ b/src/components/ConditionsEditor/ConditionsEditor.vue
@@ -62,6 +62,9 @@ export default class ConditionsEditor extends Vue {
   })
   conditionsTree!: AbstractFilterTree;
 
+  @Prop()
+  defaultValue!: any;
+
   updateConditionsTree(newConditionsTree: AbstractFilterTree) {
     this.$emit('conditionsTreeUpdated', newConditionsTree);
   }

--- a/src/components/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/ConditionsEditor/ConditionsGroup.vue
@@ -129,6 +129,9 @@ export default class ConditionsGroup extends Vue {
   })
   conditionsTree!: AbstractFilterTree;
 
+  @Prop()
+  defaultValue!: any;
+
   @Prop({
     type: Boolean,
     default: false,
@@ -161,8 +164,7 @@ export default class ConditionsGroup extends Vue {
     const newGroups = this.conditionsTree.groups || [];
     newGroups.push({
       operator: 'and',
-      // Pass undefined values to force FilterSimpleCondition to use its default condition prop value
-      conditions: [undefined],
+      conditions: [this.defaultValue],
       groups: [],
     });
 
@@ -179,8 +181,7 @@ export default class ConditionsGroup extends Vue {
   addRow() {
     const newConditionsTree = {
       ...this.conditionsTree,
-      // Pass undefined value to force FilterSimpleCondition to use its default condition prop value
-      conditions: [...this.conditions, undefined],
+      conditions: [...this.conditions, this.defaultValue],
     } as AbstractFilterTree;
 
     this.setOperatorIfNecessaryAndUpdateConditionTree(newConditionsTree);

--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="filter-editor">
-    <ConditionsEditor :conditions-tree="conditionsTree" @conditionsTreeUpdated="updateFilterTree">
+    <ConditionsEditor
+      :conditions-tree="conditionsTree"
+      @conditionsTreeUpdated="updateFilterTree"
+      :defaultValue="defaultValue"
+    >
       <template v-slot:default="slotProps">
         <FilterSimpleConditionWidget
           :value="slotProps.condition || undefined"
@@ -28,7 +32,9 @@ import {
   buildFilterStepTree,
   castFilterStepTreeValue,
 } from '@/components/stepforms/convert-filter-step-tree.ts';
-import FilterSimpleConditionWidget from '@/components/stepforms/widgets/FilterSimpleCondition.vue';
+import FilterSimpleConditionWidget, {
+  DEFAULT_FILTER,
+} from '@/components/stepforms/widgets/FilterSimpleCondition.vue';
 import { ColumnTypeMapping } from '@/lib/dataset/index.ts';
 import { FilterCondition } from '@/lib/steps';
 import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
@@ -67,6 +73,8 @@ export default class FilterEditor extends Vue {
     default: () => [],
   })
   errors!: ErrorObject[];
+
+  readonly defaultValue = DEFAULT_FILTER;
 
   get conditionsTree() {
     return buildConditionsEditorTree(castFilterStepTreeValue(this.filterTree, this.columnTypes));

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -78,7 +78,7 @@ type OperatorOption = {
   inputWidget?: VueConstructor<Vue>;
 };
 
-const DEFAULT_FILTER = { column: '', value: '', operator: 'eq' };
+export const DEFAULT_FILTER = { column: '', value: '', operator: 'eq' };
 
 @Component({
   name: 'filter-simple-condition-widget',


### PR DESCRIPTION
When creating a condition or a group in filter step, there is a short time where condition is undefined (it's updated by default of FilterEditor on init ). Under this short time we don't want the undefined value to be casted.