### PR TITLE
fix(getters): bound active step index to pipeline size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Bound active step to pipeline size to avoid ending up with no step selected in some specific cases
+
 ## [0.34.1] - 2020-12-18
 
 ### Fixed

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -39,7 +39,10 @@ const getters: GetterTree<VQBState, any> = {
     if (!pipeline) {
       return;
     }
-    return state.selectedStepIndex === -1 ? pipeline.length - 1 : state.selectedStepIndex;
+    const lastStepIndex = pipeline.length - 1;
+    return state.selectedStepIndex === -1 || state.selectedStepIndex > lastStepIndex
+      ? lastStepIndex
+      : state.selectedStepIndex;
   },
   /**
    * the first step of the pipeline. Since it's handled differently in the UI,

--- a/tests/unit/statistics-step-form.spec.ts
+++ b/tests/unit/statistics-step-form.spec.ts
@@ -45,7 +45,7 @@ describe('statistics Step Form', () => {
         },
       ],
     },
-    selectedStepIndex: 2,
+    selectedStepIndex: 1,
   });
 
   runner.testResetSelectedIndex();

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -168,6 +168,18 @@ describe('getter tests', () => {
       expect(getters.computedActiveStepIndex(state, {}, {}, {})).toEqual(2);
     });
 
+    it('should bound active step index if selectedIndex is out of bound', () => {
+      // This can happen when we externally load a pipeline smaller than the current one
+      // and selectedStepIndex !== -1 because we played with the current pipeline
+      const pipeline: Pipeline = [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', toRename: [['foo', 'bar']] },
+        { name: 'rename', toRename: [['baz', 'spam']] },
+      ];
+      const state = buildStateWithOnePipeline(pipeline, { selectedStepIndex: 8396 });
+      expect(getters.computedActiveStepIndex(state, {}, {}, {})).toEqual(2);
+    });
+
     it('should compute active step index if selectedIndex is specified', () => {
       const pipeline: Pipeline = [
         { name: 'domain', domain: 'foo' },


### PR DESCRIPTION
This PR prevent the computed active step index to end up out of bound (meaning above the pipeline length).

Side note : I'm not a fan of having a specific `selectedStepIndex` value associated with a specific meaning, here `-1 <=> pipeline.length - 1`. It seems better to me to have `selectedStepIndex` explicitly set to `pipeline.length - 1` when necessary i.e. when loading/selecting pipelines. Fortunately it's not this big of a deal :wink: 