### PR TITLE
feat(pipeline): delete multiple steps at once

### DIFF
--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -70,6 +70,7 @@ export default class PipelineComponent extends Vue {
   @VQBModule.Getter('isStepDisabled') isDisabled!: (index: number) => boolean;
 
   @VQBModule.Action selectStep!: ({ index }: { index: number }) => void;
+  @VQBModule.Action deleteSteps!: (payload: { indexes: number[] }) => void;
 
   editStep(step: PipelineStep, index: number) {
     this.$emit('editStep', step, index);
@@ -93,7 +94,7 @@ export default class PipelineComponent extends Vue {
   }
 
   deleteSelectedSteps(): void {
-    // TODO: handle store logic
+    this.deleteSteps({ indexes: this.stepsToDelete });
     // clean steps to delete
     this.stepsToDelete = [];
     this.closeDeleteConfirmationModal();

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -16,7 +16,11 @@
       @editStep="editStep"
       @toggleDelete="toggleStepToDelete({ index })"
     />
-    <div class="query-pipeline__delete-steps" v-if="stepsToDelete.length">
+    <div
+      class="query-pipeline__delete-steps"
+      v-if="stepsToDelete.length"
+      @click="openDeleteConfirmationModal"
+    >
       Delete [{{ stepsToDelete.length }}] selected
     </div>
     <div class="query-pipeline__tips-container">

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -22,6 +22,11 @@
       </div>
       <i class="fas fa-magic" aria-hidden="true" />
     </div>
+    <DeleteConfirmationModal
+      v-if="deleteConfirmationModalIsOpened"
+      @cancelDelete="closeDeleteConfirmationModal"
+      @validateDelete="deleteSelectedSteps"
+    />
   </div>
 </template>
 
@@ -34,17 +39,20 @@ import { DomainStep, Pipeline, PipelineStep } from '@/lib/steps';
 import { VariableDelimiters } from '@/lib/variables';
 import { VQBModule } from '@/store';
 
+import DeleteConfirmationModal from './DeleteConfirmationModal.vue';
 import Step from './Step.vue';
 
 @Component({
   name: 'pipeline',
   components: {
+    DeleteConfirmationModal,
     Step,
   },
 })
 export default class PipelineComponent extends Vue {
   // pipeline steps to delete based on their indexes
   stepsToDelete: number[] = [];
+  deleteConfirmationModalIsOpened = false;
 
   @VQBModule.State domains!: string[];
   @VQBModule.State variableDelimiters!: VariableDelimiters;
@@ -68,6 +76,21 @@ export default class PipelineComponent extends Vue {
   toggleStepToDelete({ index }: { index: number }): void {
     // toggle step to delete using its index in pipeline
     this.stepsToDelete = _xor(this.stepsToDelete, [index]);
+  }
+
+  openDeleteConfirmationModal(): void {
+    this.deleteConfirmationModalIsOpened = true;
+  }
+
+  closeDeleteConfirmationModal(): void {
+    this.deleteConfirmationModalIsOpened = false;
+  }
+
+  deleteSelectedSteps(): void {
+    // TODO: handle store logic
+    // clean steps to delete
+    this.stepsToDelete = [];
+    this.closeDeleteConfirmationModal();
   }
 }
 </script>

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -8,11 +8,13 @@
       :is-disabled="isDisabled(index)"
       :is-first="index === 0"
       :is-last="index === steps.length - 1"
+      :toDelete="toDelete({ index })"
       :step="step"
       :indexInPipeline="index"
       :variable-delimiters="variableDelimiters"
       @selectedStep="selectStep({ index: index })"
       @editStep="editStep"
+      @toggleDelete="toggleStepToDelete({ index })"
     />
     <div class="query-pipeline__tips-container">
       <div class="query-pipeline__tips">
@@ -24,6 +26,7 @@
 </template>
 
 <script lang="ts">
+import _xor from 'lodash/xor';
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 
@@ -40,6 +43,9 @@ import Step from './Step.vue';
   },
 })
 export default class PipelineComponent extends Vue {
+  // pipeline steps to delete based on their indexes
+  stepsToDelete: number[] = [];
+
   @VQBModule.State domains!: string[];
   @VQBModule.State variableDelimiters!: VariableDelimiters;
 
@@ -53,6 +59,15 @@ export default class PipelineComponent extends Vue {
 
   editStep(step: PipelineStep, index: number) {
     this.$emit('editStep', step, index);
+  }
+
+  toDelete({ index }: { index: number }): boolean {
+    return this.stepsToDelete.indexOf(index) !== -1;
+  }
+
+  toggleStepToDelete({ index }: { index: number }): void {
+    // toggle step to delete using its index in pipeline
+    this.stepsToDelete = _xor(this.stepsToDelete, [index]);
   }
 }
 </script>

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -16,12 +16,11 @@
       @editStep="editStep"
       @toggleDelete="toggleStepToDelete({ index })"
     />
-    <div
-      class="query-pipeline__delete-steps"
-      v-if="stepsToDelete.length"
-      @click="openDeleteConfirmationModal"
-    >
-      Delete [{{ stepsToDelete.length }}] selected
+    <div class="query-pipeline__delete-steps-container" v-if="stepsToDelete.length">
+      <div class="query-pipeline__delete-steps" @click="openDeleteConfirmationModal">
+        <i aria-hidden="true" class="fas fa-trash" />
+        Delete [{{ stepsToDelete.length }}] selected
+      </div>
     </div>
     <div class="query-pipeline__tips-container">
       <div class="query-pipeline__tips">
@@ -126,6 +125,26 @@ export default class PipelineComponent extends Vue {
   margin-top: 120px;
   margin-bottom: 40px;
   text-align: center;
+}
+
+.query-pipeline__delete-steps-container {
+  margin-top: 10px;
+  padding-left: 40px;
+  width: 100%;
+}
+
+.query-pipeline__delete-steps {
+  background: #b52519;
+  padding: 15px;
+  width: 100%;
+  text-align: center;
+  text-transform: uppercase;
+  color: white;
+  letter-spacing: 1.5px;
+  font-size: 12px;
+  font-weight: bold;
+  cursor: pointer;
+  border-radius: 2px;
 }
 
 .fa-code {

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -16,6 +16,9 @@
       @editStep="editStep"
       @toggleDelete="toggleStepToDelete({ index })"
     />
+    <div class="query-pipeline__delete-steps" v-if="stepsToDelete.length">
+      Delete [{{ stepsToDelete.length }}] selected
+    </div>
     <div class="query-pipeline__tips-container">
       <div class="query-pipeline__tips">
         Interact with the widgets and table on the right to add steps

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -2,8 +2,10 @@
   <div :class="classContainer">
     <div class="query-pipeline-queue">
       <div :class="firstStrokeClass" />
-      <div class="query-pipeline-queue__dot" @click="toggleDelete">
-        <div class="query-pipeline-queue__dot-ink" />
+      <div class="query-pipeline-queue__dot" :class="dotClass" @click="toggleDelete">
+        <div class="query-pipeline-queue__dot-ink">
+          <i class="fas fa-check" />
+        </div>
       </div>
       <div :class="lastStrokeClass" />
     </div>
@@ -104,6 +106,13 @@ export default class Step extends Vue {
     };
   }
 
+  get dotClass() {
+    return {
+      'query-pipeline-queue__dot--togglable': !this.isFirst,
+      'query-pipeline-queue__dot--to-delete': this.toDelete,
+    };
+  }
+
   get lastStrokeClass() {
     return {
       'query-pipeline-queue__stroke': true,
@@ -148,6 +157,7 @@ export default class Step extends Vue {
 
 .query-pipeline-queue {
   position: relative;
+  padding: 0 4px;
   margin-right: 20px;
   height: 100%;
   flex-direction: column;
@@ -169,11 +179,42 @@ export default class Step extends Vue {
   transition: transform 0.2s;
 }
 
+.query-pipeline-queue__dot--togglable:hover,
+.query-pipeline-queue__dot--to-delete {
+  transform: scale(1.3);
+  .query-pipeline-queue__dot-ink {
+    width: 16px;
+    height: 16px;
+    border: 2px solid $active-color;
+  }
+}
+
+.query-pipeline-queue__dot--togglable:hover .query-pipeline-queue__dot-ink {
+  background-color: white;
+}
+
+.query-pipeline-queue__dot--to-delete .query-pipeline-queue__dot-ink,
+.query-pipeline-queue__dot--to-delete:hover .query-pipeline-queue__dot-ink {
+  background-color: $active-color;
+  i {
+    visibility: visible;
+  }
+}
+
 .query-pipeline-queue__dot-ink {
   background-color: $active-color-faded;
   width: 8px;
   height: 8px;
   border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 8px;
+  color: white;
+  transform: width 0.2s, height 0.2s;
+  i {
+    visibility: hidden;
+  }
 }
 
 .query-pipeline-queue__stroke {
@@ -304,6 +345,16 @@ export default class Step extends Vue {
   .query-pipeline-queue__dot-ink {
     background-color: $error;
   }
+
+  .query-pipeline-queue__dot--togglable:hover .query-pipeline-queue__dot-ink {
+    border-color: $error;
+  }
+
+  .query-pipeline-queue__dot--to-delete .query-pipeline-queue__dot-ink,
+  .query-pipeline-queue__dot--to-delete:hover .query-pipeline-queue__dot-ink {
+    background-color: $error;
+    border-color: $error;
+  }
 }
 
 .query-pipeline-step__container--disabled {
@@ -320,6 +371,16 @@ export default class Step extends Vue {
   .query-pipeline-queue__dot-ink,
   .query-pipeline-step {
     opacity: 0.5;
+  }
+
+  .query-pipeline-queue__dot--togglable:hover .query-pipeline-queue__dot-ink {
+    border-color: $grey-dark;
+  }
+
+  .query-pipeline-queue__dot--to-delete .query-pipeline-queue__dot-ink,
+  .query-pipeline-queue__dot--to-delete:hover .query-pipeline-queue__dot-ink {
+    background-color: $grey-dark;
+    border-color: $grey-dark;
   }
 }
 </style>

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -15,13 +15,6 @@
           <div class="query-pipeline-step__action" @click.stop="editStep()">
             <i class="far fa-cog" aria-hidden="true" />
           </div>
-          <div
-            v-if="!isFirst"
-            class="query-pipeline-step__action"
-            @click="toggleDeleteConfirmationModal"
-          >
-            <i class="far fa-trash-alt" aria-hidden="true" />
-          </div>
         </div>
       </div>
       <div class="query-pipeline-step__footer" v-if="errorMessage && !isDisabled">

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -290,15 +290,15 @@ export default class Step extends Vue {
 .query-pipeline-step__container--togglable:hover {
   .query-pipeline-queue__dot-ink {
     background-color: white;
-    border-color: $active-color;
+    border-color: $active-color-faded;
   }
 }
 
 .query-pipeline-step__container--to-delete,
 .query-pipeline-step__container--to-delete:hover {
   .query-pipeline-queue__dot-ink {
-    background-color: $active-color;
-    border-color: $active-color;
+    background-color: $active-color-faded;
+    border-color: $active-color-faded;
     i {
       visibility: visible;
     }
@@ -323,6 +323,19 @@ export default class Step extends Vue {
   }
   .query-pipeline-queue__dot-ink {
     background-color: $active-color;
+  }
+  &.query-pipeline-step__container--togglable:hover {
+    .query-pipeline-queue__dot-ink {
+      border-color: $active-color;
+    }
+  }
+
+  &.query-pipeline-step__container--to-delete,
+  &.query-pipeline-step__container--to-delete:hover {
+    .query-pipeline-queue__dot-ink {
+      background-color: $active-color;
+      border-color: $active-color;
+    }
   }
 }
 .query-pipeline-step__container--errors {

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -23,11 +23,6 @@
         </div>
       </div>
     </div>
-    <DeleteConfirmationModal
-      v-if="deleteConfirmationModalIsOpened"
-      @cancelDelete="toggleDeleteConfirmationModal"
-      @validateDelete="deleteThisStep"
-    />
   </div>
 </template>
 <script lang="ts">
@@ -39,13 +34,8 @@ import { PipelineStep } from '@/lib/steps';
 import { VariableDelimiters } from '@/lib/variables';
 import { VQBModule } from '@/store';
 
-import DeleteConfirmationModal from './DeleteConfirmationModal.vue';
-
 @Component({
   name: 'step',
-  components: {
-    DeleteConfirmationModal,
-  },
 })
 export default class Step extends Vue {
   @Prop(Boolean)
@@ -74,10 +64,6 @@ export default class Step extends Vue {
 
   @Prop()
   readonly indexInPipeline!: number;
-
-  deleteConfirmationModalIsOpened = false;
-
-  @VQBModule.Action deleteStep;
 
   @VQBModule.Getter stepConfig!: (index: number) => PipelineStep;
 
@@ -125,21 +111,12 @@ export default class Step extends Vue {
     };
   }
 
-  deleteThisStep() {
-    this.toggleDeleteConfirmationModal();
-    this.deleteStep({ index: this.indexInPipeline });
-  }
-
   editStep() {
     this.$emit('editStep', this.stepConfig(this.indexInPipeline), this.indexInPipeline);
   }
 
   select() {
     this.$emit('selectedStep');
-  }
-
-  toggleDeleteConfirmationModal() {
-    this.deleteConfirmationModalIsOpened = !this.deleteConfirmationModalIsOpened;
   }
 
   toggleDelete(): void {

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -4,7 +4,7 @@
       <div :class="firstStrokeClass" />
       <div class="query-pipeline-queue__dot" :class="dotClass" @click="toggleDelete">
         <div class="query-pipeline-queue__dot-ink">
-          <i class="fas fa-check" />
+          <i class="fas fa-check" aria-hidden="true" />
         </div>
       </div>
       <div :class="lastStrokeClass" />

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -63,6 +63,9 @@ export default class Step extends Vue {
   @Prop(Boolean)
   readonly isDisabled!: boolean;
 
+  @Prop(Boolean)
+  readonly toDelete!: boolean;
+
   @Prop()
   step!: PipelineStep;
 

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -2,7 +2,7 @@
   <div :class="classContainer">
     <div class="query-pipeline-queue">
       <div :class="firstStrokeClass" />
-      <div class="query-pipeline-queue__dot" :class="dotClass" @click="toggleDelete">
+      <div class="query-pipeline-queue__dot" @click="toggleDelete">
         <div class="query-pipeline-queue__dot-ink">
           <i class="fas fa-check" aria-hidden="true" />
         </div>
@@ -92,6 +92,8 @@ export default class Step extends Vue {
   get classContainer() {
     return {
       'query-pipeline-step__container': true,
+      'query-pipeline-step__container--togglable': !this.isFirst,
+      'query-pipeline-step__container--to-delete': this.toDelete,
       'query-pipeline-step__container--active': this.isActive,
       'query-pipeline-step__container--last-active': this.isLastActive,
       'query-pipeline-step__container--disabled': this.isDisabled,
@@ -103,13 +105,6 @@ export default class Step extends Vue {
     return {
       'query-pipeline-queue__stroke': true,
       'query-pipeline-queue__stroke--hidden': this.isFirst,
-    };
-  }
-
-  get dotClass() {
-    return {
-      'query-pipeline-queue__dot--togglable': !this.isFirst,
-      'query-pipeline-queue__dot--to-delete': this.toDelete,
     };
   }
 
@@ -174,31 +169,8 @@ export default class Step extends Vue {
   display: flex;
   justify-content: center;
   align-items: center;
-  cursor: pointer;
   transform: scale(1);
   transition: transform 0.2s;
-}
-
-.query-pipeline-queue__dot--togglable:hover,
-.query-pipeline-queue__dot--to-delete {
-  transform: scale(1.3);
-  .query-pipeline-queue__dot-ink {
-    width: 16px;
-    height: 16px;
-    border: 2px solid $active-color;
-  }
-}
-
-.query-pipeline-queue__dot--togglable:hover .query-pipeline-queue__dot-ink {
-  background-color: white;
-}
-
-.query-pipeline-queue__dot--to-delete .query-pipeline-queue__dot-ink,
-.query-pipeline-queue__dot--to-delete:hover .query-pipeline-queue__dot-ink {
-  background-color: $active-color;
-  i {
-    visibility: visible;
-  }
 }
 
 .query-pipeline-queue__dot-ink {
@@ -302,6 +274,37 @@ export default class Step extends Vue {
   width: 100%;
 }
 
+.query-pipeline-step__container--to-delete,
+.query-pipeline-step__container--togglable:hover {
+  .query-pipeline-queue__dot {
+    transform: scale(1.3);
+    cursor: pointer;
+  }
+  .query-pipeline-queue__dot-ink {
+    width: 16px;
+    height: 16px;
+    border: 2px solid;
+  }
+}
+
+.query-pipeline-step__container--togglable:hover {
+  .query-pipeline-queue__dot-ink {
+    background-color: white;
+    border-color: $active-color;
+  }
+}
+
+.query-pipeline-step__container--to-delete,
+.query-pipeline-step__container--to-delete:hover {
+  .query-pipeline-queue__dot-ink {
+    background-color: $active-color;
+    border-color: $active-color;
+    i {
+      visibility: visible;
+    }
+  }
+}
+
 .query-pipeline-step__container--last-active {
   .query-pipeline-step {
     background: $active-color-faded-3;
@@ -346,14 +349,18 @@ export default class Step extends Vue {
     background-color: $error;
   }
 
-  .query-pipeline-queue__dot--togglable:hover .query-pipeline-queue__dot-ink {
-    border-color: $error;
+  &.query-pipeline-step__container--togglable:hover {
+    .query-pipeline-queue__dot-ink {
+      border-color: $error;
+    }
   }
 
-  .query-pipeline-queue__dot--to-delete .query-pipeline-queue__dot-ink,
-  .query-pipeline-queue__dot--to-delete:hover .query-pipeline-queue__dot-ink {
-    background-color: $error;
-    border-color: $error;
+  &.query-pipeline-step__container--to-delete,
+  &.query-pipeline-step__container--to-delete:hover {
+    .query-pipeline-queue__dot-ink {
+      background-color: $error;
+      border-color: $error;
+    }
   }
 }
 
@@ -373,14 +380,18 @@ export default class Step extends Vue {
     opacity: 0.5;
   }
 
-  .query-pipeline-queue__dot--togglable:hover .query-pipeline-queue__dot-ink {
-    border-color: $grey-dark;
+  &.query-pipeline-step__container--togglable:hover {
+    .query-pipeline-queue__dot-ink {
+      border-color: $grey-dark;
+    }
   }
 
-  .query-pipeline-queue__dot--to-delete .query-pipeline-queue__dot-ink,
-  .query-pipeline-queue__dot--to-delete:hover .query-pipeline-queue__dot-ink {
-    background-color: $grey-dark;
-    border-color: $grey-dark;
+  &.query-pipeline-step__container--to-delete,
+  &.query-pipeline-step__container--to-delete:hover {
+    .query-pipeline-queue__dot-ink {
+      background-color: $grey-dark;
+      border-color: $grey-dark;
+    }
   }
 }
 </style>

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -1,13 +1,13 @@
 <template>
-  <div :class="classContainer" @click="select()">
+  <div :class="classContainer">
     <div class="query-pipeline-queue">
       <div :class="firstStrokeClass" />
-      <div class="query-pipeline-queue__dot">
+      <div class="query-pipeline-queue__dot" @click="toggleDelete">
         <div class="query-pipeline-queue__dot-ink" />
       </div>
       <div :class="lastStrokeClass" />
     </div>
-    <div class="query-pipeline-step">
+    <div class="query-pipeline-step" @click="select()">
       <div class="query-pipeline-step__body">
         <span class="query-pipeline-step__name" :title="stepTitle" v-html="stepLabel" />
         <div class="query-pipeline-step__actions">
@@ -137,6 +137,10 @@ export default class Step extends Vue {
 
   toggleDeleteConfirmationModal() {
     this.deleteConfirmationModalIsOpened = !this.deleteConfirmationModalIsOpened;
+  }
+
+  toggleDelete(): void {
+    if (!this.isFirst) this.$emit('toggleDelete');
   }
 }
 </script>

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -104,8 +104,11 @@ class Actions {
     dispatch('updateDataset');
   }
 
-  deleteStep({ commit, dispatch }: ActionContext<VQBState, any>, { index }: { index: number }) {
-    commit('deleteStep', { index });
+  deleteSteps(
+    { commit, dispatch }: ActionContext<VQBState, any>,
+    { indexes }: { indexes: number[] },
+  ) {
+    commit('deleteSteps', { indexes });
     dispatch('updateDataset');
   }
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -6,7 +6,7 @@ import Vue from 'vue';
 import { MutationTree } from 'vuex';
 
 import { BackendError, BackendWarning } from '@/lib/backend';
-import { DomainStep, Pipeline, PipelineStepName } from '@/lib/steps';
+import { DomainStep, Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
 import { setVariableDelimiters } from '@/lib/translators';
 
 import { currentPipeline, VQBState } from './state';
@@ -185,16 +185,19 @@ class Mutations {
     }
   }
   /**
-   * Delete the step of index `index` in pipeline.
+   * Delete selected steps by indexes in pipeline.
    */
   @resetPagination
-  deleteStep(state: VQBState, { index }: { index: number }) {
+  deleteSteps(state: VQBState, { indexes }: { indexes: number[] }) {
     const pipeline = currentPipeline(state);
-    if (!pipeline) {
+    if (state.currentPipelineName === undefined || pipeline === undefined) {
       return;
     }
-    pipeline.splice(index, 1);
-    state.selectedStepIndex = index - 1;
+    const pipelineWithDeletedSteps = pipeline.filter(
+      (_: PipelineStep, index: number) => indexes.indexOf(index) === -1,
+    );
+    state.pipelines[state.currentPipelineName] = pipelineWithDeletedSteps;
+    state.selectedStepIndex = pipelineWithDeletedSteps.length - 1;
   }
   /**
    * change current selected domain and reset pipeline accordingly.

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,10 +1,10 @@
 // COLOR VARIABLES
 $base-color: #404040 !default;
 $base-color-light: #4c4c4c !default;
-$active-color: rgb(38, 101, 163) !default;
-$active-color-faded: rgba($active-color, 0.5) !default;
-$active-color-faded-2: rgba($active-color, 0.1) !default;
-$active-color-faded-3: rgba($active-color, 0.05) !default;
+$active-color: #2a66a1 !default;
+$active-color-faded: #89AACB !default;
+$active-color-faded-2: #e9eff5 !default;
+$active-color-faded-3: #e9eff5 !default;
 $data-viewer-border-color: #e0e0e0 !default;
 $light-grey: #fafafa;
 $grey: #eeeeee;

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -1,4 +1,4 @@
-import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { createLocalVue, shallowMount, Wrapper } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import PipelineComponent from '@/components/Pipeline.vue';
@@ -28,6 +28,7 @@ describe('Pipeline.vue', () => {
       isDisabled: false,
       isFirst: true,
       isLast: false,
+      toDelete: false,
       indexInPipeline: 0,
     });
     expect(step2).toEqual({
@@ -37,6 +38,7 @@ describe('Pipeline.vue', () => {
       isDisabled: false,
       isFirst: false,
       isLast: false,
+      toDelete: false,
       indexInPipeline: 1,
     });
     expect(step3).toEqual({
@@ -46,6 +48,7 @@ describe('Pipeline.vue', () => {
       isDisabled: false,
       isFirst: false,
       isLast: true,
+      toDelete: false,
       indexInPipeline: 2,
     });
   });
@@ -58,5 +61,42 @@ describe('Pipeline.vue', () => {
       'Interact with the widgets and table on the right to add steps',
     );
     expect(wrapper.find('.fa-magic').exists()).toBeTruthy();
+  });
+
+  describe('toggle delete step', () => {
+    let wrapper: Wrapper<PipelineComponent>, stepToDelete: Wrapper<any>;
+    beforeEach(async () => {
+      const pipeline: Pipeline = [
+        { name: 'domain', domain: 'GoT' },
+        { name: 'rename', toRename: [['foo', 'bar']] },
+      ];
+      const store = setupMockStore(buildStateWithOnePipeline(pipeline));
+      wrapper = shallowMount(PipelineComponent, { store, localVue });
+      const steps = wrapper.findAll('step-stub');
+      stepToDelete = steps.at(1);
+      stepToDelete.vm.$emit('toggleDelete');
+      await wrapper.vm.$nextTick();
+    });
+
+    //TODO: make better tests when feature updates during PR
+    it('should add step to steps to delete', () => {
+      expect((wrapper.vm as any).stepsToDelete).toContain(1);
+    });
+    it('should apply delete class to step', () => {
+      expect(stepToDelete.props().toDelete).toBe(true);
+    });
+
+    describe('when already selected', () => {
+      beforeEach(async () => {
+        stepToDelete.vm.$emit('toggleDelete');
+        await wrapper.vm.$nextTick();
+      });
+      it('should remove step from step to delete', () => {
+        expect((wrapper.vm as any).stepsToDelete).not.toContain(1);
+      });
+      it('should remove delete class from step', () => {
+        expect(stepToDelete.props().toDelete).toBe(false);
+      });
+    });
   });
 });

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -70,6 +70,7 @@ describe('Pipeline.vue', () => {
       const pipeline: Pipeline = [
         { name: 'domain', domain: 'GoT' },
         { name: 'rename', toRename: [['foo', 'bar']] },
+        { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
       ];
       const store = setupMockStore(buildStateWithOnePipeline(pipeline));
       wrapper = shallowMount(PipelineComponent, { store, localVue });
@@ -97,6 +98,31 @@ describe('Pipeline.vue', () => {
       });
       it('should remove delete class from step', () => {
         expect(stepToDelete.props().toDelete).toBe(false);
+      });
+    });
+
+    describe('when there is steps selected', () => {
+      beforeEach(async () => {
+        wrapper.setData({ stepsToDelete: [1, 2] });
+        await wrapper.vm.$nextTick();
+      });
+      it('should show the delete steps button', () => {
+        expect(wrapper.find('.query-pipeline__delete-steps').exists()).toBe(true);
+      });
+      it('should display the number of selected steps into the delete steps button', () => {
+        expect(wrapper.find('.query-pipeline__delete-steps').text()).toStrictEqual(
+          'Delete [2] selected',
+        );
+      });
+    });
+
+    describe('when there is no steps to delete', () => {
+      beforeEach(async () => {
+        wrapper.setData({ stepsToDelete: [] });
+        await wrapper.vm.$nextTick();
+      });
+      it('should hide the delete steps button', () => {
+        expect(wrapper.find('.query-pipeline__delete-steps').exists()).toBe(false);
       });
     });
   });

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -1,6 +1,7 @@
-import { createLocalVue, shallowMount, Wrapper } from '@vue/test-utils';
+import { createLocalVue, mount, shallowMount, Wrapper } from '@vue/test-utils';
 import Vuex from 'vuex';
 
+import DeleteConfirmationModal from '@/components/DeleteConfirmationModal.vue';
 import PipelineComponent from '@/components/Pipeline.vue';
 import { Pipeline } from '@/lib/steps';
 
@@ -96,6 +97,72 @@ describe('Pipeline.vue', () => {
       });
       it('should remove delete class from step', () => {
         expect(stepToDelete.props().toDelete).toBe(false);
+      });
+    });
+  });
+
+  it('does not render a delete confirmation modal by default', () => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'GoT' },
+      { name: 'rename', toRename: [['foo', 'bar']] },
+    ];
+    const store = setupMockStore(buildStateWithOnePipeline(pipeline));
+    const wrapper = shallowMount(PipelineComponent, { store, localVue });
+    const modal = wrapper.find('deleteconfirmationmodal-stub');
+    expect(modal.exists()).toBe(false);
+  });
+
+  describe('clicking on the delete button', () => {
+    let wrapper: Wrapper<PipelineComponent>, modal: Wrapper<any>;
+    const stepsToDelete = [1];
+
+    beforeEach(async () => {
+      const pipeline: Pipeline = [
+        { name: 'domain', domain: 'GoT' },
+        { name: 'rename', toRename: [['foo', 'bar']] },
+      ];
+      const store = setupMockStore(buildStateWithOnePipeline(pipeline));
+      wrapper = mount(PipelineComponent, { store, localVue });
+      wrapper.setData({ stepsToDelete });
+      //TODO: update this line when delete button is enabled
+      (wrapper.vm as any).openDeleteConfirmationModal();
+      await wrapper.vm.$nextTick();
+      modal = wrapper.find(DeleteConfirmationModal);
+    });
+
+    it('should render a delete confirmation modal', async () => {
+      expect(modal.exists()).toBe(true);
+    });
+
+    describe('when cancel confirmation', () => {
+      //TODO: update this tests when delete logic is enabled
+      beforeEach(async () => {
+        modal.find('.vqb-modal__action--secondary').trigger('click');
+        await wrapper.vm.$nextTick();
+        modal = wrapper.find(DeleteConfirmationModal);
+      });
+      it('should close the confirmation modal', () => {
+        // close the modal
+        expect(modal.exists()).toBe(false);
+      });
+      it('should keep the selected steps unchanged', () => {
+        expect((wrapper.vm as any).stepsToDelete).toStrictEqual(stepsToDelete);
+      });
+    });
+
+    describe('when validate', () => {
+      //TODO: update this tests when delete logic is enabled
+      beforeEach(async () => {
+        modal.find('.vqb-modal__action--primary').trigger('click');
+        await wrapper.vm.$nextTick();
+        modal = wrapper.find(DeleteConfirmationModal);
+      });
+      it('should close the confirmation modal', () => {
+        // close the modal
+        expect(modal.exists()).toBe(false);
+      });
+      it('should clean the selected steps', () => {
+        expect((wrapper.vm as any).stepsToDelete).toStrictEqual([]);
       });
     });
   });

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -107,10 +107,10 @@ describe('Pipeline.vue', () => {
         await wrapper.vm.$nextTick();
       });
       it('should show the delete steps button', () => {
-        expect(wrapper.find('.query-pipeline__delete-steps').exists()).toBe(true);
+        expect(wrapper.find('.query-pipeline__delete-steps-container').exists()).toBe(true);
       });
       it('should display the number of selected steps into the delete steps button', () => {
-        expect(wrapper.find('.query-pipeline__delete-steps').text()).toStrictEqual(
+        expect(wrapper.find('.query-pipeline__delete-steps').text()).toContain(
           'Delete [2] selected',
         );
       });
@@ -122,7 +122,7 @@ describe('Pipeline.vue', () => {
         await wrapper.vm.$nextTick();
       });
       it('should hide the delete steps button', () => {
-        expect(wrapper.find('.query-pipeline__delete-steps').exists()).toBe(false);
+        expect(wrapper.find('.qquery-pipeline__delete-steps-container').exists()).toBe(false);
       });
     });
   });

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -131,6 +131,7 @@ describe('Pipeline.vue', () => {
     const pipeline: Pipeline = [
       { name: 'domain', domain: 'GoT' },
       { name: 'rename', toRename: [['foo', 'bar']] },
+      { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
     ];
     const store = setupMockStore(buildStateWithOnePipeline(pipeline));
     const wrapper = shallowMount(PipelineComponent, { store, localVue });
@@ -140,18 +141,18 @@ describe('Pipeline.vue', () => {
 
   describe('clicking on the delete button', () => {
     let wrapper: Wrapper<PipelineComponent>, modal: Wrapper<any>;
-    const stepsToDelete = [1];
+    const stepsToDelete = [1, 2];
 
     beforeEach(async () => {
       const pipeline: Pipeline = [
         { name: 'domain', domain: 'GoT' },
         { name: 'rename', toRename: [['foo', 'bar']] },
+        { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
       ];
       const store = setupMockStore(buildStateWithOnePipeline(pipeline));
       wrapper = mount(PipelineComponent, { store, localVue });
       wrapper.setData({ stepsToDelete });
-      //TODO: update this line when delete button is enabled
-      (wrapper.vm as any).openDeleteConfirmationModal();
+      wrapper.find('.query-pipeline__delete-steps').trigger('click');
       await wrapper.vm.$nextTick();
       modal = wrapper.find(DeleteConfirmationModal);
     });

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -81,7 +81,6 @@ describe('Pipeline.vue', () => {
       await wrapper.vm.$nextTick();
     });
 
-    //TODO: make better tests when feature updates during PR
     it('should add step to steps to delete', () => {
       expect((wrapper.vm as any).stepsToDelete).toContain(1);
     });

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -81,7 +81,7 @@ describe('Pipeline.vue', () => {
       await wrapper.vm.$nextTick();
     });
 
-    it('should add step to steps to delete', () => {
+    it('should add step index to steps to delete', () => {
       expect((wrapper.vm as any).stepsToDelete).toContain(1);
     });
     it('should apply delete class to step', () => {
@@ -93,7 +93,7 @@ describe('Pipeline.vue', () => {
         stepToDelete.vm.$emit('toggleDelete');
         await wrapper.vm.$nextTick();
       });
-      it('should remove step from step to delete', () => {
+      it('should remove step index from step to delete', () => {
         expect((wrapper.vm as any).stepsToDelete).not.toContain(1);
       });
       it('should remove delete class from step', () => {

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -28,23 +28,6 @@ describe('Step.vue', () => {
     });
   };
 
-  it('emit selectedStep when clicking on a step "time travel" dot', async () => {
-    const wrapper = createStepWrapper({
-      propsData: {
-        key: 0,
-        isActive: true,
-        isDisabled: false,
-        isFirst: false,
-        isLast: true,
-        step: { name: 'rename', toRename: [['foo', 'bar']] },
-        indexInPipeline: 2,
-      },
-    });
-    wrapper.find('.query-pipeline-queue__dot').trigger('click');
-    await localVue.nextTick();
-    expect(wrapper.emitted()).toEqual({ selectedStep: [[]] });
-  });
-
   it('emit selectedStep when clicking on the step itself', async () => {
     const wrapper = createStepWrapper({
       propsData: {
@@ -76,6 +59,41 @@ describe('Step.vue', () => {
     });
     const modal = wrapper.find('deleteconfirmationmodal-stub');
     expect(modal.exists()).toBeFalsy();
+  });
+
+  it('emit toggleDelete when clicking on a step "time travel" dot', async () => {
+    const wrapper = createStepWrapper({
+      propsData: {
+        key: 0,
+        isActive: true,
+        isDisabled: false,
+        isFirst: false,
+        isLast: true,
+        step: { name: 'rename', toRename: [['foo', 'bar']] },
+        indexInPipeline: 2,
+      },
+    });
+    wrapper.find('.query-pipeline-queue__dot').trigger('click');
+    await localVue.nextTick();
+    expect(wrapper.emitted()).toEqual({ toggleDelete: [[]] });
+  });
+
+  it('should not enable to delete domain step', async () => {
+    const wrapper = createStepWrapper({
+      propsData: {
+        key: 0,
+        isActive: true,
+        isLastActive: true,
+        isDisabled: false,
+        isFirst: true,
+        isLast: true,
+        step: { name: 'domain', domain: 'GoT' },
+        indexInPipeline: 0,
+      },
+    });
+    wrapper.find('.query-pipeline-queue__dot').trigger('click');
+    await localVue.nextTick();
+    expect(wrapper.emitted().toggleDelete).toBeUndefined();
   });
 
   //TODO: update this tests with new delete multiple steps at once logic
@@ -265,7 +283,10 @@ describe('Step.vue', () => {
       );
       const wrapper = mount(PipelineComponent, { store, localVue });
       const stepsArray = wrapper.findAll(Step);
-      stepsArray.at(0).trigger('click');
+      stepsArray
+        .at(0)
+        .find('.query-pipeline-step')
+        .trigger('click');
       await localVue.nextTick();
       const replaceStep = stepsArray.at(1);
       expect(replaceStep.find('.query-pipeline-step__footer').exists()).toBe(false);

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -1,11 +1,9 @@
 import { createLocalVue, mount, shallowMount } from '@vue/test-utils';
 import Vuex from 'vuex';
 
-import DeleteConfirmationModal from '@/components/DeleteConfirmationModal.vue';
 import PipelineComponent from '@/components/Pipeline.vue';
 import Step from '@/components/Step.vue';
 import { Pipeline } from '@/lib/steps';
-import { VQBnamespace } from '@/store';
 
 import { buildStateWithOnePipeline, setupMockStore } from './utils';
 
@@ -45,22 +43,6 @@ describe('Step.vue', () => {
     expect(wrapper.emitted()).toEqual({ selectedStep: [[]] });
   });
 
-  it('does not render a delete confirmation modal by default', () => {
-    const wrapper = createStepWrapper({
-      propsData: {
-        key: 0,
-        isActive: true,
-        isDisabled: false,
-        isFirst: false,
-        isLast: true,
-        step: { name: 'rename', toRename: [['foo', 'bar']] },
-        indexInPipeline: 2,
-      },
-    });
-    const modal = wrapper.find('deleteconfirmationmodal-stub');
-    expect(modal.exists()).toBeFalsy();
-  });
-
   it('emit toggleDelete when clicking on a step "time travel" dot', async () => {
     const wrapper = createStepWrapper({
       propsData: {
@@ -95,29 +77,6 @@ describe('Step.vue', () => {
     await localVue.nextTick();
     expect(wrapper.emitted().toggleDelete).toBeUndefined();
   });
-
-  //TODO: update this tests with new delete multiple steps at once logic
-  it.skip('should render a delete confirmation modal when clicking on the button with the trash icon', async () => {
-    const wrapper = createStepWrapper({
-      propsData: {
-        key: 0,
-        isActive: true,
-        isDisabled: false,
-        isFirst: false,
-        isLast: true,
-        step: { name: 'rename', toRename: [['foo', 'bar']] },
-        indexInPipeline: 2,
-      },
-    });
-    wrapper
-      .findAll('.query-pipeline-step__action')
-      .at(1)
-      .trigger('click');
-    await localVue.nextTick();
-    const modal = wrapper.find('deleteconfirmationmodal-stub');
-    expect(modal.exists()).toBeTruthy();
-  });
-
   it('should render a stepLabel with the variable names', () => {
     const wrapper = createStepWrapper({
       propsData: {
@@ -133,56 +92,6 @@ describe('Step.vue', () => {
       },
     });
     expect(wrapper.find('.query-pipeline-step__name').text()).toBe('Source: "user.username"');
-  });
-
-  //TODO: update this tests with new delete multiple steps at once logic
-  describe.skip('Delete confirmation modal', () => {
-    it('does not delete a step when clicking on cancel on the delete confirmation modal', async () => {
-      const pipeline: Pipeline = [
-        { name: 'domain', domain: 'GoT' },
-        { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
-        { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
-      ];
-      const store = setupMockStore(buildStateWithOnePipeline(pipeline));
-      const wrapper = mount(PipelineComponent, { store, localVue });
-      const step = wrapper.findAll(Step).at(1);
-
-      // Test for clicking on the top-right cross
-      step.find('.fa-trash-alt').trigger('click');
-      await localVue.nextTick();
-      const modal = step.find(DeleteConfirmationModal);
-      modal.find('.fa-times').trigger('click');
-      await localVue.nextTick();
-      expect(store.getters[VQBnamespace('pipeline')].length).toEqual(3);
-      expect(step.find(DeleteConfirmationModal).exists()).toBeFalsy();
-
-      // Test for clicking on the bottom-left cancel button
-      step.find('.fa-trash-alt').trigger('click');
-      await localVue.nextTick();
-      const modalBis = step.find(DeleteConfirmationModal);
-      modalBis.find('.vqb-modal__action--secondary').trigger('click');
-      await localVue.nextTick();
-      expect(store.getters[VQBnamespace('pipeline')].length).toEqual(3);
-      expect(step.find(DeleteConfirmationModal).exists()).toBeFalsy();
-    });
-
-    it('deletes a step when clicking on validate on the delete confirmation modal', async () => {
-      const pipeline: Pipeline = [
-        { name: 'domain', domain: 'GoT' },
-        { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
-        { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
-      ];
-      const store = setupMockStore(buildStateWithOnePipeline(pipeline));
-      const wrapper = mount(PipelineComponent, { store, localVue });
-      const step = wrapper.findAll(Step).at(1);
-      step.find('.fa-trash-alt').trigger('click');
-      await localVue.nextTick();
-      const modal = step.find(DeleteConfirmationModal);
-      modal.find('.vqb-modal__action--primary').trigger('click');
-      await localVue.nextTick();
-      expect(store.getters[VQBnamespace('pipeline')].length).toEqual(2);
-      expect(step.find(DeleteConfirmationModal).exists()).toBeFalsy();
-    });
   });
 
   it('should toggle the edit mode when clicking on the edit icon and emit editStep', () => {

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -78,25 +78,8 @@ describe('Step.vue', () => {
     expect(modal.exists()).toBeFalsy();
   });
 
-  it('renders a delete confirmation modal when clicking on the trash icon', async () => {
-    const wrapper = createStepWrapper({
-      propsData: {
-        key: 0,
-        isActive: true,
-        isDisabled: false,
-        isFirst: false,
-        isLast: true,
-        step: { name: 'rename', toRename: [['foo', 'bar']] },
-        indexInPipeline: 2,
-      },
-    });
-    wrapper.find('.fa-trash-alt').trigger('click');
-    await localVue.nextTick();
-    const modal = wrapper.find('deleteconfirmationmodal-stub');
-    expect(modal.exists()).toBeTruthy();
-  });
-
-  it('should render a delete confirmation modal when clicking on the button with the trash icon', async () => {
+  //TODO: update this tests with new delete multiple steps at once logic
+  it.skip('should render a delete confirmation modal when clicking on the button with the trash icon', async () => {
     const wrapper = createStepWrapper({
       propsData: {
         key: 0,
@@ -117,22 +100,6 @@ describe('Step.vue', () => {
     expect(modal.exists()).toBeTruthy();
   });
 
-  it('should not render a trash icon on domain step', () => {
-    const wrapper = createStepWrapper({
-      propsData: {
-        key: 0,
-        isActive: true,
-        isLastActive: true,
-        isDisabled: false,
-        isFirst: true,
-        isLast: true,
-        step: { name: 'domain', domain: 'test' },
-        indexInPipeline: 0,
-      },
-    });
-    expect(wrapper.find('.fa-trash-alt').exists()).toBeFalsy();
-  });
-
   it('should render a stepLabel with the variable names', () => {
     const wrapper = createStepWrapper({
       propsData: {
@@ -150,7 +117,8 @@ describe('Step.vue', () => {
     expect(wrapper.find('.query-pipeline-step__name').text()).toBe('Source: "user.username"');
   });
 
-  describe('Delete confirmation modal', () => {
+  //TODO: update this tests with new delete multiple steps at once logic
+  describe.skip('Delete confirmation modal', () => {
     it('does not delete a step when clicking on cancel on the delete confirmation modal', async () => {
       const pipeline: Pipeline = [
         { name: 'domain', domain: 'GoT' },

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -410,14 +410,14 @@ describe('mutation tests', () => {
     spy.mockRestore();
   });
 
-  describe('deleteStep', function() {
+  describe('deleteSteps', function() {
     it('should do nothing if no pipeline is selected', () => {
       const state = buildState({});
-      mutations.deleteStep(state, { index: 1 });
+      mutations.deleteSteps(state, { indexes: [1] });
       expect(currentPipeline(state)).toBeUndefined();
     });
 
-    it('should delete a step on an existing pipeline and select the previous one', () => {
+    it('should delete selected steps on an existing pipeline and select the last available one', () => {
       const pipeline: Pipeline = [
         { name: 'domain', domain: 'foo' },
         { name: 'rename', toRename: [['foo', 'bar']] },
@@ -431,11 +431,10 @@ describe('mutation tests', () => {
           paginationContext: { pageno: 2, pagesize: 10, totalCount: 10 },
         },
       });
-      mutations.deleteStep(state, { index: 2 });
+      mutations.deleteSteps(state, { indexes: [1, 3] });
       expect(currentPipeline(state)).toEqual([
         { name: 'domain', domain: 'foo' },
-        { name: 'rename', toRename: [['foo', 'bar']] },
-        { name: 'rename', toRename: [['clou', 'vis']] },
+        { name: 'rename', toRename: [['baz', 'spam']] },
       ]);
       expect(state.selectedStepIndex).toEqual(1);
       // make sure the pagination is reset


### PR DESCRIPTION
Remove trash icon on pipeline step to use a multiple delete logic.

Changed logic:
* Before, user could click on all pipeline step to select it => now, he can only select the right rectangle, the dot is used for delete toggle only (hovering the rectangle will applyt he dot hover style)
* Before, when user deleted a step, the next step was directly selected (can be in the middle of the pipeline) =>  now, we always select the last step because we can't know where the steps as been deleted

Before:
![before](https://user-images.githubusercontent.com/59559689/116127558-45398680-a6c8-11eb-8af3-ce72c35bd288.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/116127564-48347700-a6c8-11eb-8882-904c8967d33e.gif)