### PR TITLE
fix(conditions-editor): pass the default value to ConditionsGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.33.4] - 2020-12-07
+
+### Fixed
+
+- ConditionsEditor: pass the default value to ConditionsGroup
+
 ## [0.33.3] - 2020-12-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Added
 
-- FilterEditor: add `long` as available number type 
+- FilterEditor: add `long` as available number type
 
 
 ## [0.33.0] - 2020-11-27
@@ -55,7 +55,7 @@
 ## Changed
 
 - Checkboxes: hovered and checked states are more distinct visually
-- Hide actions corresponding to steps that are not supported by the current 
+- Hide actions corresponding to steps that are not supported by the current
 
 ## [0.30.0] - 2020-11-12
 
@@ -565,6 +565,7 @@
 
 - Initial version, showtime!
 
+[0.33.4]: https://github.com/ToucanToco/weaverbird/compare/v0.33.3...v0.33.4
 [0.33.3]: https://github.com/ToucanToco/weaverbird/compare/v0.33.2...v0.33.3
 [0.33.2]: https://github.com/ToucanToco/weaverbird/compare/v0.33.1...v0.33.2
 [0.33.1]: https://github.com/ToucanToco/weaverbird/compare/v0.33.0...v0.33.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.33.3",
+  "version": "0.33.4",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
     "url": "https://github.com/ToucanToco/weaverbird/issues",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 # sonar.projectName=weaverbird
-sonar.projectVersion=0.33.3
+sonar.projectVersion=0.33.4
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./src

--- a/src/components/ConditionsEditor/ConditionsEditor.vue
+++ b/src/components/ConditionsEditor/ConditionsEditor.vue
@@ -3,7 +3,8 @@
     <ConditionsGroup
       data-path=".condition"
       :conditionsTree="conditionsTree"
-      :is-root-group="true"
+      :defaultValue="defaultValue"
+      :isRootGroup="true"
       @conditionsTreeUpdated="updateConditionsTree"
     >
       <template v-slot:default="slotProps">


### PR DESCRIPTION
@alice-sevin je pense que c'était un oubli dans https://github.com/ToucanToco/weaverbird/pull/777 mais `defaultValue` n'était pas passée de `ConditionsEditor` à son fils `ConditionsGroup`, du coup lorsqu'on cliquait sur `Add condition` ou `Add group`, `ConditionsGroup#defaultValue` était `undefined` et ça cassait `castFilterStepTreeValue`