### PR TITLE
feat(unique-values): display checkboxes and label correctly

### DIFF
--- a/src/components/ListUniqueValues.vue
+++ b/src/components/ListUniqueValues.vue
@@ -14,6 +14,7 @@
       >
         <CheckboxWidget
           :label="`${stringify(option.value)} (${option.count})`"
+          :croppedLabel="true"
           :value="isChecked(option)"
           @input="toggleCheck(option)"
         />
@@ -197,7 +198,6 @@ export default class ListUniqueValues extends Vue {
 }
 
 .list-unique-values__checkbox {
-  min-width: fit-content;
   border-bottom: 2px #ededed solid;
   font-weight: 600;
   margin: 10px 0px;

--- a/src/components/ListUniqueValues.vue
+++ b/src/components/ListUniqueValues.vue
@@ -13,7 +13,8 @@
         :key="stringify(option.value)"
       >
         <CheckboxWidget
-          :label="`${stringify(option.value)} (${option.count})`"
+          :label="stringify(option.value)"
+          :info="`(${option.count})`"
           :croppedLabel="true"
           :value="isChecked(option)"
           @input="toggleCheck(option)"

--- a/src/components/stepforms/widgets/Checkbox.vue
+++ b/src/components/stepforms/widgets/Checkbox.vue
@@ -50,9 +50,11 @@ export default class CheckboxWidget extends Vue {
   }
 
   &::before {
+    flex: 0 auto;
     box-shadow: 0 0 0 2px $base-color inset;
     height: 24px;
     width: 24px;
+    min-width: 24px;
   }
 
   &::after {
@@ -88,6 +90,7 @@ export default class CheckboxWidget extends Vue {
 
 .widget-checkbox__label {
   @extend %form-widget__label;
+  flex: 1;
   margin-top: 0;
   margin-bottom: 0;
   align-self: center;

--- a/src/components/stepforms/widgets/Checkbox.vue
+++ b/src/components/stepforms/widgets/Checkbox.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="toggleCheckedClass" @click="toggleValue">
-    <label :for="label" class="widget-checkbox__label">{{ label }}</label>
+    <label :title="title" :for="label" class="widget-checkbox__label">{{ label }}</label>
   </div>
 </template>
 
@@ -14,11 +14,22 @@ export default class CheckboxWidget extends Vue {
   @Prop({ type: String, default: null })
   label!: string;
 
+  @Prop({ type: Boolean, default: false })
+  croppedLabel?: boolean;
+
   @Prop({ type: Boolean, default: true })
   value!: boolean;
 
   get toggleCheckedClass() {
-    return { 'widget-checkbox': true, 'widget-checkbox--checked': this.value };
+    return {
+      'widget-checkbox': true,
+      'widget-checkbox--checked': this.value,
+      'widget-checkbox--cropped': this.croppedLabel,
+    };
+  }
+
+  get title(): string | undefined {
+    return this.croppedLabel ? this.label : undefined;
   }
 
   toggleValue() {
@@ -96,5 +107,12 @@ export default class CheckboxWidget extends Vue {
   align-self: center;
   margin-left: 8px;
   cursor: pointer;
+}
+
+.widget-checkbox--cropped {
+  .widget-checkbox__label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 </style>

--- a/src/components/stepforms/widgets/Checkbox.vue
+++ b/src/components/stepforms/widgets/Checkbox.vue
@@ -1,6 +1,12 @@
 <template>
   <div :class="toggleCheckedClass" @click="toggleValue">
-    <label :title="title" :for="label" class="widget-checkbox__label">{{ label }}</label>
+    <label :title="title" :for="label" class="widget-checkbox__label">
+      <template v-if="info">
+        <span class="widget-checkbox__label-content">{{ label }}</span>
+        <span class="widget-checkbox__label-info">{{ info }}</span>
+      </template>
+      <template v-else>{{ label }}</template>
+    </label>
   </div>
 </template>
 
@@ -13,6 +19,9 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 export default class CheckboxWidget extends Vue {
   @Prop({ type: String, default: null })
   label!: string;
+
+  @Prop({ type: String, default: undefined })
+  info?: string;
 
   @Prop({ type: Boolean, default: false })
   croppedLabel?: boolean;
@@ -29,7 +38,13 @@ export default class CheckboxWidget extends Vue {
   }
 
   get title(): string | undefined {
-    return this.croppedLabel ? this.label : undefined;
+    if (!this.croppedLabel) {
+      return undefined;
+    } else if (this.info) {
+      return `${this.label}${this.info}`;
+    } else {
+      return this.label;
+    }
   }
 
   toggleValue() {
@@ -111,8 +126,17 @@ export default class CheckboxWidget extends Vue {
 
 .widget-checkbox--cropped {
   .widget-checkbox__label {
+    display: flex;
+    overflow: hidden;
+  }
+  .widget-checkbox__label-content {
+    flex: 0 auto;
+    max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+  .widget-checkbox__label-info {
+    flex: 0 auto;
   }
 }
 </style>

--- a/tests/unit/checkbox-widget.spec.ts
+++ b/tests/unit/checkbox-widget.spec.ts
@@ -1,4 +1,4 @@
-import { createLocalVue, mount, shallowMount } from '@vue/test-utils';
+import { createLocalVue, mount, shallowMount, Wrapper } from '@vue/test-utils';
 
 import CheckboxWidget from '@/components/stepforms/widgets/Checkbox.vue';
 
@@ -50,5 +50,28 @@ describe('Widget Checkbox', () => {
     wrapper.trigger('click');
     await localVue.nextTick();
     expect(wrapper.emitted()).toEqual({ input: [[false]] });
+  });
+
+  it('should have no title', async () => {
+    const wrapper = mount(CheckboxWidget, {
+      propsData: { value: true },
+    });
+    expect(wrapper.find('.widget-checkbox__label').attributes('title')).toBeUndefined();
+  });
+
+  describe('when cropped', () => {
+    let wrapper: Wrapper<CheckboxWidget>;
+    beforeEach(() => {
+      wrapper = mount(CheckboxWidget, {
+        propsData: { croppedLabel: true, label: 'Title' },
+      });
+    });
+    it('should add specific class to wrapper', async () => {
+      expect(wrapper.classes()).toContain('widget-checkbox--cropped');
+    });
+
+    it('should display the label as title', async () => {
+      expect(wrapper.find('.widget-checkbox__label').attributes('title')).toBe('Title');
+    });
   });
 });

--- a/tests/unit/checkbox-widget.spec.ts
+++ b/tests/unit/checkbox-widget.spec.ts
@@ -66,12 +66,35 @@ describe('Widget Checkbox', () => {
         propsData: { croppedLabel: true, label: 'Title' },
       });
     });
-    it('should add specific class to wrapper', async () => {
+    it('should add specific class to wrapper', () => {
       expect(wrapper.classes()).toContain('widget-checkbox--cropped');
     });
 
-    it('should display the label as title', async () => {
+    it('should display the label as title', () => {
       expect(wrapper.find('.widget-checkbox__label').attributes('title')).toBe('Title');
+    });
+  });
+
+  describe('with info', () => {
+    let wrapper: Wrapper<CheckboxWidget>;
+    beforeEach(() => {
+      wrapper = mount(CheckboxWidget, {
+        propsData: { croppedLabel: true, label: 'Title', info: '(info)' },
+      });
+    });
+
+    it('should add a wrapper for info', () => {
+      expect(wrapper.find('.widget-checkbox__label-info').exists()).toBe(true);
+      expect(wrapper.find('.widget-checkbox__label-info').text()).toBe('(info)');
+    });
+
+    it('should add a wrapper for label', () => {
+      expect(wrapper.find('.widget-checkbox__label-content').exists()).toBe(true);
+      expect(wrapper.find('.widget-checkbox__label-content').text()).toBe('Title');
+    });
+
+    it('should concatenate label and info into title', async () => {
+      expect(wrapper.find('.widget-checkbox__label').attributes('title')).toBe('Title(info)');
     });
   });
 });

--- a/tests/unit/list-unique-values.spec.ts
+++ b/tests/unit/list-unique-values.spec.ts
@@ -66,10 +66,14 @@ describe('List Unique Value', () => {
     expect(wrapper.exists()).toBeTruthy();
     const CheckboxWidgetArray = wrapper.findAll('CheckboxWidget-stub');
     expect(CheckboxWidgetArray.length).toEqual(4);
-    expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('France (10)');
-    expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('Framboise (9)');
-    expect(CheckboxWidgetArray.at(2).vm.$props.label).toEqual('UK (4)');
-    expect(CheckboxWidgetArray.at(3).vm.$props.label).toEqual('Spain (2)');
+    expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('France');
+    expect(CheckboxWidgetArray.at(0).vm.$props.info).toEqual('(10)');
+    expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('Framboise');
+    expect(CheckboxWidgetArray.at(1).vm.$props.info).toEqual('(9)');
+    expect(CheckboxWidgetArray.at(2).vm.$props.label).toEqual('UK');
+    expect(CheckboxWidgetArray.at(2).vm.$props.info).toEqual('(4)');
+    expect(CheckboxWidgetArray.at(3).vm.$props.label).toEqual('Spain');
+    expect(CheckboxWidgetArray.at(3).vm.$props.info).toEqual('(2)');
   });
 
   it('should instantiate with correct value checked', () => {
@@ -85,10 +89,14 @@ describe('List Unique Value', () => {
     expect(wrapper.exists()).toBeTruthy();
     const CheckboxWidgetArray = wrapper.findAll('CheckboxWidget-stub');
     expect(CheckboxWidgetArray.length).toEqual(4);
-    expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('France (10)');
-    expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('Framboise (9)');
-    expect(CheckboxWidgetArray.at(2).vm.$props.label).toEqual('UK (4)');
-    expect(CheckboxWidgetArray.at(3).vm.$props.label).toEqual('Spain (2)');
+    expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('France');
+    expect(CheckboxWidgetArray.at(0).vm.$props.info).toEqual('(10)');
+    expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('Framboise');
+    expect(CheckboxWidgetArray.at(1).vm.$props.info).toEqual('(9)');
+    expect(CheckboxWidgetArray.at(2).vm.$props.label).toEqual('UK');
+    expect(CheckboxWidgetArray.at(2).vm.$props.info).toEqual('(4)');
+    expect(CheckboxWidgetArray.at(3).vm.$props.label).toEqual('Spain');
+    expect(CheckboxWidgetArray.at(3).vm.$props.info).toEqual('(2)');
   });
 
   it('should instantiate with correct value checked (with "nin" operator)', () => {
@@ -189,8 +197,10 @@ describe('List Unique Value', () => {
       it('should filter the unique value when search on the searchbox', async () => {
         const CheckboxWidgetArray = wrapper.findAll('CheckboxWidget-stub');
         expect(CheckboxWidgetArray.length).toEqual(2);
-        expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('France (10)');
-        expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('Framboise (9)');
+        expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('France');
+        expect(CheckboxWidgetArray.at(0).vm.$props.info).toEqual('(10)');
+        expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('Framboise');
+        expect(CheckboxWidgetArray.at(1).vm.$props.info).toEqual('(9)');
       });
 
       it('should emit new value when click "select all" button (with "in" operator)', async () => {
@@ -225,8 +235,10 @@ describe('List Unique Value', () => {
       it('should filter the unique value when search on the searchbox', async () => {
         const CheckboxWidgetArray = wrapper.findAll('CheckboxWidget-stub');
         expect(CheckboxWidgetArray.length).toEqual(2);
-        expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('France (10)');
-        expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('Framboise (9)');
+        expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('France');
+        expect(CheckboxWidgetArray.at(0).vm.$props.info).toEqual('(10)');
+        expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('Framboise');
+        expect(CheckboxWidgetArray.at(1).vm.$props.info).toEqual('(9)');
       });
 
       it('should emit new value when click "select all" button (with "nin" operator)', async () => {
@@ -276,15 +288,19 @@ describe('List Unique Value', () => {
         });
         let CheckboxWidgetArray = wrapper.findAll('CheckboxWidget-stub');
         expect(CheckboxWidgetArray.length).toEqual(3);
-        expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('{"population":10} (12)');
-        expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('{"population":2} (9)');
-        expect(CheckboxWidgetArray.at(2).vm.$props.label).toEqual('{"population":3} (4)');
+        expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('{"population":10}');
+        expect(CheckboxWidgetArray.at(0).vm.$props.info).toEqual('(12)');
+        expect(CheckboxWidgetArray.at(1).vm.$props.label).toEqual('{"population":2}');
+        expect(CheckboxWidgetArray.at(1).vm.$props.info).toEqual('(9)');
+        expect(CheckboxWidgetArray.at(2).vm.$props.label).toEqual('{"population":3}');
+        expect(CheckboxWidgetArray.at(2).vm.$props.info).toEqual('(4)');
         const input = wrapper.find('.list-unique-values__search-box').element as HTMLInputElement;
         input.value = '2'; // "Fr" like the start of "France" and "Framboise"
         await wrapper.find('.list-unique-values__search-box').trigger('input');
         CheckboxWidgetArray = wrapper.findAll('CheckboxWidget-stub');
         expect(CheckboxWidgetArray.length).toEqual(1);
-        expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('{"population":2} (9)');
+        expect(CheckboxWidgetArray.at(0).vm.$props.label).toEqual('{"population":2}');
+        expect(CheckboxWidgetArray.at(0).vm.$props.info).toEqual('(9)');
       });
     });
   });


### PR DESCRIPTION
For now, we got sometimes an issue with checkboxes (not display correctly) and very long label, it's very weird in unique values.
We also add a title on hover to be able to see the label entirely if cropped.
These options are disabled on other checkboxes but could be reimplemented in some cases if needed

Before:
![before](https://user-images.githubusercontent.com/59559689/108744645-79fb5700-753a-11eb-90ba-a5e9a86e6bae.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/108744664-7ff13800-753a-11eb-80b7-f728c06cfc0e.gif)
