### PR TITLE
fix(input-date): enable to use variables

### DIFF
--- a/src/components/stepforms/widgets/InputDate.vue
+++ b/src/components/stepforms/widgets/InputDate.vue
@@ -7,7 +7,7 @@
       </a>
     </div>
     <VariableInput
-      :value="value"
+      :value="parsedValue"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :has-arrow="true"
@@ -18,6 +18,7 @@
         class="widget-input-date"
         :placeholder="placeholder"
         type="date"
+        :value="parsedValue"
         @input="updateValue($event.target.value)"
       />
     </VariableInput>
@@ -54,7 +55,7 @@ export default class InputDateWidget extends Mixins(FormWidget) {
   placeholder!: string;
 
   @Prop({ default: '' })
-  value!: Date;
+  value!: string | Date;
 
   @Prop({ default: undefined })
   docUrl!: string | undefined;
@@ -65,16 +66,16 @@ export default class InputDateWidget extends Mixins(FormWidget) {
   @Prop()
   variableDelimiters?: VariableDelimiters;
 
-  mounted() {
-    if (this.value) {
-      const input: any = this.$refs.input;
-      // we receive back as value the full date. but the input value NEEDS to be a string
-      // 10 characters gives us YYYY-MM-DD
-      input.value = this.value.toISOString().substr(0, 10);
-    }
+  get parsedValue(): string {
+    return this.value instanceof Date ? this.parseDateToString(this.value) : this.value;
   }
 
-  updateValue(newValue: string) {
+  parseDateToString(date: Date): string {
+    // transform a date to the attended date input string with format (YYYY-MM-DD)
+    return date.toISOString().substr(0, 10);
+  }
+
+  updateValue(newValue: string): void {
     this.$emit('input', newValue);
   }
 }

--- a/src/components/stepforms/widgets/InputDate.vue
+++ b/src/components/stepforms/widgets/InputDate.vue
@@ -71,7 +71,7 @@ export default class InputDateWidget extends Mixins(FormWidget) {
   }
 
   parseDateToString(date: Date): string {
-    // transform a date to the attended date input string with format (YYYY-MM-DD)
+    // transform a date to the expected date input string with format (YYYY-MM-DD)
     return date.toISOString().substr(0, 10);
   }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -8,7 +8,7 @@ type ValueType = number | boolean | string | null | object | Date;
 type StepWithAggregations = AddTotalRowsStep | RollupStep;
 
 /**
- * Return false selected value is not a right formatted date
+ * Return false if selected value is not a right formatted date
  *
  * @param value the selected value
  */

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -7,6 +7,15 @@ type ValueType = number | boolean | string | null | object | Date;
  *  defined below */
 type StepWithAggregations = AddTotalRowsStep | RollupStep;
 
+/**
+ * Return false selected value is not a right formatted date
+ *
+ * @param value the selected value
+ */
+export function isDate(value: ValueType): boolean {
+  return value instanceof Date && !isNaN(value.getTime());
+}
+
 function isBooleanString(string: string): boolean {
   return (
     string === 'true' ||
@@ -26,7 +35,8 @@ export function castFromString(value: string, type: DataSetColumnType, esJsonEna
   } else if (type === 'boolean' && isBooleanString(value)) {
     return value === 'true' || value === 'True' || value === 'TRUE' || value === '1';
   } else if (type === 'date' && esJsonEnabled) {
-    return new Date(value);
+    const parsedValue = new Date(value);
+    return isDate(parsedValue) ? parsedValue : value;
   }
   return value;
 }
@@ -88,7 +98,7 @@ export function keepCurrentValueIfCompatibleType(
 }
 
 /**
- * Return default value if selected value is not a right formatted date
+ * Return default value if selected value is not a right formatted date or a string
  *
  * @param date the selected value
  * @param defaultValue the default to compare
@@ -97,7 +107,7 @@ export function keepCurrentValueIfCompatibleDate(
   value: ValueType,
   defaultValue: ValueType,
 ): ValueType {
-  return value instanceof Date && !isNaN(value.getTime()) ? value : defaultValue;
+  return isDate(value) || typeof value === 'string' ? value : defaultValue;
 }
 
 /**

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -332,7 +332,7 @@ describe('Widget FilterSimpleCondition', () => {
     });
     it('should transform invalid dates to valid date when changing the operator', () => {
       createWrapper(shallowMount, {
-        value: { column: 'columnA', value: 'lolo', operator: 'matches' },
+        value: { column: 'columnA', value: 1, operator: 'matches' },
       });
       const operatorWrapper = wrapper.findAll('autocompletewidget-stub').at(1);
       // eq operator

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -24,6 +24,11 @@ describe('castFromString', () => {
     expect(castFromString(string1, 'date', true)).toEqual(new Date(string1));
   });
 
+  it('should cast date variable to string', () => {
+    const variable = '<%= lala %>';
+    expect(castFromString(variable, 'date', true)).toEqual(variable);
+  });
+
   it('should not cast a string that does not convert to number type', () => {
     const string = 'Hey';
     expect(castFromString(string, 'integer')).toEqual('Hey');
@@ -138,7 +143,6 @@ describe('castFromString', () => {
     it('should return default if selected value is not a date', () => {
       expect(keepCurrentValueIfCompatibleDate(3, null)).toEqual(null);
       expect(keepCurrentValueIfCompatibleDate(null, null)).toEqual(null);
-      expect(keepCurrentValueIfCompatibleDate('12/04/2021', null)).toEqual(null);
     });
     it('should return default if selected value is not a well formatted date', () => {
       expect(keepCurrentValueIfCompatibleDate(new Date('toto'), null)).toEqual(null);
@@ -146,6 +150,9 @@ describe('castFromString', () => {
     it('should return selected value if its a well formatted date', () => {
       const value = new Date('12/04/2021');
       expect(keepCurrentValueIfCompatibleDate(value, null)).toEqual(value);
+    });
+    it('should return selected value if its a string', () => {
+      expect(keepCurrentValueIfCompatibleDate('<%= lala %>', null)).toEqual('<%= lala %>');
     });
   });
 

--- a/tests/unit/input-date-widget.spec.ts
+++ b/tests/unit/input-date-widget.spec.ts
@@ -68,13 +68,22 @@ describe('Widget Input Text', () => {
     expect(el.value).toEqual('');
   });
 
-  it('should have a non empty input', () => {
+  it('should have pass date value as string to input', () => {
     const wrapper = shallowMount(InputDateWidget, {
       propsData: { value: new Date('2021-01-01') },
     });
     const el = wrapper.find("input[type='date']").element as HTMLInputElement;
 
     expect(el.value).toEqual('2021-01-01');
+  });
+
+  it('should have pass date value as string to variable input', () => {
+    const wrapper = shallowMount(InputDateWidget, {
+      propsData: { value: new Date('2021-01-01') },
+    });
+    const el = wrapper.find('VariableInput-stub');
+
+    expect(el.props('value')).toEqual('2021-01-01');
   });
 
   it('should emit "input" event on update', () => {
@@ -121,5 +130,16 @@ describe('Widget Input Text', () => {
   it('should not display a warning message if messageError does not exist', () => {
     const wrapper = mount(InputDateWidget);
     expect(wrapper.find('.field__msg-warning').exists()).toBeFalsy();
+  });
+
+  it('should handle variables', () => {
+    const wrapper = shallowMount(InputDateWidget, {
+      propsData: {
+        value: '<%= my_variable %>',
+      },
+    });
+    const el = wrapper.find('VariableInput-stub');
+
+    expect(el.props('value')).toEqual('<%= my_variable %>');
   });
 });


### PR DESCRIPTION
Will disable logic to apply a default date in date input of  https://github.com/ToucanToco/weaverbird/pull/875 (if date is empty it will not validate the step as in other inputs :tada: )

Before:
![before](https://user-images.githubusercontent.com/59559689/114572347-b06e6c00-9c77-11eb-8c8c-014416e177bf.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/114572361-b49a8980-9c77-11eb-8f37-eee1c9a6b41c.gif)
