### PR TITLE
feat(back): no more None values in step.dict()

### DIFF
--- a/server/tests/test_pipeline.py
+++ b/server/tests/test_pipeline.py
@@ -66,7 +66,7 @@ def test_to_dict():
             {
                 'name': 'rollup',
                 'hierarchy': ['a', 'b'],
-                'aggregations': [{'newcolumns': ['a'], 'aggfunction': 'sum', 'columns': ['a']}],
+                'aggregations': [{'new_columns': ['a'], 'agg_function': 'sum', 'columns': ['a']}],
             },
         ]
     }

--- a/server/tests/test_pipeline_executor.py
+++ b/server/tests/test_pipeline_executor.py
@@ -79,7 +79,7 @@ def test_preview_pipeline_limit_offset(pipeline_executor):
 
 
 def test_extract_domain(pipeline_executor: PipelineExecutor):
-    df, _ = pipeline_executor.execute_pipeline(
+    df = pipeline_executor.execute_pipeline(
         Pipeline(steps=[{'name': 'domain', 'domain': 'domain_a'}])
     )
 
@@ -87,7 +87,7 @@ def test_extract_domain(pipeline_executor: PipelineExecutor):
 
 
 def test_filter(pipeline_executor):
-    df, _ = pipeline_executor.execute_pipeline(
+    df = pipeline_executor.execute_pipeline(
         Pipeline(
             steps=[
                 {'name': 'domain', 'domain': 'domain_a'},
@@ -106,7 +106,7 @@ def test_filter(pipeline_executor):
 
 
 def test_rename(pipeline_executor):
-    df, _ = pipeline_executor.execute_pipeline(
+    df = pipeline_executor.execute_pipeline(
         Pipeline(
             steps=[
                 {'name': 'domain', 'domain': 'domain_a'},
@@ -148,16 +148,3 @@ def test_errors(pipeline_executor):
     assert 'whatever' in exception_message
     assert excinfo.value.details['index'] == 1
     assert excinfo.value.details['message'] == exception_message
-
-
-def test_report(pipeline_executor):
-    _, report = pipeline_executor.execute_pipeline(
-        Pipeline(
-            steps=[
-                {'name': 'domain', 'domain': 'domain_a'},
-                {'name': 'rename', 'toRename': [['colA', 'col_a'], ['colB', 'col_b']]},
-            ]
-        )
-    )
-    # there should be one step_report per step in the pipeline
-    assert len(report.steps_reports) == 2

--- a/server/weaverbird/pipeline.py
+++ b/server/weaverbird/pipeline.py
@@ -125,8 +125,8 @@ PipelineStep = Union[
 class Pipeline(BaseModel):
     steps: List[PipelineStep]
 
-    def dict(self, *, exclude_none: bool = True, by_alias=True, **kwargs) -> Dict:
-        return super().dict(exclude_none=exclude_none, by_alias=by_alias, **kwargs)
+    def dict(self, *, exclude_none: bool = True, **kwargs) -> Dict:
+        return super().dict(exclude_none=True, **kwargs)
 
 
 PipelineStepWithVariables = Union[

--- a/server/weaverbird/pipeline_executor.py
+++ b/server/weaverbird/pipeline_executor.py
@@ -1,26 +1,14 @@
 import json
 import logging
-from typing import List, Tuple
 
 from pandas import DataFrame
 from pandas.io.json import build_table_schema
-from pydantic import BaseModel, Field
 
 from weaverbird.pipeline import Pipeline, PipelineStep
 from weaverbird.types import DomainRetriever
 from weaverbird.utils import StopWatch, convert_size
 
 logger = logging.getLogger(__name__)
-
-
-class StepExecutionReport(BaseModel):
-    step_index: int
-    time_spent_in_ms: int
-    memory_used_in_bytes: int
-
-
-class PipelineExecutionReport(BaseModel):
-    steps_reports: List[StepExecutionReport] = Field(min_items=0)
 
 
 class PipelineExecutor:
@@ -33,7 +21,7 @@ class PipelineExecutor:
     def __init__(self, domain_retriever: DomainRetriever):
         self.retrieve_domain = domain_retriever
 
-    def execute_pipeline(self, pipeline: Pipeline) -> Tuple[DataFrame, PipelineExecutionReport]:
+    def execute_pipeline(self, pipeline: Pipeline) -> DataFrame:
         """
         Execute a pipeline and returns the result as a pandas DataFrame
         """
@@ -42,7 +30,6 @@ class PipelineExecutor:
         steps = pipeline.steps
         df = None
         stopwatch = StopWatch()
-        step_reports = []
         for index, step in enumerate(steps):
             try:
                 with stopwatch:
@@ -54,16 +41,9 @@ class PipelineExecutor:
                 logger.info(
                     f'step {step} used {convert_size(df.memory_usage().sum())}, took {stopwatch.interval}s to execute'
                 )
-                step_reports.append(
-                    StepExecutionReport(
-                        step_index=index,
-                        memory_used_in_bytes=df.memory_usage().sum(),
-                        time_spent_in_ms=int(stopwatch.interval * 1000),
-                    )
-                )
             except Exception as e:
                 raise PipelineExecutionFailure(step, index, e) from e
-        return df, PipelineExecutionReport(steps_reports=step_reports)
+        return df
 
     def preview_pipeline(self, pipeline: Pipeline, limit: int = 50, offset: int = 0) -> str:
         """
@@ -75,7 +55,7 @@ class PipelineExecutor:
 
         Note: it's required to use pandas `to_json` methods, as it convert NaN and dates to an appropriate format.
         """
-        df, _ = self.execute_pipeline(pipeline)
+        df = self.execute_pipeline(pipeline)
         return json.dumps(
             {
                 'schema': build_table_schema(df, index=False),

--- a/server/weaverbird/steps/base.py
+++ b/server/weaverbird/steps/base.py
@@ -20,5 +20,5 @@ class BaseStep(BaseModel, ABC):
         ...
 
     # None values are excluded, to avoid triggering validation error in Tucana
-    def dict(self, *, exclude_none: bool = True, by_alias=True, **kwargs) -> Dict:
-        return super().dict(exclude_none=exclude_none, by_alias=True, **kwargs)
+    def dict(self, *, exclude_none: bool = True, **kwargs) -> Dict:
+        return super().dict(exclude_none=True, **kwargs)


### PR DESCRIPTION
What has been done in https://github.com/ToucanToco/weaverbird/pull/865 is not enough (because parent models dict()'s options are always forwarded to children models), so let's enforce `exclude_none=True`.

This PR also contains a revert of PR #868, because this PR breaks the API and should not be included in weaverbird 0.3.4. This PR will be recreated afterwards, with version 0.4.0.