### PR TITLE
fix: pass default value everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.33.5] - 2020-12-08
+
+### Fixed
+
+- ConditionsEditor, ConditionsGroup: pass the default value everywhere
+
 ## [0.33.4] - 2020-12-07
 
 ### Fixed
@@ -565,6 +571,7 @@
 
 - Initial version, showtime!
 
+[0.33.5]: https://github.com/ToucanToco/weaverbird/compare/v0.33.4...v0.33.5
 [0.33.4]: https://github.com/ToucanToco/weaverbird/compare/v0.33.3...v0.33.4
 [0.33.3]: https://github.com/ToucanToco/weaverbird/compare/v0.33.2...v0.33.3
 [0.33.2]: https://github.com/ToucanToco/weaverbird/compare/v0.33.1...v0.33.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.33.4",
+  "version": "0.33.5",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
     "url": "https://github.com/ToucanToco/weaverbird/issues",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 # sonar.projectName=weaverbird
-sonar.projectVersion=0.33.4
+sonar.projectVersion=0.33.5
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./src

--- a/src/components/ConditionsEditor/ConditionsEditor.vue
+++ b/src/components/ConditionsEditor/ConditionsEditor.vue
@@ -63,7 +63,9 @@ export default class ConditionsEditor extends Vue {
   })
   conditionsTree!: AbstractFilterTree;
 
-  @Prop()
+  @Prop({
+    required: true,
+  })
   defaultValue!: any;
 
   updateConditionsTree(newConditionsTree: AbstractFilterTree) {

--- a/src/components/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/ConditionsEditor/ConditionsGroup.vue
@@ -130,7 +130,9 @@ export default class ConditionsGroup extends Vue {
   })
   conditionsTree!: AbstractFilterTree;
 
-  @Prop()
+  @Prop({
+    required: true,
+  })
   defaultValue!: any;
 
   @Prop({

--- a/src/components/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/ConditionsEditor/ConditionsGroup.vue
@@ -69,6 +69,7 @@
       <ConditionsGroup
         :conditions-tree="groupConditionTree"
         :dataPath="`${dataPath}.${operator}[${groupIndex + conditions.length}]`"
+        :defaultValue="defaultValue"
         @conditionsTreeUpdated="updateGroup(groupIndex, $event)"
       >
         <template v-slot:default="slotProps">

--- a/stories/filter-editor.js
+++ b/stories/filter-editor.js
@@ -90,6 +90,7 @@ stories.add('with some variables available', () => ({
         operator: 'in',
         value: '{{ someArray }}',
       },
+      defaultValue: { column: '', value: '', operator: 'eq' },
     };
   },
 
@@ -110,8 +111,11 @@ stories.add('with some variables available', () => ({
 stories.add('Condition editor (empty slot)', () => ({
   template: `
     <div style="margin: 30px; overflow: auto">
-      <ConditionsEditor :conditions-tree="conditionsTree"
-                        @conditionsTreeUpdated="updateConditionsTree"></ConditionsEditor>
+      <ConditionsEditor
+        :conditions-tree="conditionsTree"
+        :defaultValue="defaultValue"
+        @conditionsTreeUpdated="updateConditionsTree"
+      />
       <pre style="margin-top: 30px;">{{ conditionsStringify }}</pre>
     </div>
   `,

--- a/tests/unit/conditions-editor.spec.ts
+++ b/tests/unit/conditions-editor.spec.ts
@@ -2,9 +2,11 @@ import { shallowMount } from '@vue/test-utils';
 
 import ConditionsEditor from '@/components/ConditionsEditor/ConditionsEditor.vue';
 
+const defaultValue = { column: '', operator: 'eq', value: '' };
+
 describe('ConditionsEditor', () => {
   it('should instantiate', () => {
-    const wrapper = shallowMount(ConditionsEditor);
+    const wrapper = shallowMount(ConditionsEditor, { propsData: { defaultValue } });
     expect(wrapper.exists()).toBeTruthy();
   });
 
@@ -12,6 +14,7 @@ describe('ConditionsEditor', () => {
     const wrapper = shallowMount(ConditionsEditor, {
       propsData: {
         conditionsTree: { column: 'foo', value: 'bar', operator: 'gt' },
+        defaultValue,
       },
     });
     (wrapper.vm as any).updateConditionsTree({

--- a/tests/unit/conditions-group.spec.ts
+++ b/tests/unit/conditions-group.spec.ts
@@ -7,17 +7,17 @@ let wrapper: Wrapper<Vue>;
 
 describe('ConditionsGroup', () => {
   it('should instantiate', () => {
-    const wrapper = shallowMount(ConditionsGroup);
+    wrapper = shallowMount(ConditionsGroup);
     expect(wrapper.exists()).toBeTruthy();
   });
 
   it('should not have the class "conditions-group--root"', () => {
-    const wrapper = shallowMount(ConditionsGroup);
+    wrapper = shallowMount(ConditionsGroup);
     expect(wrapper.find('.conditions-group').classes()).not.toContain('conditions-group--root');
   });
 
   it('should not display the trash button for a row when there is only one condition', () => {
-    const wrapper = shallowMount(ConditionsGroup, {
+    wrapper = shallowMount(ConditionsGroup, {
       propsData: {
         conditionsTree: {
           operator: '',
@@ -30,7 +30,7 @@ describe('ConditionsGroup', () => {
   });
 
   it('should display the trash button for a row if there is at least a group', () => {
-    const wrapper = shallowMount(ConditionsGroup, {
+    wrapper = shallowMount(ConditionsGroup, {
       propsData: {
         conditionsTree: {
           operator: 'and',
@@ -52,7 +52,7 @@ describe('ConditionsGroup', () => {
   });
 
   it('should display the trash button for a row when there is more than one condition', () => {
-    const wrapper = shallowMount(ConditionsGroup, {
+    wrapper = shallowMount(ConditionsGroup, {
       propsData: {
         conditionsTree: {
           operator: 'and',
@@ -68,7 +68,7 @@ describe('ConditionsGroup', () => {
   });
 
   it('should have the class "conditions-group__switch-button--active" on the right switch button', () => {
-    const wrapper = shallowMount(ConditionsGroup, {
+    wrapper = shallowMount(ConditionsGroup, {
       propsData: {
         conditionsTree: {
           operator: 'or',
@@ -583,7 +583,7 @@ describe('ConditionsGroup', () => {
   });
 
   it('should set the operator to "and" when the operator is empty (when setOperatorIfNecessaryAndUpdateConditionTree is called)', () => {
-    const wrapper = shallowMount(ConditionsGroup);
+    wrapper = shallowMount(ConditionsGroup);
     const newConditionsTree = {
       operator: '',
       conditions: [

--- a/tests/unit/conditions-group.spec.ts
+++ b/tests/unit/conditions-group.spec.ts
@@ -4,15 +4,16 @@ import Vue from 'vue';
 import ConditionsGroup from '@/components/ConditionsEditor/ConditionsGroup.vue';
 
 let wrapper: Wrapper<Vue>;
+const defaultValue = { column: '', operator: 'eq', value: '' };
 
 describe('ConditionsGroup', () => {
   it('should instantiate', () => {
-    wrapper = shallowMount(ConditionsGroup);
+    wrapper = shallowMount(ConditionsGroup, { propsData: { defaultValue } });
     expect(wrapper.exists()).toBeTruthy();
   });
 
   it('should not have the class "conditions-group--root"', () => {
-    wrapper = shallowMount(ConditionsGroup);
+    wrapper = shallowMount(ConditionsGroup, { propsData: { defaultValue } });
     expect(wrapper.find('.conditions-group').classes()).not.toContain('conditions-group--root');
   });
 
@@ -21,9 +22,10 @@ describe('ConditionsGroup', () => {
       propsData: {
         conditionsTree: {
           operator: '',
-          conditions: [{ column: '', operator: 'eq', value: '' }],
+          conditions: [defaultValue],
           groups: [],
         },
+        defaultValue,
       },
     });
     expect(wrapper.find('.condition-row__delete').exists()).toBeFalsy();
@@ -34,18 +36,16 @@ describe('ConditionsGroup', () => {
       propsData: {
         conditionsTree: {
           operator: 'and',
-          conditions: [{ column: '', operator: 'eq', value: '' }],
+          conditions: [defaultValue],
           groups: [
             {
               operator: 'or',
-              conditions: [
-                { column: '', operator: 'eq', value: '' },
-                { column: '', operator: 'eq', value: '' },
-              ],
+              conditions: [defaultValue, defaultValue],
               groups: [],
             },
           ],
         },
+        defaultValue,
       },
     });
     expect(wrapper.find('.condition-row__delete').exists()).toBeTruthy();
@@ -56,12 +56,10 @@ describe('ConditionsGroup', () => {
       propsData: {
         conditionsTree: {
           operator: 'and',
-          conditions: [
-            { column: '', operator: 'eq', value: '' },
-            { column: '', operator: 'eq', value: '' },
-          ],
+          conditions: [defaultValue, defaultValue],
           groups: [],
         },
+        defaultValue,
       },
     });
     expect(wrapper.find('.condition-row__delete').exists()).toBeTruthy();
@@ -75,6 +73,7 @@ describe('ConditionsGroup', () => {
           conditions: [undefined],
           groups: [],
         },
+        defaultValue,
       },
     });
     expect(wrapper.find('.conditions-group__switch-button--or').classes()).toContain(
@@ -91,6 +90,7 @@ describe('ConditionsGroup', () => {
             conditions: ['only condition'],
             groups: [undefined],
           },
+          defaultValue,
         },
       });
     });
@@ -113,6 +113,7 @@ describe('ConditionsGroup', () => {
             conditions: ['only condition'],
             groups: [undefined],
           },
+          defaultValue,
         },
       });
     });
@@ -133,6 +134,7 @@ describe('ConditionsGroup', () => {
           conditionsTree: {
             conditions: ['condition A', 'condition B'],
           },
+          defaultValue,
         },
       });
     });
@@ -182,6 +184,7 @@ describe('ConditionsGroup', () => {
               },
             ],
           },
+          defaultValue,
         },
       });
     });
@@ -267,6 +270,7 @@ describe('ConditionsGroup', () => {
               },
             ],
           },
+          defaultValue,
         },
       });
     });
@@ -292,7 +296,7 @@ describe('ConditionsGroup', () => {
               comparison: 'eq',
               value: 'tata',
             },
-            undefined,
+            defaultValue,
           ],
           groups: [
             {
@@ -334,7 +338,7 @@ describe('ConditionsGroup', () => {
               comparison: 'eq',
               value: 'toto',
             },
-            undefined,
+            defaultValue,
           ],
           groups: [],
         },
@@ -371,7 +375,7 @@ describe('ConditionsGroup', () => {
             },
             {
               operator: 'and',
-              conditions: [undefined],
+              conditions: [defaultValue],
               groups: [],
             },
           ],
@@ -408,7 +412,7 @@ describe('ConditionsGroup', () => {
           groups: [
             {
               operator: 'and',
-              conditions: [undefined],
+              conditions: [defaultValue],
               groups: [],
             },
           ],
@@ -583,7 +587,7 @@ describe('ConditionsGroup', () => {
   });
 
   it('should set the operator to "and" when the operator is empty (when setOperatorIfNecessaryAndUpdateConditionTree is called)', () => {
-    wrapper = shallowMount(ConditionsGroup);
+    wrapper = shallowMount(ConditionsGroup, { propsData: { defaultValue } });
     const newConditionsTree = {
       operator: '',
       conditions: [
@@ -646,7 +650,8 @@ describe('ConditionsGroup', () => {
     };
     wrapper = shallowMount(ConditionsGroup, {
       propsData: {
-        conditionsTree: conditionsTree,
+        conditionsTree,
+        defaultValue,
       },
     });
 
@@ -691,6 +696,7 @@ describe('ConditionsGroup', () => {
           ],
           groups: [],
         },
+        defaultValue,
       },
     });
     await (wrapper.vm as any).resetOperatorIfNecessary();
@@ -729,6 +735,7 @@ describe('ConditionsGroup', () => {
           ],
           groups: [],
         },
+        defaultValue,
       },
     });
     (wrapper.vm as any).resetOperatorIfNecessary();
@@ -755,6 +762,7 @@ describe('ConditionsGroup', () => {
             },
           ],
         },
+        defaultValue,
       },
     });
     (wrapper.vm as any).resetOperatorIfNecessary();


### PR DESCRIPTION
There was some places that were missed both in https://github.com/ToucanToco/weaverbird/pull/786 and https://github.com/ToucanToco/weaverbird/pull/777 where `defaultValue` was not passed as prop

This caused some bug in Tucana's alerts, which was using the filter editor (crash when clicking on `add group` then `add condition`)

I passed the default value everywhere, updated the tests accordingly, and made it a required prop so that we don't make the same mistake again