### PR TITLE
feat(front): add a tooltip for each column name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Tooltip for column names in DataViewer (useful for long ones that needs to be copied easily)
+
 ## [0.33.5] - 2020-12-08
 
 ### Fixed

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -36,7 +36,18 @@
                   />
                   <span v-html="getIconType(column.type)" />
                 </span>
-                <span class="data-viewer__header-label">{{ column.name }}</span>
+                <span
+                  class="data-viewer__header-label"
+                  v-tooltip.top="{
+                    targetClasses: 'has-weaverbird__tooltip',
+                    classes: 'weaverbird__tooltip',
+                    content: column.name,
+                    autoHide: false,
+                    boundariesElement: 'td',
+                    delay: { show: 500, hide: 100 },
+                  }"
+                  >{{ column.name }}</span
+                >
                 <span class="data-viewer__header-action" @click.stop="openMenu(column.name)">
                   <ActionMenu
                     :column-name="column.name"
@@ -69,6 +80,7 @@
 </template>
 <script lang="ts">
 import _ from 'lodash';
+import VTooltip from 'v-tooltip';
 import Vue from 'vue';
 import { Component, Watch } from 'vue-property-decorator';
 
@@ -83,6 +95,8 @@ import ActionMenu from './ActionMenu.vue';
 import ActionToolbar from './ActionToolbar.vue';
 import DataTypesMenu from './DataTypesMenu.vue';
 import DataViewerCell from './DataViewerCell.vue';
+
+Vue.use(VTooltip);
 
 /**
  * @name DataViewer

--- a/src/styles/utils/v-tooltip.scss
+++ b/src/styles/utils/v-tooltip.scss
@@ -6,7 +6,6 @@
   display: block;
   padding: 4px;
   z-index: 10000;
-  pointer-events: none;
 
   &[aria-hidden='true'] {
     visibility: hidden;
@@ -42,6 +41,7 @@
     line-height: 21px;
     font-size: 13px;
     font-family: 'Montserrat', sans-serif;
+    text-align: center;
   }
 
   .tooltip-inner::first-letter {

--- a/tests/unit/data-viewer.spec.ts
+++ b/tests/unit/data-viewer.spec.ts
@@ -117,32 +117,55 @@ describe('Data Viewer', () => {
       expect(headerCellsWrapper.length).toEqual(3);
     });
 
-    it("should contains column's names", () => {
-      const store = setupMockStore(
-        buildStateWithOnePipeline([], {
-          dataset: {
-            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-            data: [
-              ['value1', 'value2', 'value3'],
-              ['value4', 'value5', 'value6'],
-              ['value7', 'value8', 'value9'],
-              ['value10', 'value11', 'value12'],
-              ['value13', 'value14', 'value15'],
-            ],
-            paginationContext: {
-              totalCount: 50,
-              pagesize: 10,
-              pageno: 1,
+    describe('column names', () => {
+      let wrapper: Wrapper<DataViewer>;
+      const vTooltipStub = jest.fn();
+
+      beforeEach(() => {
+        const store = setupMockStore(
+          buildStateWithOnePipeline([], {
+            dataset: {
+              headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+              data: [
+                ['value1', 'value2', 'value3'],
+                ['value4', 'value5', 'value6'],
+                ['value7', 'value8', 'value9'],
+                ['value10', 'value11', 'value12'],
+                ['value13', 'value14', 'value15'],
+              ],
+              paginationContext: {
+                totalCount: 50,
+                pagesize: 10,
+                pageno: 1,
+              },
+            },
+          }),
+        );
+        wrapper = shallowMount(DataViewer, {
+          store,
+          localVue,
+          directives: {
+            tooltip: {
+              bind: vTooltipStub,
             },
           },
-        }),
-      );
-      const wrapper = shallowMount(DataViewer, { store, localVue });
+        });
+      });
 
-      const headerCellsWrapper = wrapper.findAll('.data-viewer__header-cell');
-      expect(headerCellsWrapper.at(0).text()).toContain('columnA');
-      expect(headerCellsWrapper.at(1).text()).toContain('columnB');
-      expect(headerCellsWrapper.at(2).text()).toContain('columnC');
+      afterEach(() => {
+        vTooltipStub.mockReset();
+      });
+
+      it("should contains column's names", () => {
+        const headerCellsWrapper = wrapper.findAll('.data-viewer__header-cell');
+        expect(headerCellsWrapper.at(0).text()).toContain('columnA');
+        expect(headerCellsWrapper.at(1).text()).toContain('columnB');
+        expect(headerCellsWrapper.at(2).text()).toContain('columnC');
+      });
+
+      it('should have a tooltip for each column', () => {
+        expect(vTooltipStub).toHaveBeenCalledTimes(3);
+      });
     });
 
     it("should contains column's names even if not on every rows", () => {


### PR DESCRIPTION
The tooltip is selectable for easy copy/paste

![Screenshot from 2020-12-14 18-37-50](https://user-images.githubusercontent.com/932583/102118999-c2164300-3e40-11eb-9ba7-ec60f2ea8a82.png)
![Screenshot from 2020-12-14 18-37-42](https://user-images.githubusercontent.com/932583/102119007-c4789d00-3e40-11eb-9fdb-e3db8311bbb4.png)
