### PR TITLE
fix(variables): retrieve variable identifier from malformatted variables

### DIFF
--- a/src/lib/variables.ts
+++ b/src/lib/variables.ts
@@ -40,7 +40,7 @@ export function extractVariableIdentifier(
     // Removes delimiters
     variableIdentifier = variableIdentifier.slice(
       variableDelimiters.start.length,
-      variableIdentifier.length - 1,
+      variableIdentifier.length,
     );
     variableIdentifier = variableIdentifier.slice(
       0,

--- a/tests/unit/variables.spec.ts
+++ b/tests/unit/variables.spec.ts
@@ -10,7 +10,7 @@ describe('extractVariableIdentifier', () => {
     ).toBe('hummus');
   });
 
-  it('should extract malformatted variable', () => {
+  it('should extract the right variable identifier despite leading or trailing whitespace or their absence', () => {
     expect(
       extractVariableIdentifier('{{ malformatted}}', {
         start: '{{',

--- a/tests/unit/variables.spec.ts
+++ b/tests/unit/variables.spec.ts
@@ -10,6 +10,27 @@ describe('extractVariableIdentifier', () => {
     ).toBe('hummus');
   });
 
+  it('should extract malformatted variable', () => {
+    expect(
+      extractVariableIdentifier('{{ malformatted}}', {
+        start: '{{',
+        end: '}}',
+      }),
+    ).toBe('malformatted');
+    expect(
+      extractVariableIdentifier('{{malformatted }}', {
+        start: '{{',
+        end: '}}',
+      }),
+    ).toBe('malformatted');
+    expect(
+      extractVariableIdentifier('{{malformatted}}', {
+        start: '{{',
+        end: '}}',
+      }),
+    ).toBe('malformatted');
+  });
+
   it('should extract variable names with dots', () => {
     expect(
       extractVariableIdentifier('{{ hummus.mtabal }}', {


### PR DESCRIPTION
Seems that we shouldn't use the -1 length in this case, work for all cases including new tests for malformatted variables (without spaces or some spaces only)