### PR TITLE
feat(pandas): add no joins translator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- temporary `pandas-no_joins` translator
+
 ## [0.43.0] - 2021-03-17
 
 ### Changed

--- a/src/components/stepforms/FromDateStepForm.vue
+++ b/src/components/stepforms/FromDateStepForm.vue
@@ -112,6 +112,11 @@ export default class FromDateStepForm extends BaseStepForm<FromDateStep> {
       label: 'Pandas',
       doc: 'https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes',
     },
+    {
+      id: 'pandas-no_joins',
+      label: 'Pandas',
+      doc: 'https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes',
+    },
   ];
 
   get selectedFormat(): FormatOption {

--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -122,6 +122,11 @@ export default class ToDateStepForm extends BaseStepForm<ToDateStep> {
       label: 'Pandas',
       doc: 'https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes',
     },
+    {
+      id: 'pandas-no_joins',
+      label: 'Pandas',
+      doc: 'https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes',
+    },
   ];
 
   get selectedFormat(): FormatOption {

--- a/src/lib/translators/index.ts
+++ b/src/lib/translators/index.ts
@@ -13,6 +13,7 @@ import { Mongo36Translator } from './mongo';
 import { Mongo40Translator } from './mongo4';
 import { Mongo42Translator } from './mongo42';
 import { PandasTranslator } from './pandas';
+import { PandasNoJoinsTranslator } from './pandas-no_joins';
 
 const TRANSLATORS: { [backend: string]: typeof BaseTranslator } = {};
 
@@ -64,6 +65,7 @@ registerTranslator('mongo36', Mongo36Translator);
 registerTranslator('mongo40', Mongo40Translator);
 registerTranslator('mongo42', Mongo42Translator);
 registerTranslator('pandas', PandasTranslator);
+registerTranslator('pandas-no_joins', PandasNoJoinsTranslator);
 
 /**
  * Initialize variable delimiters for all translators

--- a/src/lib/translators/pandas-no_joins.ts
+++ b/src/lib/translators/pandas-no_joins.ts
@@ -1,0 +1,181 @@
+/**
+ * This translator is a temporary clone of Pandas one to release now the
+ * VQB pipelines over live queries feature that does not support joins & appends yet.
+ * */
+
+import * as S from '@/lib/steps';
+
+import { BaseTranslator } from './base';
+
+/* istanbul ignore next */
+export class PandasNoJoinsTranslator extends BaseTranslator {
+  static label = 'PandasNoJoins';
+
+  addmissingdates(step: Readonly<S.AddMissingDatesStep>) {
+    return step;
+  }
+
+  aggregate(step: Readonly<S.AggregateStep>) {
+    return step;
+  }
+
+  append(step: Readonly<S.AppendStep>) {
+    return step;
+  }
+
+  argmax(step: Readonly<S.ArgmaxStep>) {
+    return step;
+  }
+
+  argmin(step: Readonly<S.ArgminStep>) {
+    return step;
+  }
+
+  comparetext(step: Readonly<S.CompareTextStep>) {
+    return step;
+  }
+
+  concatenate(step: Readonly<S.ConcatenateStep>) {
+    return step;
+  }
+
+  convert(step: Readonly<S.ConvertStep>) {
+    return step;
+  }
+
+  cumsum(step: Readonly<S.CumSumStep>) {
+    return step;
+  }
+
+  dateextract(step: Readonly<S.DateExtractPropertyStep>) {
+    return step;
+  }
+
+  delete(step: Readonly<S.DeleteStep>) {
+    return step;
+  }
+
+  domain(step: Readonly<S.DomainStep>) {
+    return step;
+  }
+
+  duplicate(step: Readonly<S.DuplicateColumnStep>) {
+    return step;
+  }
+
+  duration(step: Readonly<S.ComputeDurationStep>) {
+    return step;
+  }
+
+  evolution(step: Readonly<S.EvolutionStep>) {
+    return step;
+  }
+
+  fillna(step: Readonly<S.FillnaStep>) {
+    return step;
+  }
+
+  filter(step: Readonly<S.FilterStep>) {
+    return step;
+  }
+
+  formula(step: Readonly<S.FormulaStep>) {
+    return step;
+  }
+
+  fromdate(step: Readonly<S.FromDateStep>) {
+    return step;
+  }
+
+  ifthenelse(step: Readonly<S.IfThenElseStep>) {
+    return step;
+  }
+
+  join(step: Readonly<S.JoinStep>) {
+    return step;
+  }
+
+  lowercase(step: Readonly<S.ToLowerStep>) {
+    return step;
+  }
+
+  movingaverage(step: Readonly<S.MovingAverageStep>) {
+    return step;
+  }
+
+  percentage(step: Readonly<S.PercentageStep>) {
+    return step;
+  }
+
+  pivot(step: Readonly<S.PivotStep>) {
+    return step;
+  }
+
+  rank(step: Readonly<S.RankStep>) {
+    return step;
+  }
+
+  rename(step: Readonly<S.RenameStep>) {
+    return step;
+  }
+
+  replace(step: Readonly<S.ReplaceStep>) {
+    return step;
+  }
+
+  rollup(step: Readonly<S.RollupStep>) {
+    return step;
+  }
+
+  select(step: Readonly<S.SelectStep>) {
+    return step;
+  }
+
+  sort(step: Readonly<S.SortStep>) {
+    return step;
+  }
+
+  split(step: Readonly<S.SplitStep>) {
+    return step;
+  }
+
+  statistics(step: Readonly<S.StatisticsStep>) {
+    return step;
+  }
+
+  substring(step: Readonly<S.SubstringStep>) {
+    return step;
+  }
+
+  text(step: Readonly<S.AddTextColumnStep>) {
+    return step;
+  }
+
+  todate(step: Readonly<S.ToDateStep>) {
+    return step;
+  }
+
+  top(step: Readonly<S.TopStep>) {
+    return step;
+  }
+
+  totals(step: Readonly<S.AddTotalRowsStep>) {
+    return step;
+  }
+
+  uniquegroups(step: Readonly<S.UniqueGroupsStep>) {
+    return step;
+  }
+
+  unpivot(step: Readonly<S.UnpivotStep>) {
+    return step;
+  }
+
+  uppercase(step: Readonly<S.ToUpperStep>) {
+    return step;
+  }
+
+  waterfall(step: Readonly<S.WaterfallStep>) {
+    return step;
+  }
+}

--- a/src/lib/translators/pandas-no_joins.ts
+++ b/src/lib/translators/pandas-no_joins.ts
@@ -19,10 +19,6 @@ export class PandasNoJoinsTranslator extends BaseTranslator {
     return step;
   }
 
-  append(step: Readonly<S.AppendStep>) {
-    return step;
-  }
-
   argmax(step: Readonly<S.ArgmaxStep>) {
     return step;
   }
@@ -88,10 +84,6 @@ export class PandasNoJoinsTranslator extends BaseTranslator {
   }
 
   ifthenelse(step: Readonly<S.IfThenElseStep>) {
-    return step;
-  }
-
-  join(step: Readonly<S.JoinStep>) {
     return step;
   }
 

--- a/tests/unit/translator.spec.ts
+++ b/tests/unit/translator.spec.ts
@@ -71,14 +71,26 @@ describe('base translator class', () => {
 describe('translator registration', () => {
   it('should be possible to register backends', () => {
     registerTranslator('dummy', DummyStringTranslator);
-    expect(backendsSupporting('aggregate')).toEqual(['mongo36', 'mongo40', 'mongo42', 'pandas']);
+  });
+
+  it('should provided backend supporting a specific step', () => {
+    expect(backendsSupporting('aggregate')).toEqual([
+      'mongo36',
+      'mongo40',
+      'mongo42',
+      'pandas',
+      'pandas-no_joins',
+    ]);
     expect(backendsSupporting('domain')).toEqual([
       'dummy',
       'mongo36',
       'mongo40',
       'mongo42',
       'pandas',
+      'pandas-no_joins',
     ]);
+    expect(backendsSupporting('append')).toEqual(['mongo36', 'mongo40', 'mongo42', 'pandas']);
+    expect(backendsSupporting('join')).toEqual(['mongo36', 'mongo40', 'mongo42', 'pandas']);
   });
 
   it('should throw an error if backend is not available', () => {
@@ -94,6 +106,7 @@ describe('translator registration', () => {
       'mongo40',
       'mongo42',
       'pandas',
+      'pandas-no_joins',
     ]);
   });
 });


### PR DESCRIPTION
Add a temporary `pandas-no_joins` translator that's exactly like the Pandas one without support for the join & append steps, so we can release the improved live data feature, that does not have support for those yet, now !