### PR TITLE
fix(conditions): display row corectly with long labels

### DIFF
--- a/src/components/ConditionsEditor/ConditionsGroup.vue
+++ b/src/components/ConditionsEditor/ConditionsGroup.vue
@@ -447,7 +447,7 @@ $condition-row-border-width: 1px;
 
 .condition-row__content {
   flex: 1;
-  // overflow: auto;
+  width: 100%;
 }
 
 .condition-row__delete {


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/59559689/113715126-6b7f8e00-96e9-11eb-8de4-41a7c541b7eb.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/113715099-67ec0700-96e9-11eb-999d-01a12f2814f4.gif)
