### PR TITLE
fix(front): preview request only once when changing domain

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -97,8 +97,8 @@ export default class QueryBuilder extends Vue {
       this.setCurrentDomain({ currentDomain: step.domain });
     } else {
       this.setPipeline({ pipeline: newPipeline });
+      this.selectStep({ index });
     }
-    this.selectStep({ index });
     this.closeStepForm();
     // Reset value from DataViewer
     this.resetStepFormInitialValue();


### PR DESCRIPTION
The `selectCurrentDomain` and `selectStep` both request an update of the preview.
To avoid asking twice the work to the server, keep only the first one.