### PR TITLE
fix(filter-condition): update value when changing widget

### DIFF
--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -44,7 +44,7 @@
 import { ErrorObject } from 'ajv';
 import isEqual from 'lodash/isEqual';
 import { VueConstructor } from 'vue';
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
@@ -130,6 +130,15 @@ export default class FilterSimpleConditionWidget extends Vue {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Watch('hasDateSelectedColumn')
+  verifyIfValueIsStillValid() {
+    // when column change from date to another type or inverse,
+    // we need to reapply default widget value in case current value is not valid
+    // ex: [X] '' in string column will become an 'Invalid Date' in date column
+    // ex: [X] new Date() in date column will become an object in string column
+    this.updateStepOperator(this.operator);
+  }
 
   readonly operators: OperatorOption[] = [
     { operator: 'eq', label: 'equals', inputWidget: InputTextWidget },

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -168,18 +168,21 @@ export default class FilterSimpleConditionWidget extends Vue {
     return 'Enter a value';
   }
 
+  get hasDateSelectedColumn(): boolean {
+    return (
+      this.$store.state?.vqb?.featureFlags != undefined &&
+      this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enable' &&
+      this.columnTypes[this.value.column] == 'date'
+    );
+  }
+
   get operator(): OperatorOption {
     return this.operators.filter(d => d.operator === this.value.operator)[0];
   }
 
   get inputWidget(): VueConstructor<Vue> | undefined {
     const widget = this.operators.filter(d => d.operator === this.value.operator)[0].inputWidget;
-    if (
-      this.$store.state?.vqb?.featureFlags != undefined &&
-      this.$store.state.vqb.featureFlags.QUERYBUILDER_ESJSON == 'enable' &&
-      widget === InputTextWidget &&
-      this.columnTypes[this.value.column] == 'date'
-    ) {
+    if (this.hasDateSelectedColumn && widget === InputTextWidget) {
       return InputDateWidget;
     }
     if (widget) {

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -49,7 +49,11 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import { ColumnTypeMapping } from '@/lib/dataset/index.ts';
-import { keepCurrentValueIfArrayType, keepCurrentValueIfCompatibleType } from '@/lib/helpers';
+import {
+  keepCurrentValueIfArrayType,
+  keepCurrentValueIfCompatibleDate,
+  keepCurrentValueIfCompatibleType,
+} from '@/lib/helpers';
 import { FilterSimpleCondition } from '@/lib/steps';
 import { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 import { VQBModule } from '@/store';
@@ -199,6 +203,10 @@ export default class FilterSimpleConditionWidget extends Vue {
       updatedValue.value = keepCurrentValueIfArrayType(updatedValue.value, []);
     } else if (updatedValue.operator === 'isnull' || updatedValue.operator === 'notnull') {
       updatedValue.value = null;
+    } else if (this.hasDateSelectedColumn) {
+      // when using date widget, we need value to be a valid date
+      // null as date will become "01/01/1970" as default value for input
+      updatedValue.value = keepCurrentValueIfCompatibleDate(updatedValue.value, null);
     } else {
       updatedValue.value = keepCurrentValueIfCompatibleType(updatedValue.value, '');
     }

--- a/src/components/stepforms/widgets/InputDate.vue
+++ b/src/components/stepforms/widgets/InputDate.vue
@@ -15,13 +15,9 @@
     >
       <input
         ref="input"
-        :class="elementClass"
+        class="widget-input-date"
         :placeholder="placeholder"
         type="date"
-        :min="min"
-        :max="max"
-        @blur="blur()"
-        @focus="focus()"
         @input="updateValue($event.target.value)"
       />
     </VariableInput>
@@ -76,13 +72,6 @@ export default class InputDateWidget extends Mixins(FormWidget) {
       // 10 characters gives us YYYY-MM-DD
       input.value = this.value.toISOString().substr(0, 10);
     }
-  }
-
-  get elementClass() {
-    return {
-      'widget-input-date': true,
-      'widget-input-date--focused': this.isFocused,
-    };
   }
 
   updateValue(newValue: string) {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,7 +1,7 @@
 import { DataSetColumnType } from './dataset';
 import { AddTotalRowsStep, RollupStep } from './steps';
 
-type ValueType = number | boolean | string | null;
+type ValueType = number | boolean | string | null | object | Date;
 /** We do not include AggregateStep as this step has some specifities that do
  *  not factorize well in the setAggregationsNewColumnsInStep helper function
  *  defined below */
@@ -85,6 +85,19 @@ export function keepCurrentValueIfCompatibleType(
 ): ValueType {
   if (Array.isArray(value)) return defaultValue;
   return typeof value === typeof defaultValue ? value : defaultValue;
+}
+
+/**
+ * Return default value if selected value is not a right formatted date
+ *
+ * @param date the selected value
+ * @param defaultValue the default to compare
+ */
+export function keepCurrentValueIfCompatibleDate(
+  value: ValueType,
+  defaultValue: ValueType,
+): ValueType {
+  return value instanceof Date && !isNaN(value.getTime()) ? value : defaultValue;
 }
 
 /**

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -341,5 +341,21 @@ describe('Widget FilterSimpleCondition', () => {
         { column: 'columnA', value: null, operator: 'eq' },
       ]);
     });
+    it('should transform invalid dates to valid date when changing the column type', async () => {
+      createWrapper(shallowMount, {
+        value: { column: 'columnA', value: new Date('2021-01-01'), operator: 'eq' },
+      });
+      wrapper.setProps({ columnTypes: { columnA: 'string' } });
+      await wrapper.vm.$nextTick();
+      // relaunch operator validation automatically when changing the column type
+      expect(wrapper.emitted().input[0]).toEqual([
+        { column: 'columnA', value: '', operator: 'eq' },
+      ]);
+      wrapper.setProps({ columnTypes: { columnA: 'date' } });
+      await wrapper.vm.$nextTick();
+      expect(wrapper.emitted().input[1]).toEqual([
+        { column: 'columnA', value: null, operator: 'eq' },
+      ]);
+    });
   });
 });

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -351,11 +351,6 @@ describe('Widget FilterSimpleCondition', () => {
       expect(wrapper.emitted().input[0]).toEqual([
         { column: 'columnA', value: '', operator: 'eq' },
       ]);
-      wrapper.setProps({ columnTypes: { columnA: 'date' } });
-      await wrapper.vm.$nextTick();
-      expect(wrapper.emitted().input[1]).toEqual([
-        { column: 'columnA', value: null, operator: 'eq' },
-      ]);
     });
   });
 });

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -1,4 +1,4 @@
-import { createLocalVue, mount, shallowMount } from '@vue/test-utils';
+import { createLocalVue, mount, shallowMount, Wrapper } from '@vue/test-utils';
 import Vuex, { Store } from 'vuex';
 
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
@@ -276,26 +276,70 @@ describe('Widget FilterSimpleCondition', () => {
     expect(wrapper.emitted().input[0]).toEqual([{ column: 'columnA', value: [], operator: 'in' }]);
   });
 
-  it("should have a date input if the column type is 'Date' and the featureflag is enabled", async () => {
-    const store = setupMockStore({
-      dataset: {
-        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-        data: [],
-      },
-      selectedColumns: ['columnA'],
+  describe('date column and date featureflag enabled', () => {
+    let wrapper: Wrapper<FilterSimpleConditionWidget>;
+    const createWrapper = (mountType: Function, customProps: any = {}) => {
+      const store = setupMockStore({
+        dataset: {
+          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+          data: [],
+        },
+        selectedColumns: ['columnA'],
+      });
+      store.state.vqb.featureFlags = {};
+      store.state.vqb.featureFlags.QUERYBUILDER_ESJSON = 'enable';
+      wrapper = mountType(FilterSimpleConditionWidget, {
+        propsData: {
+          value: { column: 'columnA', value: new Date('2021-01-01'), operator: 'eq' },
+          columnTypes: { columnA: 'date' },
+          ...customProps,
+        },
+        store,
+        localVue,
+        sync: false,
+      });
+    };
+
+    it('should use the date input', () => {
+      createWrapper(mount);
+      const widgetWrappers = wrapper.findAll('.filterValue');
+      expect(widgetWrappers.at(0).classes()).toContain('widget-input-date__container');
     });
-    store.state.vqb.featureFlags = {};
-    store.state.vqb.featureFlags.QUERYBUILDER_ESJSON = 'enable';
-    const wrapper = mount(FilterSimpleConditionWidget, {
-      propsData: {
-        value: { column: 'columnA', value: new Date('2021-01-01'), operator: 'eq' },
-        columnTypes: { columnA: 'date' },
-      },
-      store,
-      localVue,
-      sync: false,
+
+    it('should emit a new condition with the correct type of value when changing the operator', () => {
+      createWrapper(shallowMount);
+      const operatorWrapper = wrapper.findAll('autocompletewidget-stub').at(1);
+      // ne operator
+      operatorWrapper.vm.$emit('input', { operator: 'ne' });
+      expect(wrapper.emitted().input[0]).toEqual([
+        { column: 'columnA', value: new Date('2021-01-01'), operator: 'ne' },
+      ]);
+      // eq operator
+      operatorWrapper.vm.$emit('input', { operator: 'eq' });
+      expect(wrapper.emitted().input[1]).toEqual([
+        { column: 'columnA', value: new Date('2021-01-01'), operator: 'eq' },
+      ]);
+      // in operator
+      operatorWrapper.vm.$emit('input', { operator: 'in' });
+      expect(wrapper.emitted().input[2]).toEqual([
+        { column: 'columnA', value: [], operator: 'in' },
+      ]);
+      // isnull operator
+      operatorWrapper.vm.$emit('input', { operator: 'isnull' });
+      expect(wrapper.emitted().input[3]).toEqual([
+        { column: 'columnA', value: null, operator: 'isnull' },
+      ]);
     });
-    const widgetWrappers = wrapper.findAll('.filterValue');
-    expect(widgetWrappers.at(0).classes()).toContain('widget-input-date__container');
+    it('should transform invalid dates to valid date when changing the operator', () => {
+      createWrapper(shallowMount, {
+        value: { column: 'columnA', value: 'lolo', operator: 'matches' },
+      });
+      const operatorWrapper = wrapper.findAll('autocompletewidget-stub').at(1);
+      // eq operator
+      operatorWrapper.vm.$emit('input', { operator: 'eq' });
+      expect(wrapper.emitted().input[0]).toEqual([
+        { column: 'columnA', value: null, operator: 'eq' },
+      ]);
+    });
   });
 });

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -5,6 +5,7 @@ import {
   enumerate,
   generateNewColumnName,
   keepCurrentValueIfArrayType,
+  keepCurrentValueIfCompatibleDate,
   keepCurrentValueIfCompatibleType,
   setAggregationsNewColumnsInStep,
 } from '@/lib/helpers';
@@ -130,6 +131,21 @@ describe('castFromString', () => {
     });
     it('should return selected value if its type match default one', () => {
       expect(keepCurrentValueIfCompatibleType('3', '')).toEqual('3');
+    });
+  });
+
+  describe('keepCurrentValueIfCompatibleDate', () => {
+    it('should return default if selected value is not a date', () => {
+      expect(keepCurrentValueIfCompatibleDate(3, null)).toEqual(null);
+      expect(keepCurrentValueIfCompatibleDate(null, null)).toEqual(null);
+      expect(keepCurrentValueIfCompatibleDate('12/04/2021', null)).toEqual(null);
+    });
+    it('should return default if selected value is not a well formatted date', () => {
+      expect(keepCurrentValueIfCompatibleDate(new Date('toto'), null)).toEqual(null);
+    });
+    it('should return selected value if its a well formatted date', () => {
+      const value = new Date('12/04/2021');
+      expect(keepCurrentValueIfCompatibleDate(value, null)).toEqual(value);
     });
   });
 


### PR DESCRIPTION
Case 1: changing operator.
Add a case for date input to keep date for matches operator (otherwise date should be a string to match the keepCurrentValueIfCompatibleType logic (which apply a default value if type is not the same than default value one ).
Ex: we choose an eq operator, we change to ne operator (default value of ne oprator is '', and we have a date selected, we compare a date to a string so we reapply '' but we want to keep the date).
So we add a case for date with method keepCurrentValueIfCompatibleDate when column type is date

Case 2: changing column type
We need to reverify operator in this case too because we may don't want to keep old value.

Before:
![before-o](https://user-images.githubusercontent.com/59559689/114572539-ddbb1a00-9c77-11eb-9375-bc76f6ab8eb7.gif)

After:
![after-o](https://user-images.githubusercontent.com/59559689/114572551-e14ea100-9c77-11eb-8d00-716d081b274e.gif)