### PR TITLE
Better structured exceptions

### DIFF
--- a/server/tests/test_pipeline_executor.py
+++ b/server/tests/test_pipeline_executor.py
@@ -146,3 +146,5 @@ def test_errors(pipeline_executor):
     assert 'delete' in exception_message
     assert 'columnThatDoesNotExist' in exception_message
     assert 'whatever' in exception_message
+    assert excinfo.value.details['index'] == 1
+    assert excinfo.value.details['message'] == exception_message

--- a/server/weaverbird/pipeline_executor.py
+++ b/server/weaverbird/pipeline_executor.py
@@ -10,6 +10,7 @@ from weaverbird.utils import StopWatch, convert_size
 
 logger = logging.getLogger(__name__)
 
+
 class PipelineExecutor:
     """
     The main class of the module.
@@ -74,7 +75,4 @@ class PipelineExecutionFailure(Exception):
         self.index = index
         self.original_exception = original_exception
         self.message = f'Step #{index + 1} ({step.name}) failed: {original_exception}'
-        self.details = {
-            'index': index,
-            'message': self.message
-        }
+        self.details = {'index': index, 'message': self.message}

--- a/server/weaverbird/pipeline_executor.py
+++ b/server/weaverbird/pipeline_executor.py
@@ -10,7 +10,6 @@ from weaverbird.utils import StopWatch, convert_size
 
 logger = logging.getLogger(__name__)
 
-
 class PipelineExecutor:
     """
     The main class of the module.
@@ -75,3 +74,7 @@ class PipelineExecutionFailure(Exception):
         self.index = index
         self.original_exception = original_exception
         self.message = f'Step #{index + 1} ({step.name}) failed: {original_exception}'
+        self.details = {
+            'index': index,
+            'message': self.message
+        }


### PR DESCRIPTION
feat(structured exceptions): the exceptions thrown now has a field 'details'. It is a dict that will be returned as-is up to the front end. it MUST contains only json serializable objects.

cf. https://github.com/ToucanToco/laputa/pull/4265