### PR TITLE
fix(mongo): "not in" (`nin`) in if/then/else conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Mongo: Fix operator "not in" (`nin`) in if/then/else conditions
+
 ## [0.35.0] - 2021-01-07
 
 ### Fixed

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -269,7 +269,7 @@ function buildCondExpression(
     gt: '$gt',
     ge: '$gte',
     in: '$in',
-    nin: '$nin',
+    nin: '$in',
     isnull: '$eq',
     notnull: '$ne',
     matches: '$regexMatch',
@@ -309,9 +309,14 @@ function buildCondExpression(
     }
     return condExpression;
   } else {
-    return {
+    let condExpression: MongoStep = {
       [operatorMapping[cond.operator]]: [$$(cond.column), cond.value],
     };
+    // There is not 'not in' operator
+    if (cond.operator === 'nin') {
+      condExpression = { $not: condExpression };
+    }
+    return condExpression;
   }
 }
 

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -3454,6 +3454,35 @@ describe.each(['36', '40', '42'])(`Mongo %s translator`, version => {
     ]);
   });
 
+  it('can generate an ifthenelse step with `not in` operator', () => {
+    const pipeline: Pipeline = [
+      {
+        name: 'ifthenelse',
+        newColumn: 'NEW_COL',
+        if: {
+          and: [{ column: 'TEST_COL', operator: 'nin', value: ['TEST_VALUE_1', 'TEST_VALUE_2'] }],
+        },
+        then: '"True"',
+        else: '"False"',
+      },
+    ];
+    const querySteps = translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      {
+        $addFields: {
+          NEW_COL: {
+            $cond: {
+              if: { $not: { $in: ['$TEST_COL', ['TEST_VALUE_1', 'TEST_VALUE_2']] } },
+              then: 'True',
+              else: 'False',
+            },
+          },
+        },
+      },
+      { $project: { _id: 0 } },
+    ]);
+  });
+
   it('can generate an ifthenelse step with formulas', () => {
     const pipeline: Pipeline = [
       {


### PR DESCRIPTION
$nin doesn't exist in https://docs.mongodb.com/manual/meta/aggregation-quick-reference/#array-expression-operators