### PR TITLE
fix(to date step): enable to transform a year string to a date

### DIFF
--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -93,6 +93,7 @@ export default class ToDateStepForm extends BaseStepForm<ToDateStep> {
     { format: '%Y/%m', label: '%Y/%m', example: '1970/12' },
     { format: '%m-%Y', label: '%m-%Y', example: '12-1970' },
     { format: '%m/%Y', label: '%m/%Y', example: '12/1970' },
+    { format: '%Y', label: '%Y', example: '1970' },
   ];
   readonly datePresets = this.formatOptions
     .filter(d => d.format !== 'guess' && d.format !== 'custom')

--- a/src/lib/translators/mongo4.ts
+++ b/src/lib/translators/mongo4.ts
@@ -262,6 +262,19 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
         },
         { $project: { _vqbTempDate: 0 } },
       ];
+    case '%Y':
+      // Mongo does not support "incomplete" date string where the day or month is missing
+      // so we add the first day of the month and of the first month of the year and use the format %d/%m/%Y
+      // WARNING: this format cannot be guess by mongo himself
+      return [
+        { $addFields: { _vqbTempDate: { $concat: ['01/01/', $$(step.column)] } } },
+        {
+          $addFields: {
+            [step.column]: { $dateFromString: { dateString: '$_vqbTempDate', format: '%d/%m/%Y' } },
+          },
+        },
+        { $project: { _vqbTempDate: 0 } },
+      ];
     default:
       return [
         {

--- a/src/lib/translators/mongo4.ts
+++ b/src/lib/translators/mongo4.ts
@@ -265,7 +265,7 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
     case '%Y':
       // Mongo does not support "incomplete" date string where the day or month is missing
       // so we add the first day of the month and of the first month of the year and use the format %d/%m/%Y
-      // WARNING: this format cannot be guess by mongo himself
+      // WARNING: this format cannot be guessed by mongo himself
       return [
         { $addFields: { _vqbTempDate: { $concat: ['01/01/', $$(step.column)] } } },
         {

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -5540,6 +5540,26 @@ describe.each(['36', '40', '42'])(`Mongo %s translator`, version => {
           { $project: { _id: 0, _vqbTempDate: 0 } },
         ]);
       });
+
+      it('can generate a todate step with "%Y" format', () => {
+        const pipeline: Pipeline = [
+          {
+            name: 'todate',
+            column: 'foo',
+            format: '%Y',
+          },
+        ];
+        const querySteps = translator.translate(pipeline);
+        expect(querySteps).toEqual([
+          { $addFields: { _vqbTempDate: { $concat: ['01/01/', '$foo'] } } },
+          {
+            $addFields: {
+              foo: { $dateFromString: { dateString: '$_vqbTempDate', format: '%d/%m/%Y' } },
+            },
+          },
+          { $project: { _id: 0, _vqbTempDate: 0 } },
+        ]);
+      });
     }
   });
 


### PR DESCRIPTION
Transform string as year "2019" to a date based on first day of the month and first month of the year: 01/01/2019
:information_source: The column should always be cast as string to enable concat to work

Before:
![before](https://user-images.githubusercontent.com/59559689/108733487-d5274c80-752e-11eb-88a8-800e12a5505c.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/108733450-cfca0200-752e-11eb-8b87-5589b57d2cfc.gif)