### PR TITLE
feat(convert step): support cast from string to integer and vice versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Added
+
+- convert step: support cast from integer to date and from date to integer
+
 ## [0.35.1] - 2021-01-15
 
 ### Fixed

--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -10,10 +10,9 @@
       data-path=".column"
       :errors="errors"
     />
-    <!-- We display format options only for mongo40 and pandas translators as
-    this is not supported in Mongo 3.6 -->
+    <!-- Format options are not supported in Mongo 3.6 -->
     <AutocompleteWidget
-      v-if="translator === 'mongo40' || translator === 'pandas'"
+      v-if="translator !== 'mongo36'"
       name="Date format:"
       class="format"
       :value="selectedFormat"
@@ -26,7 +25,7 @@
     />
     <InputTextWidget
       v-if="
-        (translator === 'mongo40' || translator === 'pandas') &&
+        translator !== 'mongo36' &&
           editedStep.format !== undefined &&
           !datePresets.includes(editedStep.format)
       "
@@ -108,6 +107,12 @@ export default class ToDateStepForm extends BaseStepForm<ToDateStep> {
     {
       id: 'mongo40',
       label: 'Mongo 4.0',
+      doc:
+        'https://docs.mongodb.com/manual/reference/operator/aggregation/dateFromString/index.html#datefromstring-format-specifiers',
+    },
+    {
+      id: 'mongo42',
+      label: 'Mongo 4.2',
       doc:
         'https://docs.mongodb.com/manual/reference/operator/aggregation/dateFromString/index.html#datefromstring-format-specifiers',
     },

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -4906,7 +4906,14 @@ describe.each(['36', '40', '42'])(`Mongo %s translator`, version => {
           },
           {
             $addFields: {
-              date: { $convert: { input: '$date', to: 'date' } },
+              date: {
+                $convert: {
+                  input: {
+                    $cond: [{ $eq: [{ $type: '$date' }, 'int'] }, { $toLong: '$date' }, '$date'],
+                  },
+                  to: 'date',
+                },
+              },
             },
           },
           {
@@ -4916,7 +4923,7 @@ describe.each(['36', '40', '42'])(`Mongo %s translator`, version => {
           },
           {
             $addFields: {
-              int: { $convert: { input: '$int', to: 'int' } },
+              int: { $convert: { input: '$int', to: 'long' } },
             },
           },
           {

--- a/tests/unit/todate-step-form.spec.ts
+++ b/tests/unit/todate-step-form.spec.ts
@@ -21,6 +21,10 @@ describe('Convert String to Date Step Form', () => {
   );
   runner.testExpectedComponents(
     { 'columnpicker-stub': 1, 'autocompletewidget-stub': 1, 'inputtextwidget-stub': 0 },
+    { translator: 'mongo42' },
+  );
+  runner.testExpectedComponents(
+    { 'columnpicker-stub': 1, 'autocompletewidget-stub': 1, 'inputtextwidget-stub': 0 },
     { translator: 'pandas' },
   );
 


### PR DESCRIPTION
Before this PR, we were unable to cast from a date to an integer or from an integer to a date, although this was expected by users, in particular to be able to perform some arithmetics on timestamps.

After this PR, a user can cast n integer to a date or vice versa via the interface.