### PR TITLE
fix(date-step-form): always display custom input format when custom format is selected

### DIFF
--- a/src/components/stepforms/FromDateStepForm.vue
+++ b/src/components/stepforms/FromDateStepForm.vue
@@ -125,17 +125,6 @@ export default class FromDateStepForm extends BaseStepForm<FromDateStep> {
   ];
   selectedFormat?: FormatOption;
 
-  created() {
-    this.selectedFormat = this.getSelectedFormat();
-  }
-
-  getSelectedFormat(): FormatOption {
-    if (this.datePresets.includes(this.editedStep.format)) {
-      return this.formatOptions.filter(d => d.format === this.editedStep.format)[0];
-    }
-    return this.formatOptions.filter(d => d.format === 'custom')[0];
-  }
-
   get stepSelectedColumn() {
     return this.editedStep.column;
   }
@@ -145,6 +134,17 @@ export default class FromDateStepForm extends BaseStepForm<FromDateStep> {
       throw new Error('should not try to set null on "column" field');
     }
     this.editedStep.column = colname;
+  }
+
+  created() {
+    this.selectedFormat = this.getSelectedFormat();
+  }
+
+  getSelectedFormat(): FormatOption {
+    if (this.datePresets.includes(this.editedStep.format)) {
+      return this.formatOptions.filter(d => d.format === this.editedStep.format)[0];
+    }
+    return this.formatOptions.filter(d => d.format === 'custom')[0];
   }
 
   updateStepFormat(newFormat: FormatOption) {

--- a/src/components/stepforms/FromDateStepForm.vue
+++ b/src/components/stepforms/FromDateStepForm.vue
@@ -27,7 +27,7 @@
       :withExample="true"
     />
     <InputTextWidget
-      v-if="editedStep.format !== undefined && !datePresets.includes(editedStep.format)"
+      v-if="editedStep.format !== undefined && useCustomFormat"
       class="customFormat"
       v-model="editedStep.format"
       name="Custom date format:"
@@ -123,7 +123,7 @@ export default class FromDateStepForm extends BaseStepForm<FromDateStep> {
       doc: 'https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes',
     },
   ];
-  selectedFormat?: FormatOption;
+  selectedFormat: FormatOption = this.formatOptions[0];
 
   get stepSelectedColumn() {
     return this.editedStep.column;
@@ -134,6 +134,10 @@ export default class FromDateStepForm extends BaseStepForm<FromDateStep> {
       throw new Error('should not try to set null on "column" field');
     }
     this.editedStep.column = colname;
+  }
+
+  get useCustomFormat(): boolean {
+    return this.selectedFormat.format === 'custom';
   }
 
   created() {

--- a/src/components/stepforms/FromDateStepForm.vue
+++ b/src/components/stepforms/FromDateStepForm.vue
@@ -123,8 +123,13 @@ export default class FromDateStepForm extends BaseStepForm<FromDateStep> {
       doc: 'https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes',
     },
   ];
+  selectedFormat?: FormatOption;
 
-  get selectedFormat(): FormatOption {
+  created() {
+    this.selectedFormat = this.getSelectedFormat();
+  }
+
+  getSelectedFormat(): FormatOption {
     if (this.datePresets.includes(this.editedStep.format)) {
       return this.formatOptions.filter(d => d.format === this.editedStep.format)[0];
     }
@@ -148,6 +153,7 @@ export default class FromDateStepForm extends BaseStepForm<FromDateStep> {
     } else {
       this.editedStep.format = newFormat.format;
     }
+    this.selectedFormat = newFormat;
   }
 }
 </script>

--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -29,11 +29,7 @@
       :withExample="true"
     />
     <InputTextWidget
-      v-if="
-        translator !== 'mongo36' &&
-          editedStep.format !== undefined &&
-          !datePresets.includes(editedStep.format)
-      "
+      v-if="translator !== 'mongo36' && editedStep.format !== undefined && useCustomFormat"
       class="customFormat"
       v-model="editedStep.format"
       name="Custom date format:"
@@ -134,7 +130,7 @@ export default class ToDateStepForm extends BaseStepForm<ToDateStep> {
     },
   ];
 
-  selectedFormat?: FormatOption;
+  selectedFormat: FormatOption = this.formatOptions[0];
 
   get stepSelectedColumn() {
     return this.editedStep.column;
@@ -145,6 +141,9 @@ export default class ToDateStepForm extends BaseStepForm<ToDateStep> {
       throw new Error('should not try to set null on "column" field');
     }
     this.editedStep.column = colname;
+  }
+  get useCustomFormat(): boolean {
+    return this.selectedFormat.format === 'custom';
   }
 
   created() {

--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -136,6 +136,17 @@ export default class ToDateStepForm extends BaseStepForm<ToDateStep> {
 
   selectedFormat?: FormatOption;
 
+  get stepSelectedColumn() {
+    return this.editedStep.column;
+  }
+
+  set stepSelectedColumn(colname: string | null) {
+    if (colname === null) {
+      throw new Error('should not try to set null on "column" field');
+    }
+    this.editedStep.column = colname;
+  }
+
   created() {
     this.selectedFormat = this.getSelectedFormat();
   }
@@ -148,17 +159,6 @@ export default class ToDateStepForm extends BaseStepForm<ToDateStep> {
       return this.formatOptions.filter(d => d.format === this.editedStep.format)[0];
     }
     return this.formatOptions.filter(d => d.format === 'custom')[0];
-  }
-
-  get stepSelectedColumn() {
-    return this.editedStep.column;
-  }
-
-  set stepSelectedColumn(colname: string | null) {
-    if (colname === null) {
-      throw new Error('should not try to set null on "column" field');
-    }
-    this.editedStep.column = colname;
   }
 
   updateStepFormat(newFormat: FormatOption) {

--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -134,7 +134,13 @@ export default class ToDateStepForm extends BaseStepForm<ToDateStep> {
     },
   ];
 
-  get selectedFormat(): FormatOption {
+  selectedFormat?: FormatOption;
+
+  created() {
+    this.selectedFormat = this.getSelectedFormat();
+  }
+
+  getSelectedFormat(): FormatOption {
     if (this.editedStep.format === undefined) {
       return this.formatOptions.filter(d => d.format === 'guess')[0];
     }
@@ -163,6 +169,7 @@ export default class ToDateStepForm extends BaseStepForm<ToDateStep> {
     } else {
       this.editedStep.format = newFormat.format;
     }
+    this.selectedFormat = newFormat;
   }
 }
 </script>

--- a/tests/unit/fromdate-step-form.spec.ts
+++ b/tests/unit/fromdate-step-form.spec.ts
@@ -1,4 +1,4 @@
-import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { createLocalVue, shallowMount, Wrapper } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import FromDateStepForm from '@/components/stepforms/FromDateStepForm.vue';
@@ -56,16 +56,23 @@ describe('Convert Date to String Step Form', () => {
     expect(wrapper.vm.$data.editedStep.format).toEqual('%Y-%m');
   });
 
-  it('should pass down the right value to autcomplete', () => {
-    const wrapper = shallowMount(FromDateStepForm, {
-      store: setupMockStore({}),
-      localVue,
-      propsData: {
-        initialStepValue: { name: 'fromdate', column: '', format: '' },
-      },
+  describe('on init', () => {
+    let wrapper: Wrapper<FromDateStepForm>;
+    const createWrapper = (format: string) => {
+      if (wrapper) wrapper.destroy();
+      wrapper = shallowMount(FromDateStepForm, {
+        store: setupMockStore({}),
+        localVue,
+        propsData: {
+          initialStepValue: { name: 'fromdate', column: '', format },
+        },
+      });
+    };
+    it('should pass down the right value to autocomplete', () => {
+      createWrapper('');
+      expect(wrapper.find('.format').vm.$props.value.format).toEqual('custom');
+      createWrapper('%Y-%m');
+      expect(wrapper.find('.format').vm.$props.value.format).toEqual('%Y-%m');
     });
-    expect(wrapper.find('.format').vm.$props.value.format).toEqual('custom');
-    wrapper.setData({ editedStep: { name: 'todate', column: '', format: '%Y-%m' } });
-    expect(wrapper.find('.format').vm.$props.value.format).toEqual('%Y-%m');
   });
 });

--- a/tests/unit/fromdate-step-form.spec.ts
+++ b/tests/unit/fromdate-step-form.spec.ts
@@ -55,6 +55,24 @@ describe('Convert Date to String Step Form', () => {
       .vm.$emit('input', { format: '%Y-%m', label: '%Y-%m', example: '1970-12' });
     expect(wrapper.vm.$data.editedStep.format).toEqual('%Y-%m');
   });
+  it('should toggle custom format input correctly when switching selected format', () => {
+    const wrapper = shallowMount(FromDateStepForm, {
+      store: setupMockStore({}),
+      localVue,
+    });
+    wrapper
+      .find('autocompletewidget-stub')
+      .vm.$emit('input', { format: '%Y-%m', label: '%Y-%m', example: '1970-12' });
+    expect(wrapper.find('.customFormat').exists()).toBe(false);
+    wrapper
+      .find('autocompletewidget-stub')
+      .vm.$emit('input', { format: 'custom', label: '%Y-%m', example: '' });
+    expect(wrapper.find('.customFormat').exists()).toBe(true);
+    wrapper
+      .find('autocompletewidget-stub')
+      .vm.$emit('input', { format: '%Y-%m', label: '%Y-%m', example: '1970-12' });
+    expect(wrapper.find('.customFormat').exists()).toBe(false);
+  });
 
   describe('on init', () => {
     let wrapper: Wrapper<FromDateStepForm>;

--- a/tests/unit/todate-step-form.spec.ts
+++ b/tests/unit/todate-step-form.spec.ts
@@ -1,4 +1,4 @@
-import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { createLocalVue, shallowMount, Wrapper } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import ToDateStepForm from '@/components/stepforms/ToDateStepForm.vue';
@@ -71,18 +71,25 @@ describe('Convert String to Date Step Form', () => {
     expect(wrapper.vm.$data.editedStep.format).toEqual('%Y-%m');
   });
 
-  it('should pass downn the right value to autcomplete', () => {
-    const wrapper = shallowMount(ToDateStepForm, {
-      store: setupMockStore({}),
-      localVue,
-      propsData: {
-        initialStepValue: { name: 'todate', column: '' },
-      },
+  describe('on init', () => {
+    let wrapper: Wrapper<ToDateStepForm>;
+    const createWrapper = (format?: string) => {
+      if (wrapper) wrapper.destroy();
+      wrapper = shallowMount(ToDateStepForm, {
+        store: setupMockStore({}),
+        localVue,
+        propsData: {
+          initialStepValue: { name: 'todate', column: '', format },
+        },
+      });
+    };
+    it('should pass down the right value to autocomplete', () => {
+      createWrapper();
+      expect(wrapper.find('.format').vm.$props.value.format).toEqual('guess');
+      createWrapper('');
+      expect(wrapper.find('.format').vm.$props.value.format).toEqual('custom');
+      createWrapper('%Y-%m');
+      expect(wrapper.find('.format').vm.$props.value.format).toEqual('%Y-%m');
     });
-    expect(wrapper.find('.format').vm.$props.value.format).toEqual('guess');
-    wrapper.setData({ editedStep: { name: 'todate', column: '', format: '' } });
-    expect(wrapper.find('.format').vm.$props.value.format).toEqual('custom');
-    wrapper.setData({ editedStep: { name: 'todate', column: '', format: '%Y-%m' } });
-    expect(wrapper.find('.format').vm.$props.value.format).toEqual('%Y-%m');
   });
 });

--- a/tests/unit/todate-step-form.spec.ts
+++ b/tests/unit/todate-step-form.spec.ts
@@ -71,6 +71,25 @@ describe('Convert String to Date Step Form', () => {
     expect(wrapper.vm.$data.editedStep.format).toEqual('%Y-%m');
   });
 
+  it('should toggle custom format input correctly when switching selected format', () => {
+    const wrapper = shallowMount(ToDateStepForm, {
+      store: setupMockStore({}),
+      localVue,
+    });
+    wrapper
+      .find('autocompletewidget-stub')
+      .vm.$emit('input', { format: 'guess', label: '%Y-%m', example: '' });
+    expect(wrapper.find('.customFormat').exists()).toBe(false);
+    wrapper
+      .find('autocompletewidget-stub')
+      .vm.$emit('input', { format: 'custom', label: '%Y-%m', example: '' });
+    expect(wrapper.find('.customFormat').exists()).toBe(true);
+    wrapper
+      .find('autocompletewidget-stub')
+      .vm.$emit('input', { format: '%Y-%m', label: '%Y-%m', example: '1970-12' });
+    expect(wrapper.find('.customFormat').exists()).toBe(false);
+  });
+
   describe('on init', () => {
     let wrapper: Wrapper<ToDateStepForm>;
     const createWrapper = (format?: string) => {


### PR DESCRIPTION
Issue: We used a computed to define selected format (this computed was updated when changing value of custom format input (not only selected format in dropdown). 
We also automatically hide the custom format input if the format was present in the dropdown.

Resolve:
Remove computed property and use method to set selected format (custom format input update won't impact dropdown anymore)
Display custom format input when selected format is 'custom' 

:information_source: Made it on both steps (from and to) because logic is the same for the two steps

Before:
![before](https://user-images.githubusercontent.com/59559689/115250146-97f3cb00-a129-11eb-91ab-36cbe80f7db4.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/115250455-e1441a80-a129-11eb-9d0d-7a5edbc14a0d.gif)