### PR TITLE
fix(rollup-step): use correct schema when updating step

### DIFF
--- a/src/components/stepforms/RollupStepForm.vue
+++ b/src/components/stepforms/RollupStepForm.vue
@@ -84,7 +84,10 @@ import MultiselectWidget from './widgets/Multiselect.vue';
 export default class RollupStepForm extends BaseStepForm<RollupStep> {
   stepname: PipelineStepName = 'rollup';
 
-  @Prop({ type: Object, default: () => ({ name: 'rollup', hierarchy: [], aggregations: [] }) })
+  @Prop({
+    type: Object,
+    default: () => ({ name: 'rollup', hierarchy: [], aggregations: [], groupby: [] }),
+  })
   initialStepValue!: RollupStep;
 
   readonly title: string = 'Hierarchical rollup';

--- a/src/components/stepforms/schemas/rollup.ts
+++ b/src/components/stepforms/schemas/rollup.ts
@@ -35,7 +35,7 @@ export default {
       },
     },
     labelCol: {
-      type: 'string',
+      type: ['null', 'string'],
       minLength: 1,
       title: 'Label column name',
       description: 'The name of the label column that will be created',
@@ -44,7 +44,7 @@ export default {
       },
     },
     levelCol: {
-      type: 'string',
+      type: ['null', 'string'],
       minLength: 1,
       title: 'Level column name',
       description: 'The name of the level column that will be created',
@@ -53,7 +53,7 @@ export default {
       },
     },
     parentLabelCol: {
-      type: 'string',
+      type: ['null', 'string'],
       minLength: 1,
       title: 'Parent column name',
       description: 'The name of the parent column that will be created',


### PR DESCRIPTION
Two errors were provided when editing a rollup step:
1. If user didn't provided a groupby value, field disappeared
2. If user leave the optionnal field empty, he had an error for string type missing in fields.

How fixes work?
1.We apply a default empty array to groupby value to avoid an error in line:
```
@input="setSelectedColumns({ column: editedStep.groupby[editedStep.groupby.length - 1] })"
```
The code look for an array that is 'null' while it should be empty if null 

2. We authorized null as value for optionnnal field in schema to avoid the string type error to be displayed