### PR TITLE
fix(mongo): fix usage of $regexMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Mongo 4.2: fix parameters passed to `$regexMatch`
+
 ## [0.34.0] - 2020-12-17
 
 ### Added

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -3693,7 +3693,7 @@ describe.each(['36', '40', '42'])(`Mongo %s translator`, version => {
             NEW_COL: {
               $cond: {
                 else: 'False',
-                if: { $regexMatch: ['$TEST_COL', '^a'] },
+                if: { $regexMatch: { input: '$TEST_COL', regex: '^a' } },
                 then: 'True',
               },
             },
@@ -3718,7 +3718,7 @@ describe.each(['36', '40', '42'])(`Mongo %s translator`, version => {
             NEW_COL: {
               $cond: {
                 else: 'False',
-                if: { $not: { $regexMatch: ['$TEST_COL', '^a'] } },
+                if: { $not: { $regexMatch: { input: '$TEST_COL', regex: '^a' } } },
                 then: 'True',
               },
             },


### PR DESCRIPTION
This is what happen when you skip reading the docs before using an operator :stuck_out_tongue: 
I've tested this against my local mongo (4.4) to be sure it works (should be the same with 4.2).