### PR TITLE
fix(front): column types in filter step and ifthenelse step

### DIFF
--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -7,6 +7,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :columnTypes="columnTypes"
       @filterTreeUpdated="updateFilterTree"
     />
     <StepFormButtonbar />
@@ -18,6 +19,7 @@ import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
 
 import FilterEditor from '@/components/FilterEditor.vue';
+import { ColumnTypeMapping } from '@/lib/dataset';
 import { FilterCondition, FilterSimpleCondition, FilterStep, PipelineStepName } from '@/lib/steps';
 import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 import { VQBModule } from '@/store';
@@ -43,8 +45,9 @@ export default class FilterStepForm extends BaseStepForm<FilterStep> {
   initialStepValue!: FilterStep;
 
   @VQBModule.State availableVariables?: VariablesBucket;
-
   @VQBModule.State variableDelimiters?: VariableDelimiters;
+
+  @VQBModule.Getter columnTypes!: ColumnTypeMapping;
 
   readonly title: string = 'Filter';
 

--- a/src/components/stepforms/IfThenElseStepForm.vue
+++ b/src/components/stepforms/IfThenElseStepForm.vue
@@ -16,6 +16,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :column-types="columnTypes"
       @input="updateIfThenElse"
     />
     <StepFormButtonbar />
@@ -29,6 +30,7 @@ import { Prop } from 'vue-property-decorator';
 
 import IfThenElseWidget from '@/components/stepforms/widgets/IfThenElseWidget.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
+import { ColumnTypeMapping } from '@/lib/dataset';
 import { IfThenElseStep, PipelineStepName } from '@/lib/steps';
 import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 import { VQBModule } from '@/store';
@@ -46,8 +48,9 @@ export default class IfThenElseStepForm extends BaseStepForm<IfThenElseStep> {
   stepname: PipelineStepName = 'ifthenelse';
 
   @VQBModule.State availableVariables?: VariablesBucket;
-
   @VQBModule.State variableDelimiters?: VariableDelimiters;
+
+  @VQBModule.Getter columnTypes!: ColumnTypeMapping;
 
   @Prop({
     type: Object,

--- a/src/components/stepforms/widgets/IfThenElseWidget.vue
+++ b/src/components/stepforms/widgets/IfThenElseWidget.vue
@@ -163,7 +163,11 @@ export default class IfThenElseWidget extends Vue {
   })
   errors!: ErrorObject[];
 
-  @VQBModule.Getter columnTypes!: ColumnTypeMapping;
+  @Prop({
+    type: Object,
+    default: () => {},
+  })
+  columnTypes!: ColumnTypeMapping;
 
   readonly title: string = 'Add a conditional column';
   collapsed = false;

--- a/src/components/stepforms/widgets/IfThenElseWidget.vue
+++ b/src/components/stepforms/widgets/IfThenElseWidget.vue
@@ -29,6 +29,7 @@
           :data-path="`${dataPath}.if`"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
+          :column-types="columnTypes"
           @filterTreeUpdated="updateFilterTree"
         />
       </div>
@@ -93,6 +94,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :column-types="columnTypes"
       @input="updateElseFormula"
       @deletedElseIf="transformElseIfIntoElse"
     />
@@ -121,7 +123,6 @@ import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import { ColumnTypeMapping } from '@/lib/dataset';
 import { FilterCondition, Formula, IfThenElseStep } from '@/lib/steps';
 import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
-import { VQBModule } from '@/store';
 
 @Component({
   name: 'ifthenelse-widget',

--- a/tests/unit/.eslintrc.js
+++ b/tests/unit/.eslintrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  env: {
-    jest: true
-  }
-}

--- a/tests/unit/filter-step-form.spec.ts
+++ b/tests/unit/filter-step-form.spec.ts
@@ -1,3 +1,5 @@
+import { Wrapper } from '@vue/test-utils';
+
 import FilterStepForm from '@/components/stepforms/FilterStepForm.vue';
 
 import { BasicStepFormTestRunner, setupMockStore } from './utils';
@@ -54,20 +56,39 @@ describe('Filter Step Form', () => {
   runner.testResetSelectedIndex();
 
   describe('FilterEditor', () => {
-    it('should pass down the "filter-tree" prop to the FilterEditor value prop', async () => {
-      const wrapper = runner.shallowMount(undefined, {
-        data: {
-          editedStep: {
-            name: 'filter',
-            condition: { column: 'foo', value: 'bar', operator: 'gt' },
+    let wrapper: Wrapper<FilterStepForm>;
+
+    beforeEach(async () => {
+      wrapper = runner.shallowMount(
+        {
+          dataset: {
+            headers: [{ name: 'foo', type: 'string' }],
+            data: [[null]],
           },
         },
-      });
+        {
+          data: {
+            editedStep: {
+              name: 'filter',
+              condition: { column: 'foo', value: 'bar', operator: 'gt' },
+            },
+          },
+        },
+      );
       await wrapper.vm.$nextTick();
+    });
+
+    it('should pass down the "filter-tree" prop to the FilterEditor value prop', () => {
       expect(wrapper.find('FilterEditor-stub').props().filterTree).toEqual({
         column: 'foo',
         value: 'bar',
         operator: 'gt',
+      });
+    });
+
+    it('should pass down the columnTypes to the FilterEditor', () => {
+      expect(wrapper.find('FilterEditor-stub').props().columnTypes).toStrictEqual({
+        foo: 'string',
       });
     });
   });

--- a/tests/unit/ifthenelse-step-form.spec.ts
+++ b/tests/unit/ifthenelse-step-form.spec.ts
@@ -132,6 +132,18 @@ describe.only('If...Then...Else Step Form', () => {
     });
   });
 
+  it('should pass the column types to the IfThenElse widget', () => {
+    const wrapper = runner.shallowMount({
+      dataset: {
+        headers: [{ name: 'foo', type: 'string' }],
+        data: [],
+      },
+    });
+    expect(wrapper.find('IfThenElseWidget-stub').props().columnTypes).toStrictEqual({
+      foo: 'string',
+    });
+  });
+
   it('should update editedStep with the if...then...else object', () => {
     const wrapper = runner.shallowMount(undefined, {
       data: {

--- a/tests/unit/ifthenelse-widget.spec.ts
+++ b/tests/unit/ifthenelse-widget.spec.ts
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, Wrapper } from '@vue/test-utils';
 
 import IfThenElseWidget from '@/components/stepforms/widgets/IfThenElseWidget.vue';
 
@@ -15,6 +15,43 @@ describe('IfThenElseWidget', () => {
       expect(filtereditorWrappers.length).toEqual(1);
       const inputtextWrappers = wrapper.findAll('inputtextwidget-stub');
       expect(inputtextWrappers.length).toEqual(2);
+    });
+
+    describe('columnTypes', () => {
+      let wrapper: Wrapper<IfThenElseWidget>;
+
+      beforeEach(() => {
+        wrapper = shallowMount(IfThenElseWidget, {
+          propsData: {
+            columnTypes: {
+              plop: 'string',
+              yop: 'integer',
+            },
+          },
+        });
+      });
+
+      it('should forward its columnTypes to the FilterEditor', () => {
+        expect(wrapper.find('FilterEditor-stub').props().columnTypes).toStrictEqual({
+          plop: 'string',
+          yop: 'integer',
+        });
+      });
+
+      it('should forward its columnTypes to the nested IfThenElse widgets', async () => {
+        wrapper.setProps({
+          value: {
+            if: { column: '', value: '', operator: 'eq' },
+            then: '',
+            else: { if: { column: '', value: '', operator: 'eq' }, then: '', else: '' },
+          },
+        });
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find('IfThenElse-Widget-stub').props().columnTypes).toStrictEqual({
+          plop: 'string',
+          yop: 'integer',
+        });
+      });
     });
 
     it('should be able to nest itself', () => {


### PR DESCRIPTION
Following the change of FilterStep, which now takes columnTypes as props, we now need to propagate this prop from the step form components to the FilterEditor widgets.
Note that in the IfThenElse step, there is an intermediate widget, between the step form and the FilterEditor.