### PR TITLE
filter on a date column now allows to use a date input.

### DIFF
--- a/server/weaverbird/conditions.py
+++ b/server/weaverbird/conditions.py
@@ -4,7 +4,7 @@ from typing import Any, List, Literal, Union
 
 from numpy.ma import logical_and, logical_or
 from pandas import DataFrame, Series, to_datetime
-from pydantic import BaseModel, Field, root_validator, validator
+from pydantic import BaseModel, Field, validator
 
 from weaverbird.types import ColumnName, PopulatedWithFieldnames
 

--- a/server/weaverbird/conditions.py
+++ b/server/weaverbird/conditions.py
@@ -1,9 +1,10 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Any, List, Literal, Union
 
 from numpy.ma import logical_and, logical_or
-from pandas import DataFrame, Series
-from pydantic import BaseModel, Field
+from pandas import DataFrame, Series, to_datetime
+from pydantic import BaseModel, Field, root_validator, validator
 
 from weaverbird.types import ColumnName, PopulatedWithFieldnames
 
@@ -24,6 +25,14 @@ class ComparisonCondition(BaseCondition):
     column: ColumnName
     operator: Literal['eq', 'ne', 'lt', 'le', 'gt', 'ge']
     value: Any
+
+    @validator('value')
+    def value_must_have_compatible_type_pandas(cls, v):
+        print(f'validating value {cls=} {v=} ')
+        if isinstance(v, datetime):
+            print(f'converting {v} to pandas datetime')
+            return to_datetime(v.replace(tzinfo=None), utc=False)
+        return v
 
     def filter(self, df: DataFrame) -> Series:
         return getattr(df[self.column], self.operator)(self.value)

--- a/src/components/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/ConditionsEditor/ConditionsGroup.vue
@@ -443,6 +443,7 @@ $condition-row-border-width: 1px;
   display: flex;
   margin: $condition-row-margin 0;
   position: relative;
+  overflow-y: hidden;
 }
 
 .condition-row__content {

--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -78,8 +78,10 @@ export default class FilterEditor extends Vue {
   readonly defaultValue = DEFAULT_FILTER;
 
   get conditionsTree() {
-    const esJsonEnabled = this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enabled'
-    return buildConditionsEditorTree(castFilterStepTreeValue(this.filterTree, this.columnTypes, esJsonEnabled));
+    const esJsonEnabled = this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enable';
+    return buildConditionsEditorTree(
+      castFilterStepTreeValue(this.filterTree, this.columnTypes, esJsonEnabled),
+    );
   }
 
   updateFilterTree(newConditionsTree: AbstractFilterTree) {

--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -15,6 +15,7 @@
           :data-path="slotProps.dataPath"
           :errors="errors"
           :multi-variable="multiVariable"
+          :columnTypes="columnTypes"
         />
       </template>
     </ConditionsEditor>

--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -78,7 +78,8 @@ export default class FilterEditor extends Vue {
   readonly defaultValue = DEFAULT_FILTER;
 
   get conditionsTree() {
-    return buildConditionsEditorTree(castFilterStepTreeValue(this.filterTree, this.columnTypes));
+    const esJsonEnabled = this.$store.state.vqb.feature_flags.QUERYBUILDER_ESJSON == 'enabled'
+    return buildConditionsEditorTree(castFilterStepTreeValue(this.filterTree, this.columnTypes, esJsonEnabled));
   }
 
   updateFilterTree(newConditionsTree: AbstractFilterTree) {

--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -78,7 +78,9 @@ export default class FilterEditor extends Vue {
   readonly defaultValue = DEFAULT_FILTER;
 
   get conditionsTree() {
-    const esJsonEnabled = this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enable';
+    const esJsonEnabled =
+      this.$store?.state?.vqb?.featureFlags != undefined &&
+      this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enable';
     return buildConditionsEditorTree(
       castFilterStepTreeValue(this.filterTree, this.columnTypes, esJsonEnabled),
     );

--- a/src/components/FilterEditor.vue
+++ b/src/components/FilterEditor.vue
@@ -78,7 +78,7 @@ export default class FilterEditor extends Vue {
   readonly defaultValue = DEFAULT_FILTER;
 
   get conditionsTree() {
-    const esJsonEnabled = this.$store.state.vqb.feature_flags.QUERYBUILDER_ESJSON == 'enabled'
+    const esJsonEnabled = this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enabled'
     return buildConditionsEditorTree(castFilterStepTreeValue(this.filterTree, this.columnTypes, esJsonEnabled));
   }
 

--- a/src/components/stepforms/convert-filter-step-tree.ts
+++ b/src/components/stepforms/convert-filter-step-tree.ts
@@ -194,7 +194,9 @@ export function castFilterStepTreeValue(
     const type = columnTypes[filterStepTree.column];
     if (type !== undefined) {
       if (Array.isArray(filterStepTree.value)) {
-        filterStepTree.value = filterStepTree.value.map(v => castFromString(v, type, esJsonEnabled));
+        filterStepTree.value = filterStepTree.value.map(v =>
+          castFromString(v, type, esJsonEnabled),
+        );
       } else {
         filterStepTree.value = castFromString(filterStepTree.value, type, esJsonEnabled);
       }

--- a/src/components/stepforms/convert-filter-step-tree.ts
+++ b/src/components/stepforms/convert-filter-step-tree.ts
@@ -176,16 +176,17 @@ into:
 export function castFilterStepTreeValue(
   filterStepTree: FilterCondition,
   columnTypes: ColumnTypeMapping,
+  esJsonEnabled = false,
 ) {
   if (isFilterCombo(filterStepTree)) {
     if (isFilterComboOr(filterStepTree)) {
       for (let condition of filterStepTree.or) {
-        condition = castFilterStepTreeValue(condition, columnTypes);
+        condition = castFilterStepTreeValue(condition, columnTypes, esJsonEnabled);
       }
     }
     if (isFilterComboAnd(filterStepTree)) {
       for (let condition of filterStepTree.and) {
-        condition = castFilterStepTreeValue(condition, columnTypes);
+        condition = castFilterStepTreeValue(condition, columnTypes, esJsonEnabled);
       }
     }
     return filterStepTree;
@@ -193,9 +194,9 @@ export function castFilterStepTreeValue(
     const type = columnTypes[filterStepTree.column];
     if (type !== undefined) {
       if (Array.isArray(filterStepTree.value)) {
-        filterStepTree.value = filterStepTree.value.map(v => castFromString(v, type));
+        filterStepTree.value = filterStepTree.value.map(v => castFromString(v, type, esJsonEnabled));
       } else {
-        filterStepTree.value = castFromString(filterStepTree.value, type);
+        filterStepTree.value = castFromString(filterStepTree.value, type, esJsonEnabled);
       }
     }
     return filterStepTree;

--- a/src/components/stepforms/schemas/filter.ts
+++ b/src/components/stepforms/schemas/filter.ts
@@ -98,7 +98,7 @@ export default {
           },
         },
         value: {
-          type: ['string', 'number', 'boolean', 'null', 'array'],
+          type: ['string', 'number', 'boolean', 'null', 'array', 'object'],
           title: 'Value',
           description: 'The value to compare',
           attrs: {

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -173,7 +173,7 @@ export default class FilterSimpleConditionWidget extends Vue {
   }
 
   get inputWidget(): VueConstructor<Vue> | undefined {
-    if (this.$store.state.vqb.feature_flags.QUERYBUILDER_ESJSON == 'enabled' && this.columnTypes[this.value.column] == 'date') {
+    if (this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enabled' && this.value.operator == 'eq' && this.columnTypes[this.value.column] == 'date') {
       return InputDateWidget;
     }
 

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -173,7 +173,12 @@ export default class FilterSimpleConditionWidget extends Vue {
   }
 
   get inputWidget(): VueConstructor<Vue> | undefined {
-    if (this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enabled' && this.value.operator == 'eq' && this.columnTypes[this.value.column] == 'date') {
+    const widget = this.operators.filter(d => d.operator === this.value.operator)[0].inputWidget;
+    if (
+      this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enabled' &&
+      widget === InputTextWidget &&
+      this.columnTypes[this.value.column] == 'date'
+    ) {
       return InputDateWidget;
     }
 

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -175,6 +175,7 @@ export default class FilterSimpleConditionWidget extends Vue {
   get inputWidget(): VueConstructor<Vue> | undefined {
     const widget = this.operators.filter(d => d.operator === this.value.operator)[0].inputWidget;
     if (
+      this.$store.state?.vqb?.featureFlags != undefined &&
       this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enable' &&
       widget === InputTextWidget &&
       this.columnTypes[this.value.column] == 'date'

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -175,14 +175,12 @@ export default class FilterSimpleConditionWidget extends Vue {
   get inputWidget(): VueConstructor<Vue> | undefined {
     const widget = this.operators.filter(d => d.operator === this.value.operator)[0].inputWidget;
     if (
-      this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enabled' &&
+      this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enable' &&
       widget === InputTextWidget &&
       this.columnTypes[this.value.column] == 'date'
     ) {
       return InputDateWidget;
     }
-
-    const widget = this.operators.filter(d => d.operator === this.value.operator)[0].inputWidget;
     if (widget) {
       return widget;
     } else {

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -48,15 +48,15 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
+import { ColumnTypeMapping } from '@/lib/dataset/index.ts';
 import { keepCurrentValueIfArrayType, keepCurrentValueIfCompatibleType } from '@/lib/helpers';
 import { FilterSimpleCondition } from '@/lib/steps';
 import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
 
-import MultiInputTextWidget from './MultiInputText.vue';
 import InputDateWidget from './InputDate.vue';
-import { ColumnTypeMapping } from '@/lib/dataset/index.ts';
+import MultiInputTextWidget from './MultiInputText.vue';
 
 type LiteralOperator =
   | 'equals'

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -55,6 +55,8 @@ import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
 
 import MultiInputTextWidget from './MultiInputText.vue';
+import InputDateWidget from './InputDate.vue';
+import { ColumnTypeMapping } from '@/lib/dataset/index.ts';
 
 type LiteralOperator =
   | 'equals'
@@ -108,6 +110,12 @@ export default class FilterSimpleConditionWidget extends Vue {
 
   @Prop({ type: Boolean, default: true })
   multiVariable!: boolean; // display multiInputText as multiVariableInput
+
+  @Prop({
+    type: Object,
+    default: () => ({}),
+  })
+  columnTypes!: ColumnTypeMapping;
 
   @VQBModule.Getter('columnNames') columnNamesFromStore!: string[];
 
@@ -165,6 +173,10 @@ export default class FilterSimpleConditionWidget extends Vue {
   }
 
   get inputWidget(): VueConstructor<Vue> | undefined {
+    if (this.$store.state.vqb.feature_flags.QUERYBUILDER_ESJSON == 'enabled' && this.columnTypes[this.value.column] == 'date') {
+      return InputDateWidget;
+    }
+
     const widget = this.operators.filter(d => d.operator === this.value.operator)[0].inputWidget;
     if (widget) {
       return widget;

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -224,6 +224,7 @@ export default class FilterSimpleConditionWidget extends Vue {
 }
 
 .widget-autocomplete__container,
+.widget-input-date__container,
 .widget-input-text__container {
   margin: 0;
 }
@@ -231,7 +232,7 @@ export default class FilterSimpleConditionWidget extends Vue {
 .filter-form-simple-condition-column-input,
 .filter-form-simple-condition-operator-input,
 .filter-form-simple-condition__container .widget-input-text__container,
-.filter-form-simple-condition__container .widget-input-text__container,
+.filter-form-simple-condition__container .widget-input-date__container,
 .filter-form-simple-condition__container .widget-multiinputtext__container {
   margin: 4px;
   margin-right: 0;
@@ -243,6 +244,7 @@ export default class FilterSimpleConditionWidget extends Vue {
 }
 
 .filter-form-simple-condition__container ::v-deep .widget-input-text,
+.filter-form-simple-condition__container ::v-deep .widget-input-date,
 .filter-form-simple-condition__container ::v-deep .multiselect {
   background-color: white;
 

--- a/src/components/stepforms/widgets/InputDate.vue
+++ b/src/components/stepforms/widgets/InputDate.vue
@@ -85,8 +85,8 @@ export default class InputDateWidget extends Mixins(FormWidget) {
 
   get elementClass() {
     return {
-      'widget-input-number': true,
-      'widget-input-number--focused': this.isFocused,
+      'widget-input-date': true,
+      'widget-input-date--focused': this.isFocused,
     };
   }
 

--- a/src/components/stepforms/widgets/InputDate.vue
+++ b/src/components/stepforms/widgets/InputDate.vue
@@ -58,16 +58,16 @@ export default class InputDateWidget extends Mixins(FormWidget) {
   placeholder!: string;
 
   @Prop({ default: '' })
-  value!: string | number | boolean | Date;
+  value!: Date;
 
   @Prop({ default: undefined })
   docUrl!: string | undefined;
 
   @Prop({ type: Number, default: undefined })
-  min!: number;
+  min!: Date;
 
   @Prop({ type: Number, default: undefined })
-  max!: number;
+  max!: Date;
 
   @Prop()
   availableVariables?: VariablesBucket;
@@ -78,9 +78,11 @@ export default class InputDateWidget extends Mixins(FormWidget) {
   isFocused = false;
 
   mounted() {
-    const input: any = this.$refs.input;
-    // we receive back as value the full date. but the input value NEEDS to be a string
-    input.value = this.value.toISOString().substr(0, 10);
+    if (this.value) {
+      const input: any = this.$refs.input;
+      // we receive back as value the full date. but the input value NEEDS to be a string
+      input.value = this.value.toISOString().substr(0, 10);
+    }
   }
 
   get elementClass() {

--- a/src/components/stepforms/widgets/InputDate.vue
+++ b/src/components/stepforms/widgets/InputDate.vue
@@ -92,14 +92,6 @@ export default class InputDateWidget extends Mixins(FormWidget) {
     };
   }
 
-  blur() {
-    this.isFocused = false;
-  }
-
-  focus() {
-    this.isFocused = true;
-  }
-
   updateValue(newValue: string) {
     this.$emit('input', newValue);
   }

--- a/src/components/stepforms/widgets/InputDate.vue
+++ b/src/components/stepforms/widgets/InputDate.vue
@@ -98,7 +98,6 @@ export default class InputDateWidget extends Mixins(FormWidget) {
   }
 
   updateValue(newValue: string) {
-    console.log('new value = ', newValue);
     this.$emit('input', newValue);
   }
 }

--- a/src/components/stepforms/widgets/InputDate.vue
+++ b/src/components/stepforms/widgets/InputDate.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="widget-input-date__container" :class="toggleClassErrorWarning">
-    <div class="widget-input-date__container">
+    <div class="widget-input-date__label">
       <label v-if="name" @click="$refs.input.focus()">{{ name }}</label>
       <a v-if="docUrl" :href="docUrl" target="_blank" rel="noopener">
         <i class="fas fa-question-circle" aria-hidden="true" />
@@ -107,27 +107,26 @@ export default class InputDateWidget extends Mixins(FormWidget) {
 <style lang="scss" scoped>
 @import '../../../styles/_variables';
 
-.widget-input-number__container {
+.widget-input-date__container {
   @extend %form-widget__container;
 }
 
-.widget-input-number {
+.widget-input-date {
   @extend %form-widget__field;
-  padding: 8px;
+
+  &:focus-within {
+    @extend %form-widget__field--focused;
+  }
 }
 
-.widget-input-number--focused {
-  @extend %form-widget__field--focused;
-}
-
-.widget-input-number__container {
+.widget-input-date__label {
   align-items: flex-start;
   display: flex;
   justify-content: space-between;
   width: 100%;
 }
 
-.widget-input-number__container label {
+.widget-input-date__label label {
   @extend %form-widget__label;
 }
 

--- a/src/components/stepforms/widgets/InputDate.vue
+++ b/src/components/stepforms/widgets/InputDate.vue
@@ -79,6 +79,7 @@ export default class InputDateWidget extends Mixins(FormWidget) {
 
   mounted() {
     const input: any = this.$refs.input;
+    // we receive back as value the full date. but the input value NEEDS to be a string
     input.value = this.value.toISOString().substr(0, 10);
   }
 

--- a/src/components/stepforms/widgets/InputDate.vue
+++ b/src/components/stepforms/widgets/InputDate.vue
@@ -73,6 +73,7 @@ export default class InputDateWidget extends Mixins(FormWidget) {
     if (this.value) {
       const input: any = this.$refs.input;
       // we receive back as value the full date. but the input value NEEDS to be a string
+      // 10 characters gives us YYYY-MM-DD
       input.value = this.value.toISOString().substr(0, 10);
     }
   }

--- a/src/components/stepforms/widgets/InputDate.vue
+++ b/src/components/stepforms/widgets/InputDate.vue
@@ -63,19 +63,11 @@ export default class InputDateWidget extends Mixins(FormWidget) {
   @Prop({ default: undefined })
   docUrl!: string | undefined;
 
-  @Prop({ type: Number, default: undefined })
-  min!: Date;
-
-  @Prop({ type: Number, default: undefined })
-  max!: Date;
-
   @Prop()
   availableVariables?: VariablesBucket;
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
-
-  isFocused = false;
 
   mounted() {
     if (this.value) {

--- a/src/components/stepforms/widgets/InputDate.vue
+++ b/src/components/stepforms/widgets/InputDate.vue
@@ -1,0 +1,143 @@
+<template>
+  <div class="widget-input-date__container" :class="toggleClassErrorWarning">
+    <div class="widget-input-date__container">
+      <label v-if="name" @click="$refs.input.focus()">{{ name }}</label>
+      <a v-if="docUrl" :href="docUrl" target="_blank" rel="noopener">
+        <i class="fas fa-question-circle" aria-hidden="true" />
+      </a>
+    </div>
+    <VariableInput
+      :value="value"
+      :available-variables="availableVariables"
+      :variable-delimiters="variableDelimiters"
+      :has-arrow="true"
+      @input="updateValue"
+    >
+      <input
+        ref="input"
+        :class="elementClass"
+        :placeholder="placeholder"
+        type="date"
+        :min="min"
+        :max="max"
+        @blur="blur()"
+        @focus="focus()"
+        @input="updateValue($event.target.value)"
+      />
+    </VariableInput>
+    <div v-if="messageError" class="field__msg-error">
+      <span class="fa fa-exclamation-circle" />
+      {{ messageError }}
+    </div>
+    <div v-if="messageWarning" class="field__msg-warning">
+      <span class="fas fa-exclamation-triangle" />
+      {{ messageWarning }}
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Prop } from 'vue-property-decorator';
+
+import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
+
+import FormWidget from './FormWidget.vue';
+import VariableInput from './VariableInput.vue';
+
+@Component({
+  name: 'input-date-widget',
+  components: {
+    VariableInput,
+  },
+})
+export default class InputDateWidget extends Mixins(FormWidget) {
+  @Prop({ type: String, default: '' })
+  name!: string;
+
+  @Prop({ type: String, default: '' })
+  placeholder!: string;
+
+  @Prop({ default: '' })
+  value!: string | number | boolean | Date;
+
+  @Prop({ default: undefined })
+  docUrl!: string | undefined;
+
+  @Prop({ type: Number, default: undefined })
+  min!: number;
+
+  @Prop({ type: Number, default: undefined })
+  max!: number;
+
+  @Prop()
+  availableVariables?: VariablesBucket;
+
+  @Prop()
+  variableDelimiters?: VariableDelimiters;
+
+  isFocused = false;
+
+  mounted() {
+    const input: any = this.$refs.input;
+    input.value = this.value.toISOString().substr(0, 10);
+  }
+
+  get elementClass() {
+    return {
+      'widget-input-number': true,
+      'widget-input-number--focused': this.isFocused,
+    };
+  }
+
+  blur() {
+    this.isFocused = false;
+  }
+
+  focus() {
+    this.isFocused = true;
+  }
+
+  updateValue(newValue: string) {
+    console.log('new value = ', newValue);
+    this.$emit('input', newValue);
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../../styles/_variables';
+
+.widget-input-number__container {
+  @extend %form-widget__container;
+}
+
+.widget-input-number {
+  @extend %form-widget__field;
+  padding: 8px;
+}
+
+.widget-input-number--focused {
+  @extend %form-widget__field--focused;
+}
+
+.widget-input-number__container {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.widget-input-number__container label {
+  @extend %form-widget__label;
+}
+
+.fas.fa-question-circle {
+  margin-left: 5px;
+  color: $base-color;
+  font-size: 14px;
+
+  &:hover {
+    color: $active-color;
+  }
+}
+</style>

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -20,12 +20,12 @@ function isBooleanString(string: string): boolean {
   );
 }
 
-export function castFromString(value: string, type: DataSetColumnType) {
+export function castFromString(value: string, type: DataSetColumnType, esJsonEnabled = false) {
   if (['integer', 'float', 'long'].includes(type) && value !== null && !isNaN(Number(value))) {
     return Number(value);
   } else if (type === 'boolean' && isBooleanString(value)) {
     return value === 'true' || value === 'True' || value === 'TRUE' || value === '1';
-  } else if (type === 'date') {
+  } else if (type === 'date' && esJsonEnabled) {
     return new Date(value);
   }
   return value;

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -20,17 +20,13 @@ function isBooleanString(string: string): boolean {
   );
 }
 
-/**
- * Determines if a value canto be be cast to number
- *
- * @param value the value to be tested
- * @returns a boolean to determine if the value can be connverted to a number
- */
 export function castFromString(value: string, type: DataSetColumnType) {
   if (['integer', 'float', 'long'].includes(type) && value !== null && !isNaN(Number(value))) {
     return Number(value);
   } else if (type === 'boolean' && isBooleanString(value)) {
     return value === 'true' || value === 'True' || value === 'TRUE' || value === '1';
+  } else if (type === 'date') {
+    return new Date(value);
   }
   return value;
 }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -110,7 +110,7 @@ export interface VQBState {
    * variable delimiter for templating
    */
   variableDelimiters?: VariableDelimiters;
-  featureFlags: any;
+  featureFlags?: Record<string, boolean | undefined>;
 }
 
 /**

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -110,7 +110,7 @@ export interface VQBState {
    * variable delimiter for templating
    */
   variableDelimiters?: VariableDelimiters;
-  featureFlags?: Record<string, boolean | undefined>;
+  featureFlags?: Record<string, boolean | string | undefined>;
 }
 
 /**

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -110,6 +110,7 @@ export interface VQBState {
    * variable delimiter for templating
    */
   variableDelimiters?: VariableDelimiters;
+  featureFlags: any;
 }
 
 /**
@@ -143,6 +144,7 @@ export function emptyState(): VQBState {
     translator: 'mongo40',
     backendService: UnsetBackendService,
     interpolateFunc: (x: string | any[], _context: ScopeContext) => x,
+    featureFlags: undefined,
   };
 }
 

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -275,4 +275,27 @@ describe('Widget FilterSimpleCondition', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted().input[0]).toEqual([{ column: 'columnA', value: [], operator: 'in' }]);
   });
+
+  it("should have a date input if the column type is 'Date' and the featureflag is enabled", async () => {
+    const store = setupMockStore({
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+      selectedColumns: ['columnA'],
+    });
+    store.state.vqb.featureFlags = {};
+    store.state.vqb.featureFlags.QUERYBUILDER_ESJSON = 'enable';
+    const wrapper = mount(FilterSimpleConditionWidget, {
+      propsData: {
+        value: { column: 'columnA', value: new Date('2021-01-01'), operator: 'eq' },
+        columnTypes: { columnA: 'date' },
+      },
+      store,
+      localVue,
+      sync: false,
+    });
+    const widgetWrappers = wrapper.findAll('.filterValue');
+    expect(widgetWrappers.at(0).classes()).toContain('widget-input-date__container');
+  });
 });

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -18,6 +18,11 @@ describe('castFromString', () => {
     expect(castFromString(string2, 'float')).toEqual(4.2);
   });
 
+  it('should cast date string to dates, if ejson is enabled', () => {
+    const string1 = '2021-01-01';
+    expect(castFromString(string1, 'date', true)).toEqual(new Date(string1));
+  });
+
   it('should not cast a string that does not convert to number type', () => {
     const string = 'Hey';
     expect(castFromString(string, 'integer')).toEqual('Hey');

--- a/tests/unit/input-date-widget.spec.ts
+++ b/tests/unit/input-date-widget.spec.ts
@@ -1,0 +1,125 @@
+import { mount, shallowMount } from '@vue/test-utils';
+
+import InputDateWidget from '@/components/stepforms/widgets/InputDate.vue';
+
+describe('Widget Input Text', () => {
+  it('should instantiate', () => {
+    const wrapper = shallowMount(InputDateWidget);
+
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('should have a date input', () => {
+    const wrapper = shallowMount(InputDateWidget);
+
+    expect(wrapper.find("input[type='date']").exists()).toBeTruthy();
+  });
+
+  it('should not have a label if prop "name" is undefined', () => {
+    const wrapper = shallowMount(InputDateWidget);
+    expect(wrapper.find('label').exists()).toBeFalsy();
+  });
+
+  it('should have a label if prop "name" is defined', () => {
+    const wrapper = shallowMount(InputDateWidget, { propsData: { name: 'Stark' } });
+    const labelWrapper = wrapper.find('label');
+    expect(labelWrapper.text()).toEqual('Stark');
+  });
+
+  it('should not have a hyperlink element if prop "docUrl" is undefined', () => {
+    const wrapper = shallowMount(InputDateWidget);
+    expect(wrapper.find('a').exists()).toBeFalsy();
+  });
+
+  it('should have a hyperlink element if prop "docUrl" is defined', () => {
+    const wrapper = shallowMount(InputDateWidget, { propsData: { docUrl: 'testURL' } });
+    const linkWrapper = wrapper.find('a');
+    expect(wrapper.find('a').exists()).toBeTruthy();
+    expect(linkWrapper.attributes().href).toEqual('testURL');
+  });
+
+  it('should have an empty placeholder', () => {
+    const wrapper = shallowMount(InputDateWidget, {
+      propsData: {
+        value: new Date('2021-01-01'),
+      },
+    });
+    const el = wrapper.find("input[type='date']").element as HTMLInputElement;
+
+    expect(el.placeholder).toEqual('');
+  });
+
+  it('should have a placeholder', () => {
+    const wrapper = shallowMount(InputDateWidget, {
+      propsData: {
+        placeholder: 'I m a placeholder',
+        value: new Date('2021-01-01'),
+      },
+    });
+    const el = wrapper.find("input[type='date']").element as HTMLInputElement;
+
+    expect(el.placeholder).toEqual('I m a placeholder');
+  });
+
+  it('should have an empty input', () => {
+    const wrapper = shallowMount(InputDateWidget);
+    const el = wrapper.find("input[type='date']").element as HTMLInputElement;
+
+    expect(el.value).toEqual('');
+  });
+
+  it('should have a non empty input', () => {
+    const wrapper = shallowMount(InputDateWidget, {
+      propsData: { value: new Date('2021-01-01') },
+    });
+    const el = wrapper.find("input[type='date']").element as HTMLInputElement;
+
+    expect(el.value).toEqual('2021-01-01');
+  });
+
+  it('should emit "input" event on update', () => {
+    const wrapper = shallowMount(InputDateWidget, {
+      propsData: {
+        value: '',
+      },
+    });
+    const inputWrapper = wrapper.find('input[type="date"]');
+    (inputWrapper.element as HTMLInputElement).value = '2021-01-01';
+    inputWrapper.trigger('input', { value: '2021-01-01' });
+    expect(wrapper.emitted()).toEqual({ input: [['2021-01-01']] });
+  });
+
+  it('should display an error message if messageError exists', () => {
+    const wrapper = mount(InputDateWidget, {
+      propsData: {
+        dataPath: '.condition',
+        errors: [
+          {
+            dataPath: '.condition',
+            message: 'test error',
+          },
+        ],
+      },
+    });
+    expect(wrapper.find('.field__msg-error').exists()).toBeTruthy();
+  });
+
+  it('should not display an error message if messageError does not exist', () => {
+    const wrapper = mount(InputDateWidget);
+    expect(wrapper.find('.field__msg-error').exists()).toBeFalsy();
+  });
+
+  it('should display an warning message if messageError exists', () => {
+    const wrapper = mount(InputDateWidget, {
+      propsData: {
+        warning: 'warning',
+      },
+    });
+    expect(wrapper.find('.field__msg-warning').exists()).toBeTruthy();
+  });
+
+  it('should not display a warning message if messageError does not exist', () => {
+    const wrapper = mount(InputDateWidget);
+    expect(wrapper.find('.field__msg-warning').exists()).toBeFalsy();
+  });
+});


### PR DESCRIPTION
This PR:

* adds feature flags to weaverbird
* when the feature flag QUERYBUILDER_ESJSON is enabled:
   * filter on a date field use a input date
   * the pipeline will contain real dates objects, and no longer string 