### PR TITLE
feat(magic-button): add mutation to populate magic config in store

### DIFF
--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -32,6 +32,11 @@ type DomainsMutation = {
   payload: Pick<VQBState, 'domains'>;
 };
 
+type MagicConfigMutation = {
+  type: 'setMagicConfig';
+  payload: Pick<VQBState, 'magicConfig'>;
+};
+
 type PipelineMutation = {
   type: 'setPipeline';
   payload: { pipeline: Pipeline };
@@ -88,6 +93,7 @@ export type StateMutation =
   | DatasetMutation
   | DeleteStepMutation
   | DomainsMutation
+  | MagicConfigMutation
   | PipelineMutation
   | SetCurrentPipelineNameMutation
   | SelectedColumnsMutation
@@ -343,6 +349,12 @@ class Mutations {
 
     // Forward them to translators
     setVariableDelimiters(variableDelimiters);
+  }
+  /**
+   * set the magic config to generate filter steps automatically based on variable/column association
+   */
+  setMagicConfig(state: VQBState, { magicConfig }: Pick<VQBState, 'magicConfig'>) {
+    state.magicConfig = magicConfig;
   }
 }
 

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -40,6 +40,11 @@ export interface VQBState {
   selectedStepIndex: number;
 
   /**
+   * magic config to automatically create filter steps for requester id / selected column association
+   */
+  magicConfig: { [name: string]: string };
+
+  /**
    * saved pipelines, with unique name as key and pipeline as value
    */
   pipelines: { [name: string]: Pipeline };
@@ -143,6 +148,7 @@ export function emptyState(): VQBState {
     translator: 'mongo40',
     backendService: UnsetBackendService,
     interpolateFunc: (x: string | any[], _context: ScopeContext) => x,
+    magicConfig: {},
   };
 }
 

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -935,4 +935,13 @@ describe('action tests', () => {
       expect(state.backendService).toEqual(backendService);
     });
   });
+
+  describe('setMagicConfig', function() {
+    it('set magic config', () => {
+      const state = buildState({});
+      const magicConfig = { 'appRequesters.report': 'col2' };
+      mutations.setMagicConfig(state, { magicConfig });
+      expect(state.magicConfig).toEqual(magicConfig);
+    });
+  });
 });


### PR DESCRIPTION
Add a mutation to populate magic config from outside of weaverbird