### PR TITLE
fix(date-extract): keep retrocompatibily without new_column_name

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weaverbird"
-version = "0.3.1"
+version = "0.3.2"
 description = "Pandas engine for weaverbird data pipelines"
 authors = ["Toucan Toco <dev+weaverbird@toucantoco.com>"]
 license = "MIT"

--- a/server/tests/steps/test_date_extract.py
+++ b/server/tests/steps/test_date_extract.py
@@ -1,7 +1,7 @@
 import pytest
 from pandas import DataFrame, to_datetime
 
-from tests.utils import assert_dataframes_equals
+from tests.utils import assert_column_equals, assert_dataframes_equals
 from weaverbird.steps import DateExtractStep
 
 
@@ -30,6 +30,12 @@ def test_date_extract_legacy_config(sample_df: DataFrame):
     ).execute(sample_df)
     expected_result = DataFrame({'date': [29, 13, 29, 9, 2, 1, None]})
     assert_dataframes_equals(df_result, expected_result)
+
+    # Without column name
+    df_result = DateExtractStep(name='dateextract', column='date', operation='day').execute(
+        sample_df
+    )
+    assert_column_equals(df_result['date_day'], [29, 13, 29, 9, 2, 1, None])
 
 
 def test_date_extract_(sample_df: DataFrame):

--- a/server/tests/utils.py
+++ b/server/tests/utils.py
@@ -1,5 +1,7 @@
-from pandas import DataFrame
-from pandas.testing import assert_frame_equal
+from typing import Any, List
+
+from pandas import DataFrame, Series
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 
 def assert_dataframes_equals(left: DataFrame, right: DataFrame):
@@ -10,5 +12,17 @@ def assert_dataframes_equals(left: DataFrame, right: DataFrame):
         left.reset_index(drop=True),
         right.reset_index(drop=True),
         check_like=True,
+        check_dtype=False,
+    )
+
+
+def assert_column_equals(serie: Series, values: List[Any]):
+    """
+    Compare vales of a dataframe's column (series)
+    """
+    assert_series_equal(
+        serie.reset_index(drop=True),
+        Series(values),
+        check_names=False,
         check_dtype=False,
     )

--- a/server/weaverbird/steps/date_extract.py
+++ b/server/weaverbird/steps/date_extract.py
@@ -63,9 +63,9 @@ class DateExtractStep(BaseStep):
 
     def execute(self, df: DataFrame, domain_retriever=None, execute_pipeline=None) -> DataFrame:
         date_info: List[DATE_INFO]
-        if self.operation and self.new_column_name:  # for retrocompatibility
+        if self.operation:  # for retrocompatibility
             date_info = [self.operation]
-            new_columns = [self.new_column_name]
+            new_columns = [self.new_column_name or f'{self.column}_{self.operation}']
         else:
             date_info = self.date_info
             new_columns = self.new_columns


### PR DESCRIPTION
The pandas translator part of https://github.com/ToucanToco/weaverbird/pull/852 has missed a retro-compatibility case: when the new column name is not indicated, we should generate one automatically.

This case was correctly tested in the mongo implementation: https://github.com/ToucanToco/weaverbird/pull/852/files#diff-fadebd5a5aec933e0a42af86569ef7ff7858207165d4153572cfdf600d5972d6R2468