### PR TITLE
feat(pipeline): display more readable errors

### DIFF
--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -64,6 +64,7 @@ export default class PipelineComponent extends Vue {
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-top: 20px;
 }
 
 .query-pipeline__tips-container {

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -164,7 +164,7 @@ export default class Step extends Vue {
   display: flex;
   flex-direction: row;
   align-items: center;
-  height: 70px;
+  height: 60px;
   width: 100%;
   flex-shrink: 0;
 }
@@ -306,7 +306,7 @@ export default class Step extends Vue {
   }
 }
 .query-pipeline-step__container--errors {
-  height: 100px;
+  height: 90px;
   .query-pipeline-step {
     background: $error-light;
     border-color: $error;

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -217,7 +217,6 @@ export default class Step extends Vue {
   border-radius: 5px;
   border: 1px solid $grey;
   background-color: white;
-  overflow: hidden;
 }
 
 .query-pipeline-step__body {

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -8,18 +8,25 @@
       <div :class="lastStrokeClass" />
     </div>
     <div class="query-pipeline-step">
-      <span class="query-pipeline-step__name" :title="stepTitle" v-html="stepLabel" />
-      <div class="query-pipeline-step__actions">
-        <!-- @click.stop is used to avoid to trigger select event when editing a step -->
-        <div class="query-pipeline-step__action" @click.stop="editStep()">
-          <i class="far fa-cog" aria-hidden="true" />
+      <div class="query-pipeline-step__body">
+        <span class="query-pipeline-step__name" :title="stepTitle" v-html="stepLabel" />
+        <div class="query-pipeline-step__actions">
+          <!-- @click.stop is used to avoid to trigger select event when editing a step -->
+          <div class="query-pipeline-step__action" @click.stop="editStep()">
+            <i class="far fa-cog" aria-hidden="true" />
+          </div>
+          <div
+            v-if="!isFirst"
+            class="query-pipeline-step__action"
+            @click="toggleDeleteConfirmationModal"
+          >
+            <i class="far fa-trash-alt" aria-hidden="true" />
+          </div>
         </div>
-        <div
-          v-if="!isFirst"
-          class="query-pipeline-step__action"
-          @click="toggleDeleteConfirmationModal"
-        >
-          <i class="far fa-trash-alt" aria-hidden="true" />
+      </div>
+      <div class="query-pipeline-step__footer" v-if="errorMessage && !isDisabled">
+        <div class="query-pipeline-step__error" :title="errorMessage">
+          <strong>ERROR</strong> - {{ errorMessage }}
         </div>
       </div>
     </div>
@@ -204,8 +211,17 @@ export default class Step extends Vue {
 }
 
 .query-pipeline-step {
-  cursor: pointer;
+  width: 100%;
   min-width: 0;
+  overflow: hidden;
+  border-radius: 5px;
+  border: 1px solid $grey;
+  background-color: white;
+  overflow: hidden;
+}
+
+.query-pipeline-step__body {
+  cursor: pointer;
   width: 100%;
   height: 50px;
   display: flex;
@@ -213,10 +229,6 @@ export default class Step extends Vue {
   padding-left: 12px;
   justify-content: space-between;
   align-items: center;
-  background: white;
-  border: 1px solid $grey;
-  border-radius: 5px;
-  overflow: hidden;
 }
 
 .query-pipeline-step__name {
@@ -257,6 +269,22 @@ export default class Step extends Vue {
   transition: color 0.3s ease;
 }
 
+.query-pipeline-step__footer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 5px 12px;
+  height: 30px;
+}
+
+.query-pipeline-step__error {
+  font-size: 10px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  width: 100%;
+}
+
 .query-pipeline-step__container--last-active {
   .query-pipeline-step {
     background: $active-color-faded-3;
@@ -278,10 +306,14 @@ export default class Step extends Vue {
   }
 }
 .query-pipeline-step__container--errors {
+  height: 100px;
   .query-pipeline-step {
     background: $error-light;
     border-color: $error;
     color: $grey-dark;
+  }
+  .query-pipeline-step__footer {
+    background-color: $error;
   }
   .query-pipeline-step__action {
     color: $error;

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -78,8 +78,14 @@ export default class Step extends Vue {
 
   @VQBModule.Getter stepConfig!: (index: number) => PipelineStep;
 
+  @VQBModule.Getter stepErrors!: (index: number) => string | undefined;
+
   get stepName(): string {
     return humanReadableLabel(this.step);
+  }
+
+  get errorMessage(): string | undefined {
+    return this.stepErrors(this.indexInPipeline);
   }
 
   get stepTitle(): string {
@@ -98,6 +104,7 @@ export default class Step extends Vue {
       'query-pipeline-step__container--active': this.isActive,
       'query-pipeline-step__container--last-active': this.isLastActive,
       'query-pipeline-step__container--disabled': this.isDisabled,
+      'query-pipeline-step__container--errors': this.errorMessage && !this.isDisabled,
     };
   }
 
@@ -268,6 +275,26 @@ export default class Step extends Vue {
   }
   .query-pipeline-queue__dot-ink {
     background-color: $active-color;
+  }
+}
+.query-pipeline-step__container--errors {
+  .query-pipeline-step {
+    background: $error-light;
+    border-color: $error;
+    color: $grey-dark;
+  }
+  .query-pipeline-step__action {
+    color: $error;
+    border-right-color: $error;
+    &:hover {
+      color: $grey-dark;
+    }
+  }
+  .query-pipeline-queue__dot {
+    background-color: $error-light;
+  }
+  .query-pipeline-queue__dot-ink {
+    background-color: $error;
   }
 }
 

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -4,6 +4,7 @@ import { Pipeline } from '@/lib/steps';
 
 export type BackendError = {
   type: 'error';
+  index?: number; // step index if error target a specific step
   message: string;
 };
 

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,5 +1,6 @@
 import { ActionContext, ActionTree } from 'vuex';
 
+import { BackendError } from '@/lib/backend';
 import { addLocalUniquesToDataset, updateLocalUniquesFromDatabase } from '@/lib/dataset/helpers.ts';
 import { pageOffset } from '@/lib/dataset/pagination';
 import { Pipeline } from '@/lib/steps';
@@ -24,6 +25,13 @@ function loading(type: 'dataset' | 'uniqueValues') {
 
     return descriptor;
   };
+}
+
+// format error to fit BackendError interface props
+function formatError(error: any): BackendError {
+  return typeof error === 'string'
+    ? { type: 'error', message: error.toString() }
+    : { type: 'error', ...error };
 }
 
 /**
@@ -71,13 +79,8 @@ class Actions {
       }
       return response;
     } catch (error) {
-      // format error to fit BackendError interface
-      const formattedError =
-        typeof error === 'string'
-          ? { type: 'error', message: error.toString() }
-          : { type: 'error', ...error };
       /* istanbul ignore next */
-      const response = { error: [formattedError] };
+      const response = { error: [formatError(error)] };
       // Avoid spamming tests results with errors, but could be useful in production
       /* istanbul ignore next */
       if (process.env.NODE_ENV !== 'test') {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -28,7 +28,7 @@ function loading(type: 'dataset' | 'uniqueValues') {
 }
 
 // format error to fit BackendError interface props
-function formatError(error: any): BackendError {
+export function formatError(error: any): BackendError {
   return typeof error === 'string'
     ? { type: 'error', message: error.toString() }
     : { type: 'error', ...error };

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -71,8 +71,13 @@ class Actions {
       }
       return response;
     } catch (error) {
+      // format error to fit BackendError interface
+      const formattedError =
+        typeof error === 'string'
+          ? { type: 'error', message: error.toString() }
+          : { type: 'error', ...error };
       /* istanbul ignore next */
-      const response = { error: [{ type: 'error', message: error.toString() }] };
+      const response = { error: [formattedError] };
       // Avoid spamming tests results with errors, but could be useful in production
       /* istanbul ignore next */
       if (process.env.NODE_ENV !== 'test') {

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -4,6 +4,7 @@
 import _ from 'lodash';
 import { GetterTree } from 'vuex';
 
+import { BackendError, BackendWarning } from '@/lib/backend';
 import { getPipelineNamesReferencing } from '@/lib/dereference-pipeline';
 import { getTranslator } from '@/lib/translators';
 
@@ -132,6 +133,15 @@ const getters: GetterTree<VQBState, any> = {
   stepConfig: (state: VQBState) => (index: number) => {
     const pipeline = currentPipeline(state);
     return pipeline?.[index];
+  },
+  /**
+   * Filter errors to retrieve step ones based on its index
+   */
+  stepErrors: (state: VQBState) => (index: number) => {
+    const error = [...state.backendMessages].find(
+      (e: BackendError | BackendWarning) => e.type === 'error' && e.index === index,
+    );
+    return error?.message;
   },
   /**
    * Return the app translator name

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -10,6 +10,8 @@ $light-grey: #fafafa;
 $grey: #eeeeee;
 $grey-medium: #aaaaaa;
 $grey-dark: #585858;
+$error-light: #fdf9e5;
+$error: #f3c600;
 
 //GLOBAL STYLE (by default we use the google font "Montserrat")
 %main-font-style {

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -13,8 +13,23 @@ const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Step.vue', () => {
+  const createStepWrapper = ({ propsData = {} }) => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'GoT' },
+      { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
+      { name: 'rename', toRename: [['region', 'kingdom']] },
+      { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
+    ];
+    const store = setupMockStore(buildStateWithOnePipeline(pipeline));
+    return shallowMount(Step, {
+      propsData,
+      store,
+      localVue,
+    });
+  };
+
   it('emit selectedStep when clicking on a step "time travel" dot', async () => {
-    const wrapper = shallowMount(Step, {
+    const wrapper = createStepWrapper({
       propsData: {
         key: 0,
         isActive: true,
@@ -31,7 +46,7 @@ describe('Step.vue', () => {
   });
 
   it('emit selectedStep when clicking on the step itself', async () => {
-    const wrapper = shallowMount(Step, {
+    const wrapper = createStepWrapper({
       propsData: {
         key: 0,
         isActive: true,
@@ -48,7 +63,7 @@ describe('Step.vue', () => {
   });
 
   it('does not render a delete confirmation modal by default', () => {
-    const wrapper = shallowMount(Step, {
+    const wrapper = createStepWrapper({
       propsData: {
         key: 0,
         isActive: true,
@@ -64,7 +79,7 @@ describe('Step.vue', () => {
   });
 
   it('renders a delete confirmation modal when clicking on the trash icon', async () => {
-    const wrapper = shallowMount(Step, {
+    const wrapper = createStepWrapper({
       propsData: {
         key: 0,
         isActive: true,
@@ -82,7 +97,7 @@ describe('Step.vue', () => {
   });
 
   it('should render a delete confirmation modal when clicking on the button with the trash icon', async () => {
-    const wrapper = shallowMount(Step, {
+    const wrapper = createStepWrapper({
       propsData: {
         key: 0,
         isActive: true,
@@ -103,7 +118,7 @@ describe('Step.vue', () => {
   });
 
   it('should not render a trash icon on domain step', () => {
-    const wrapper = shallowMount(Step, {
+    const wrapper = createStepWrapper({
       propsData: {
         key: 0,
         isActive: true,
@@ -119,7 +134,7 @@ describe('Step.vue', () => {
   });
 
   it('should render a stepLabel with the variable names', () => {
-    const wrapper = shallowMount(Step, {
+    const wrapper = createStepWrapper({
       propsData: {
         key: 0,
         isActive: true,

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -239,4 +239,46 @@ describe('Step.vue', () => {
       [{ name: 'rename', toRename: [['region', 'kingdom']] }, 2],
     ]);
   });
+
+  describe('with errors', () => {
+    it('should highlight the error step', async () => {
+      const pipeline: Pipeline = [
+        { name: 'domain', domain: 'GoT' },
+        { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
+      ];
+      const store = setupMockStore(
+        buildStateWithOnePipeline(pipeline, {
+          currentStepFormName: 'replace',
+          backendMessages: [
+            { index: 1, message: 'I am an error for the replace step', type: 'error' },
+          ],
+        }),
+      );
+      const wrapper = mount(PipelineComponent, { store, localVue });
+      const stepsArray = wrapper.findAll(Step);
+      const replaceStep = stepsArray.at(1);
+      expect(replaceStep.classes()).toContain('query-pipeline-step__container--errors');
+    });
+
+    it('should override with disabled style when disabled', async () => {
+      const pipeline: Pipeline = [
+        { name: 'domain', domain: 'GoT' },
+        { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
+      ];
+      const store = setupMockStore(
+        buildStateWithOnePipeline(pipeline, {
+          currentStepFormName: 'domain',
+          backendMessages: [
+            { index: 1, message: 'I am an error for the replace step', type: 'error' },
+          ],
+        }),
+      );
+      const wrapper = mount(PipelineComponent, { store, localVue });
+      const stepsArray = wrapper.findAll(Step);
+      stepsArray.at(0).trigger('click');
+      await localVue.nextTick();
+      const replaceStep = stepsArray.at(1);
+      expect(replaceStep.classes()).not.toContain('query-pipeline-step__container--errors');
+    });
+  });
 });

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -260,6 +260,28 @@ describe('Step.vue', () => {
       expect(replaceStep.classes()).toContain('query-pipeline-step__container--errors');
     });
 
+    it('should display the error message', async () => {
+      const pipeline: Pipeline = [
+        { name: 'domain', domain: 'GoT' },
+        { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
+      ];
+      const store = setupMockStore(
+        buildStateWithOnePipeline(pipeline, {
+          currentStepFormName: 'replace',
+          backendMessages: [
+            { index: 1, message: 'I am an error for the replace step', type: 'error' },
+          ],
+        }),
+      );
+      const wrapper = mount(PipelineComponent, { store, localVue });
+      const stepsArray = wrapper.findAll(Step);
+      const replaceStep = stepsArray.at(1);
+      expect(replaceStep.find('.query-pipeline-step__footer').exists()).toBe(true);
+      expect(replaceStep.find('.query-pipeline-step__footer').text()).toContain(
+        'I am an error for the replace step',
+      );
+    });
+
     it('should override with disabled style when disabled', async () => {
       const pipeline: Pipeline = [
         { name: 'domain', domain: 'GoT' },
@@ -278,6 +300,7 @@ describe('Step.vue', () => {
       stepsArray.at(0).trigger('click');
       await localVue.nextTick();
       const replaceStep = stepsArray.at(1);
+      expect(replaceStep.find('.query-pipeline-step__footer').exists()).toBe(false);
       expect(replaceStep.classes()).not.toContain('query-pipeline-step__container--errors');
     });
   });

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -342,7 +342,7 @@ describe('getter tests', () => {
       const state = buildState({
         backendMessages: [{ type: 'error', message: 'lalalolilol', index: 3 }],
       });
-      expect(getters.stepConfig(state, {}, {}, {})(3)).toBeUndefined();
+      expect(getters.stepErrors(state, {}, {}, {})(3)).toStrictEqual('lalalolilol');
     });
     it('should return undefined if step index has no errors', function() {
       const state = buildState({

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -817,6 +817,44 @@ describe('action tests', () => {
       expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('setLoading'));
       expect(commitSpy.mock.calls[4][1]).toEqual({ type: 'dataset', isLoading: false });
     });
+
+    it('updateDataset with specific step error from service', async () => {
+      const pipeline: Pipeline = [
+        { name: 'domain', domain: 'GoT' },
+        { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
+        { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
+      ];
+      const store = setupMockStore({
+        ...buildStateWithOnePipeline(pipeline),
+        backendService: {
+          listCollections: jest.fn(),
+          executePipeline: jest.fn().mockResolvedValue({
+            error: [{ type: 'error' as 'error', index: 1, message: 'Specific error for step' }],
+          }),
+        },
+      });
+      const commitSpy = jest.spyOn(store, 'commit');
+
+      await store.dispatch(VQBnamespace('updateDataset'));
+      expect(commitSpy).toHaveBeenCalledTimes(5);
+      // call 1 :
+      expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[0][1]).toEqual({ type: 'dataset', isLoading: true });
+      // call 2 :
+      expect(commitSpy.mock.calls[1][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[1][1]).toEqual({ isRequestOnGoing: true });
+      // call 3 :
+      expect(commitSpy.mock.calls[2][0]).toEqual(VQBnamespace('logBackendMessages'));
+      expect(commitSpy.mock.calls[2][1]).toEqual({
+        backendMessages: [{ type: 'error', index: 1, message: 'Specific error for step' }],
+      });
+      // call 4 :
+      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[3][1]).toEqual({ isRequestOnGoing: false });
+      // call 5 :
+      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[4][1]).toEqual({ type: 'dataset', isLoading: false });
+    });
   });
 
   describe('loadColumnUniqueValues', () => {

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -2,6 +2,7 @@ import { BackendService } from '@/lib/backend';
 import { DataSet } from '@/lib/dataset';
 import { Pipeline } from '@/lib/steps';
 import { VQBnamespace } from '@/store';
+import { formatError } from '@/store/actions';
 import getters from '@/store/getters';
 import mutations from '@/store/mutations';
 import { currentPipeline, emptyState } from '@/store/state';
@@ -1007,6 +1008,21 @@ describe('action tests', () => {
       } as BackendService;
       mutations.setBackendService(state, { backendService });
       expect(state.backendService).toEqual(backendService);
+    });
+  });
+
+  describe('formatError', () => {
+    it('should format a string error to a correct BackendError object', () => {
+      const error = 'global error message';
+      expect(formatError(error)).toStrictEqual({ type: 'error', message: 'global error message' });
+    });
+    it('should format an object error to a correct BackendError object', () => {
+      const error = { index: 1, message: 'Step specific error' };
+      expect(formatError(error)).toStrictEqual({
+        type: 'error',
+        index: 1,
+        message: 'Step specific error',
+      });
     });
   });
 });

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -336,6 +336,25 @@ describe('getter tests', () => {
     });
   });
 
+  describe('step errors', () => {
+    it('should return the error message if step index is found in errors', function() {
+      const state = buildState({
+        backendMessages: [{ type: 'error', message: 'lalalolilol', index: 3 }],
+      });
+      expect(getters.stepConfig(state, {}, {}, {})(3)).toBeUndefined();
+    });
+    it('should return undefined if step index has no errors', function() {
+      const state = buildState({
+        backendMessages: [{ type: 'error', message: 'lalalolilol', index: 3 }],
+      });
+      expect(getters.stepErrors(state, {}, {}, {})(0)).toBeUndefined();
+    });
+    it('should return undefined if pipeline has no errors', function() {
+      const state = buildState({});
+      expect(getters.stepErrors(state, {}, {}, {})(0)).toBeUndefined();
+    });
+  });
+
   describe('message error related test', () => {
     it('should return false if backendError is undefined', () => {
       const state = buildState({ backendMessages: [] });


### PR DESCRIPTION
Display errors directly in step.
( errors are going to be filtered from Tucana side, we still return step errors for now ).
Tucana will also return an error in index case (another PR to come, this one need to be merged first)

Before:
![before](https://user-images.githubusercontent.com/59559689/113909206-b7a8fc00-97d7-11eb-8762-e0230bebdfa5.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/113909260-c42d5480-97d7-11eb-8601-b3e762515885.gif)

Need to review: https://github.com/ToucanToco/weaverbird/pull/864 first