### PR TITLE
fix(if then else widget): remove z-index context on dropdowns

### DIFF
--- a/src/components/stepforms/widgets/IfThenElseWidget.vue
+++ b/src/components/stepforms/widgets/IfThenElseWidget.vue
@@ -274,7 +274,6 @@ export default class IfThenElseWidget extends Vue {
   ::v-deep .condition-row {
     background-color: #e9eff5;
   }
-  ::v-deep .multiselect,
   ::v-deep .widget-variable__toggle {
     z-index: 1; // prevent inputs to be over multiselect dropdown
   }


### PR DESCRIPTION
Fix a css bug that was preventing multiselect dropdowns inside the ifThenElse Widget to use their expected z-index because they were wrapped into another z-index context.

I insist that this issue was only affecting dropdowns inside the ifThenElse Widget, not any of the other one like the filter step widget for example.

Before :
![vqb_ifelse_dropdown_bug-before](https://user-images.githubusercontent.com/3978482/103345090-b6f22280-4a90-11eb-9c45-be446c2adb82.png)

After :  
![vqb_ifelse_dropdown_bug-after](https://user-images.githubusercontent.com/3978482/103345094-b8bbe600-4a90-11eb-9e5d-30119c108561.png)
