### PR TITLE
feat!(front): do not prepare pipeline outside backendService

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -125,7 +125,7 @@ class MongoService {
     return response.json();
   }
 
-  async executePipeline(pipeline, limit, offset = 0) {
+  async executePipeline(pipeline, pipelines, limit, offset = 0) {
     const { domain, pipeline: subpipeline } = filterOutDomain(pipeline);
     const query = mongoTranslator.translate(subpipeline);
     const { isResponseOk, responseContent } = await this.executeQuery(query, domain, limit, offset);
@@ -192,7 +192,7 @@ class PandasService {
     return response.json();
   }
 
-  async executePipeline(pipeline, limit, offset = 0) {
+  async executePipeline(pipeline, pipelines, limit, offset = 0) {
     // This does not modify the pipeline, but checks if all steps are supported
     pandasTranslator.translate(pipeline);
     const url = new URL(pandasBackendBaseUrl);

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -22,6 +22,7 @@ export interface BackendService {
   listCollections(): BackendResponse<string[]>;
   /**
    * @param pipeline the pipeline to translate and execute on the backend
+   * @param pipelines other pipelines, useful to resolve combination steps
    * @param limit if specified, a limit to be applied on the results. How is limit
    * is applied is up to the concrete implementor (either in the toolchain, the query
    * or afterwards on the resultset)
@@ -30,7 +31,12 @@ export interface BackendService {
    * @return a promise that holds the result of the pipeline execution,
    * formatted as as `DataSet`
    */
-  executePipeline(pipeline: Pipeline, limit: number, offset: number): BackendResponse<DataSet>;
+  executePipeline(
+    pipeline: Pipeline,
+    pipelines: { [k: string]: Pipeline },
+    limit: number,
+    offset: number,
+  ): BackendResponse<DataSet>;
 }
 
 /**

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -57,7 +57,8 @@ class Actions {
         return;
       }
       const response = await state.backendService.executePipeline(
-        preparePipeline(getters.activePipeline, state),
+        getters.activePipeline,
+        state.pipelines,
         state.pagesize,
         pageOffset(state.pagesize, getters.pageno),
       );
@@ -146,7 +147,8 @@ class Actions {
     ];
 
     const response = await context.state.backendService.executePipeline(
-      preparePipeline(loadUniqueValuesPipeline, context.state),
+      loadUniqueValuesPipeline,
+      context.state.pipelines,
       10000, // FIXME: limit is hard-coded
       0,
     );

--- a/tests/unit/pagination-component.spec.ts
+++ b/tests/unit/pagination-component.spec.ts
@@ -17,7 +17,12 @@ class DummyService implements BackendService {
     return Promise.resolve({ data: ['foo', 'bar'] });
   }
 
-  executePipeline(_pipeline: Pipeline, limit: number, offset: number) {
+  executePipeline(
+    _pipeline: Pipeline,
+    _pipelines: { [k: string]: Pipeline },
+    limit: number,
+    offset: number,
+  ) {
     executePipelineMock(limit, offset);
     return Promise.resolve({ data: { headers: [], data: [] } });
   }

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -884,7 +884,12 @@ describe('action tests', () => {
       ];
       const commitSpy = jest.spyOn(store, 'commit');
       await store.dispatch(VQBnamespace('loadColumnUniqueValues'), { column: 'city' });
-      expect(dummyService.executePipeline).toHaveBeenCalledWith(expectedPipeline, 10000, 0);
+      expect(dummyService.executePipeline).toHaveBeenCalledWith(
+        expectedPipeline,
+        expect.objectContaining({ default_pipeline: pipeline }),
+        10000,
+        0,
+      );
       expect(commitSpy).toHaveBeenCalledTimes(3);
       // call 1:
       expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('setLoading'));


### PR DESCRIPTION
BREAKING CHANGE: methode executePipeline of backend service changes
signature and scope
Dereferencing pipelines/domains should be done inside this function
Same for variables interpolation

This enables custom behavior, handled by the host app or even the server
answering to the data request