### PR TITLE
fix(server): fix util rename_duplicated_columns

### DIFF
--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -38,13 +38,6 @@ jobs:
     - name: Install Poetry
       uses: abatilo/actions-poetry@v2.0.0
 
-    - name: Cache Poetry virtualenv
-      uses: actions/cache@v1
-      with:
-        path: ~/.virtualenvs
-        key: poetry-${{ hashFiles('**/poetry.lock') }}
-        restore-keys: poetry-${{ hashFiles('**/poetry.lock') }}
-
     - name: Configure poetry
       run: |
         poetry config virtualenvs.in-project false

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weaverbird"
-version = "0.1.2"
+version = "0.1.3"
 description = "Pandas engine for weaverbird data pipelines"
 authors = ["Toucan Toco <dev+weaverbird@toucantoco.com>"]
 license = "MIT"

--- a/server/tests/test_utils.py
+++ b/server/tests/test_utils.py
@@ -1,13 +1,56 @@
+import pytest
 from pandas import DataFrame
 
 from weaverbird.utils import rename_duplicated_columns
 
 
-def test_rename_duplicated_columns():
-    columns = ['plop', 'foo', 'bar', 'foo', 'foo', 'bar', 'plip']
+@pytest.mark.parametrize(
+    ('columns', 'expected_new_columns'),
+    [
+        (
+            ['foo'],
+            ['foo'],
+        ),
+        (
+            ['foo', 'foo'],
+            ['foo', 'foo_1'],
+        ),
+        (
+            ['foo', 'foo_1', 'foo_2', 'foo_3', 'foo'],
+            ['foo', 'foo_1', 'foo_2', 'foo_3', 'foo_4'],
+        ),
+        (
+            ['foo_1', 'foo_1'],
+            ['foo_1', 'foo_2'],
+        ),
+        (
+            ['foo_1', 'foo_1', 'foo_2'],
+            ['foo_1', 'foo_3', 'foo_2'],
+        ),
+        (
+            ['foo', 'foo', 'foo_1'],
+            ['foo', 'foo_2', 'foo_1'],
+        ),
+        (
+            ['foo', 'foo_3', 'foo'],
+            ['foo', 'foo_3', 'foo_4'],
+        ),
+        (
+            ['foo', 'foo', 'foo_5', 'foo_5'],
+            ['foo', 'foo_6', 'foo_5', 'foo_7'],
+        ),
+        (
+            ['plop', 'foo', 'bar', 'foo', 'foo', 'bar', 'plip', 'foo_2', 'bar_1'],
+            ['plop', 'foo', 'bar', 'foo_3', 'foo_4', 'bar_2', 'plip', 'foo_2', 'bar_1'],
+        ),
+    ],
+)
+def test_rename_duplicated_columns(columns, expected_new_columns):
+    # ensure there are no duplicates in the output:
+    assert len(expected_new_columns) == len(set(expected_new_columns))
+
     df = DataFrame(columns=columns)
-    assert (df.columns == columns).all()
+    assert list(df.columns) == columns
 
     df_renamed = rename_duplicated_columns(df)
-    expected_columns = ['plop', 'foo', 'bar', 'foo_1', 'foo_2', 'bar_1', 'plip']
-    assert (df_renamed.columns == expected_columns).all()
+    assert list(df_renamed.columns) == expected_new_columns

--- a/server/weaverbird/utils/cleaning.py
+++ b/server/weaverbird/utils/cleaning.py
@@ -1,3 +1,4 @@
+import re
 from collections import defaultdict
 from typing import DefaultDict
 
@@ -5,23 +6,53 @@ from pandas import DataFrame
 
 from weaverbird.types import ColumnName
 
+REGEX_COLUMN_NAME_WITH_SUFFIX = re.compile(r'(.*)_(\d+)')
+
 
 def rename_duplicated_columns(df: DataFrame) -> DataFrame:
     """
     If a dataframe has several columns with the same name,
     adds a suffix to the duplicates (_1, _2, etc.)
     (the first occurrence remains without suffix)
+    If there are already some columns suffixed with numbers
+    in the dataframe, then the new suffix numbers will start
+    after the current maximum.
+    E.g: columns ['foo', 'foo_2', 'foo'] -> ['foo', 'foo_2', 'foo_3']
 
     Processes inplace.
     """
-    cols = []
-    count: DefaultDict[ColumnName, int] = defaultdict(lambda: 0)
-    for column in df.columns:
-        nb_duplicate = count[column]
-        if nb_duplicate == 0:
-            cols.append(column)
+    old_cols = list(df.columns)
+    max_suffix: DefaultDict[ColumnName, int] = defaultdict(lambda: 0)
+
+    # First step: find the current max suffix for each column name
+    for column in old_cols:
+        if match := REGEX_COLUMN_NAME_WITH_SUFFIX.fullmatch(column):
+            column_basename, suffix = match.groups()
+            suffix = int(suffix)
         else:
-            cols.append(f'{column}_{nb_duplicate}')
-        count[column] += 1
-    df.columns = cols
+            column_basename, suffix = column, 0
+        max_suffix[column_basename] = max(max_suffix[column_basename], suffix + 1)
+
+    new_cols = []
+
+    def _find_new_name_for_column(column: str) -> str:
+        if column not in new_cols:
+            return column
+
+        if match := REGEX_COLUMN_NAME_WITH_SUFFIX.fullmatch(column):
+            column_basename, suffix = match.groups()
+            new_suffix = max_suffix[column_basename]
+        else:
+            column_basename, new_suffix = column, max_suffix[column]
+        new_column = f'{column_basename}_{new_suffix}'
+        max_suffix[column_basename] += 1  # increment the current max suffix
+        return new_column
+
+    # Second step: use this max suffix to rename the columns where needed:
+    for column in old_cols:
+        new_col = _find_new_name_for_column(column)
+        new_cols.append(new_col)
+
+    # Edit the column names (inplace):
+    df.columns = new_cols
     return df


### PR DESCRIPTION
This util had issues with input like:

```foo, foo, foo_1```

which gave:

```foo, foo_1, foo_1```
(which also contains duplicates :/)

and now gives:

```foo, foo_2, foo_1```
:ok_hand: 

**EDIT** I removed the caching of poetry's virtualenv because it caused issues :shrug: It adds maybe 1 minute duration in the python CI, but it's still the fastest of all our github checks, so imo it's not a problem (and also I'm lazy to find how to fix it properly).