### PR TITLE
fix(date-step-form): display custom format input with empty field

### DIFF
--- a/src/components/stepforms/FromDateStepForm.vue
+++ b/src/components/stepforms/FromDateStepForm.vue
@@ -29,7 +29,8 @@
     <InputTextWidget
       v-if="useCustomFormat"
       class="customFormat"
-      v-model="editedStep.format"
+      :value="editedStep.format"
+      @input="updateCustomFormat"
       name="Custom date format:"
       :placeholder="`Enter a ${translators.find(t => t.id === translator).label} date format`"
       data-path=".format"
@@ -158,6 +159,11 @@ export default class FromDateStepForm extends BaseStepForm<FromDateStep> {
       this.editedStep.format = newFormat.format;
     }
     this.selectedFormat = newFormat;
+  }
+
+  updateCustomFormat(format: string | undefined) {
+    // input text return undefined when user delete field content, we need an empty string to display custom format error
+    this.editedStep.format = format ?? '';
   }
 }
 </script>

--- a/src/components/stepforms/FromDateStepForm.vue
+++ b/src/components/stepforms/FromDateStepForm.vue
@@ -27,7 +27,7 @@
       :withExample="true"
     />
     <InputTextWidget
-      v-if="editedStep.format !== undefined && useCustomFormat"
+      v-if="useCustomFormat"
       class="customFormat"
       v-model="editedStep.format"
       name="Custom date format:"

--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -29,7 +29,7 @@
       :withExample="true"
     />
     <InputTextWidget
-      v-if="translator !== 'mongo36' && editedStep.format !== undefined && useCustomFormat"
+      v-if="translator !== 'mongo36' && useCustomFormat"
       class="customFormat"
       v-model="editedStep.format"
       name="Custom date format:"

--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -31,7 +31,8 @@
     <InputTextWidget
       v-if="translator !== 'mongo36' && useCustomFormat"
       class="customFormat"
-      v-model="editedStep.format"
+      :value="editedStep.format"
+      @input="updateCustomFormat"
       name="Custom date format:"
       :placeholder="`Enter a ${translators.find(t => t.id === translator).label} date format`"
       data-path=".format"
@@ -169,6 +170,11 @@ export default class ToDateStepForm extends BaseStepForm<ToDateStep> {
       this.editedStep.format = newFormat.format;
     }
     this.selectedFormat = newFormat;
+  }
+
+  updateCustomFormat(format: string | undefined) {
+    // input text return undefined when user delete field content, we need an empty string to display custom format error
+    this.editedStep.format = format ?? '';
   }
 }
 </script>

--- a/tests/unit/fromdate-step-form.spec.ts
+++ b/tests/unit/fromdate-step-form.spec.ts
@@ -74,6 +74,21 @@ describe('Convert Date to String Step Form', () => {
     expect(wrapper.find('.customFormat').exists()).toBe(false);
   });
 
+  describe('when user delete content of custom format input', () => {
+    it('should return empty string as format', () => {
+      const wrapper = shallowMount(FromDateStepForm, {
+        store: setupMockStore({}),
+        localVue,
+        propsData: {
+          initialStepValue: { name: 'todate', format: '%Y %m %d %d', column: 'wdc' },
+        },
+      });
+      wrapper.find('.customFormat').vm.$emit('input', undefined); // fake remove input content
+      expect(wrapper.vm.$data.editedStep.format).toEqual('');
+      expect(wrapper.find('.format').vm.$props.value.format).toEqual('custom');
+    });
+  });
+
   describe('on init', () => {
     let wrapper: Wrapper<FromDateStepForm>;
     const createWrapper = (format: string) => {

--- a/tests/unit/todate-step-form.spec.ts
+++ b/tests/unit/todate-step-form.spec.ts
@@ -90,6 +90,21 @@ describe('Convert String to Date Step Form', () => {
     expect(wrapper.find('.customFormat').exists()).toBe(false);
   });
 
+  describe('when user delete content of custom format input', () => {
+    it('should return empty string as format', () => {
+      const wrapper = shallowMount(ToDateStepForm, {
+        store: setupMockStore({}),
+        localVue,
+        propsData: {
+          initialStepValue: { name: 'todate', format: '%Y %m %d %d', column: 'wdc' },
+        },
+      });
+      wrapper.find('.customFormat').vm.$emit('input', undefined); // fake remove input content
+      expect(wrapper.vm.$data.editedStep.format).toEqual('');
+      expect(wrapper.find('.format').vm.$props.value.format).toEqual('custom');
+    });
+  });
+
   describe('on init', () => {
     let wrapper: Wrapper<ToDateStepForm>;
     const createWrapper = (format?: string) => {


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/59559689/115525181-259cfb00-a28f-11eb-96ae-75fef9efebe1.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/115525197-29308200-a28f-11eb-8bdd-854b0a966ebf.gif)
