### PR TITLE
feat(front): order of combinable tables in selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Changed
+
+- Order of datasets in combination steps forms: first pipelines, then other domains
+
 ## [0.39.0] - 2021-02-11
 
 ### Added

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -102,11 +102,15 @@ const getters: GetterTree<VQBState, any> = {
   /**
    * Return all available dataset (including pipelines but excluding currentPipelineName)
    */
-  availableDatasetNames: (state: VQBState) =>
-    Object.keys(state.pipelines)
-      .concat(state.domains)
+  availableDatasetNames: (state: VQBState) => {
+    const pipelineNames = Object.keys(state.pipelines)
       .filter((name: string) => name !== state.currentPipelineName)
-      .sort((a, b) => a.localeCompare(b)),
+      .sort((a, b) => a.localeCompare(b));
+
+    const domainNames = state.domains.sort((a, b) => a.localeCompare(b));
+
+    return [...pipelineNames, ...domainNames];
+  },
   /**
    * Return the pipelines referencing the current pipeline
    */

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -111,7 +111,7 @@ describe('getter tests', () => {
         'domain2',
       ]);
     });
-    it('should sort the result', () => {
+    it('should sort the result: first pipelines ordered alphabetically, then domains ordered alphabetically', () => {
       const state = buildState({
         pipelines: {
           abc: [],
@@ -121,9 +121,9 @@ describe('getter tests', () => {
       });
       expect(getters.availableDatasetNames(state, {}, {}, {})).toEqual([
         'abc',
+        'xyz',
         'dataset1',
         'mno',
-        'xyz',
       ]);
     });
   });


### PR DESCRIPTION
We want to display:
- first pipelines
- then domains.
Each category must be sorted alphabetically