### PR TITLE
feat(pipeline): enable to reorder steps using drag and drop

### DIFF
--- a/.storybook/bundle.ts
+++ b/.storybook/bundle.ts
@@ -14,6 +14,7 @@ import FilterEditor from '../src/components/FilterEditor.vue';
 import ListUniqueValues from '../src/components/ListUniqueValues.vue';
 import VariableInput from '../src/components/stepforms/widgets/VariableInput.vue';
 import InputText from '../src/components/stepforms/widgets/InputText.vue';
+import InputDate from '../src/components/stepforms/widgets/InputDate.vue';
 import MultiInputText from '../src/components/stepforms/widgets/MultiInputText.vue';
 import Multiselect from '../src/components/stepforms/widgets/Multiselect.vue';
 import IfThenElseWidget from '../src/components/stepforms/widgets/IfThenElseWidget.vue';
@@ -44,6 +45,7 @@ export {
   RenameStepForm,
   Pipeline,
   InputText,
+  InputDate,
   ResizablePanels,
   Step,
   ListUniqueValues,

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
   "dependencies": {
     "ajv": "^6.10.0",
     "lodash": "^4.17.11",
-    "mathjs": "^7.3.0"
+    "mathjs": "^7.3.0",
+    "vuedraggable": "^2.24.3"
   }
 }

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -9,6 +9,7 @@
       :is-first="index === 0"
       :is-last="index === steps.length - 1"
       :toDelete="toDelete({ index })"
+      :isEditable="!isDeletingSteps"
       :step="step"
       :indexInPipeline="index"
       :variable-delimiters="variableDelimiters"
@@ -71,6 +72,10 @@ export default class PipelineComponent extends Vue {
 
   @VQBModule.Action selectStep!: ({ index }: { index: number }) => void;
   @VQBModule.Action deleteSteps!: (payload: { indexes: number[] }) => void;
+
+  get isDeletingSteps(): boolean {
+    return this.stepsToDelete.length > 0;
+  }
 
   editStep(step: PipelineStep, index: number) {
     this.$emit('editStep', step, index);

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -2,13 +2,13 @@
   <div class="query-pipeline">
     <Draggable
       class="query-pipeline__draggable"
-      v-model="orderedSteps"
+      v-model="arrangedSteps"
       handle=".query-pipeline-step__action--handle"
       draggable=".query-pipeline-step__container--draggable"
       @end="updateSelectedStep"
     >
       <Step
-        v-for="(step, index) in orderedSteps"
+        v-for="(step, index) in arrangedSteps"
         :key="index"
         :is-active="index < activeStepIndex"
         :is-last-active="index === activeStepIndex"
@@ -86,11 +86,11 @@ export default class PipelineComponent extends Vue {
   @VQBModule.Action deleteSteps!: (payload: { indexes: number[] }) => void;
   @VQBModule.Mutation setPipeline!: MutationCallbacks['setPipeline'];
 
-  get orderedSteps(): Pipeline {
+  get arrangedSteps(): Pipeline {
     return this.steps;
   }
 
-  set orderedSteps(pipeline: Pipeline) {
+  set arrangedSteps(pipeline: Pipeline) {
     this.setPipeline({ pipeline });
   }
 

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -5,6 +5,7 @@
       v-model="orderedSteps"
       handle=".query-pipeline-step__action--handle"
       draggable=".query-pipeline-step__container--draggable"
+      @end="updateSelectedStep"
     >
       <Step
         v-for="(step, index) in orderedSteps"
@@ -73,6 +74,7 @@ export default class PipelineComponent extends Vue {
 
   @VQBModule.State domains!: string[];
   @VQBModule.State variableDelimiters!: VariableDelimiters;
+  @VQBModule.State selectedStepIndex!: number;
 
   @VQBModule.Getter('computedActiveStepIndex') activeStepIndex!: number;
   @VQBModule.Getter domainStep!: DomainStep;
@@ -94,6 +96,11 @@ export default class PipelineComponent extends Vue {
 
   get isDeletingSteps(): boolean {
     return this.stepsToDelete.length > 0;
+  }
+
+  get currentSelectedIndex(): number {
+    // selectedStepIndex for last step is -1 by default, we need to retrieve real index
+    return this.selectedStepIndex === -1 ? this.steps.length - 1 : this.selectedStepIndex;
   }
 
   editStep(step: PipelineStep, index: number) {
@@ -122,6 +129,14 @@ export default class PipelineComponent extends Vue {
     // clean steps to delete
     this.stepsToDelete = [];
     this.closeDeleteConfirmationModal();
+  }
+
+  updateSelectedStep(event: any): void {
+    // update selected step index only if dragged step is already current selected one
+    // (otherwise keep selected step unchanged)
+    if (event.oldIndex === this.currentSelectedIndex) {
+      this.selectStep({ index: event.newIndex });
+    }
   }
 }
 </script>

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -131,11 +131,29 @@ export default class PipelineComponent extends Vue {
     this.closeDeleteConfirmationModal();
   }
 
+  /**
+   * Find the new selected index to apply after steps reordering
+   * 1. If current selected step has been moved => we need to apply new index
+   * 2. If another step has been moved:
+   *  a. Amount of steps has changed before/after selected step => we need to balance to retrieve the correct index
+   *  b. Amount of steps has not changed before/after selected step => no impact on selected index
+   */
+  findCurrentSelectedIndex({ newIndex, oldIndex }: { newIndex: number; oldIndex: number }): number {
+    if (this.currentSelectedIndex === oldIndex) {
+      return newIndex;
+    } else if (oldIndex < this.currentSelectedIndex && newIndex >= this.currentSelectedIndex) {
+      return this.currentSelectedIndex - 1;
+    } else if (oldIndex > this.currentSelectedIndex && newIndex <= this.currentSelectedIndex) {
+      return this.currentSelectedIndex + 1;
+    } else {
+      return this.currentSelectedIndex;
+    }
+  }
+
   updateSelectedStep(event: any): void {
-    // update selected step index only if dragged step is already current selected one
-    // (otherwise keep selected step unchanged)
-    if (event.oldIndex === this.currentSelectedIndex) {
-      this.selectStep({ index: event.newIndex });
+    const index = this.findCurrentSelectedIndex(event);
+    if (index !== this.currentSelectedIndex) {
+      this.selectStep({ index });
     }
   }
 }

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -22,6 +22,13 @@
           <div class="query-pipeline-step__action" @click.stop="editStep()">
             <i class="far fa-cog" aria-hidden="true" />
           </div>
+          <div
+            class="query-pipeline-step__action query-pipeline-step__action--handle"
+            v-if="!isFirst"
+            @click.stop
+          >
+            <i class="fa fa-align-justify" aria-hidden="true" />
+          </div>
         </div>
       </div>
       <div class="query-pipeline-step__footer" v-if="errorMessage && !isDisabled">
@@ -101,6 +108,7 @@ export default class Step extends Vue {
     return {
       'query-pipeline-step__container': true,
       'query-pipeline-step__container--togglable': !this.isFirst,
+      'query-pipeline-step__container--draggable': !this.isFirst,
       'query-pipeline-step__container--to-delete': this.toDelete,
       'query-pipeline-step__container--active': this.isActive,
       'query-pipeline-step__container--last-active': this.isLastActive,

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -178,7 +178,7 @@ export default class Step extends Vue {
 }
 
 .query-pipeline-queue__dot {
-  background-color: $active-color-faded-2;
+  background-color: $active-color-faded-3;
   width: 20px;
   height: 20px;
   border-radius: 50%;
@@ -209,7 +209,7 @@ export default class Step extends Vue {
   width: 2px;
   flex-grow: 1;
   justify-self: end;
-  background-color: $active-color-faded-2;
+  background-color: $active-color-faded-3;
 }
 
 .query-pipeline-queue__stroke--hidden {

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -12,7 +12,12 @@
     <div class="query-pipeline-step" @click="select()">
       <div class="query-pipeline-step__body">
         <span class="query-pipeline-step__name" :title="stepTitle" v-html="stepLabel" />
-        <div class="query-pipeline-step__actions">
+        <div
+          class="query-pipeline-step__actions"
+          :class="{
+            'query-pipeline-step__actions--disabled': !isEditable,
+          }"
+        >
           <!-- @click.stop is used to avoid to trigger select event when editing a step -->
           <div class="query-pipeline-step__action" @click.stop="editStep()">
             <i class="far fa-cog" aria-hidden="true" />
@@ -57,6 +62,9 @@ export default class Step extends Vue {
 
   @Prop(Boolean)
   readonly toDelete!: boolean;
+
+  @Prop({ type: Boolean, default: true })
+  readonly isEditable?: boolean;
 
   @Prop()
   step!: PipelineStep;
@@ -233,6 +241,16 @@ export default class Step extends Vue {
   display: flex;
   flex-direction: row;
   height: 100%;
+  opacity: 1;
+  transition: opacity 0.2s;
+}
+
+.query-pipeline-step__actions--disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+  .query-pipeline-step__action {
+    pointer-events: none;
+  }
 }
 
 .query-pipeline-step__action {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -50,6 +50,7 @@ class Actions {
   }
 
   async updateDataset({ commit, getters, state }: ActionContext<VQBState, any>) {
+    commit('logBackendMessages', { backendMessages: [] }); // clear backendMessages
     try {
       commit('setLoading', { type: 'dataset', isLoading: true });
       commit('toggleRequestOnGoing', { isRequestOnGoing: true });

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -3,7 +3,7 @@ $base-color: #404040 !default;
 $base-color-light: #4c4c4c !default;
 $active-color: #2a66a1 !default;
 $active-color-faded: #89AACB !default;
-$active-color-faded-2: #e9eff5 !default;
+$active-color-faded-2: #cbdaed !default;
 $active-color-faded-3: #e9eff5 !default;
 $data-viewer-border-color: #e0e0e0 !default;
 $light-grey: #fafafa;

--- a/stories/filter-editor.js
+++ b/stories/filter-editor.js
@@ -66,6 +66,7 @@ stories.add('with some variables available', () => ({
         :filter-tree="filterTree"
         @filterTreeUpdated="updateFilterTree"
         :available-variables="availableVariables"
+        :variableDelimiters="variableDelimiters"
       />
       <pre style="margin-top: 30px;">{{ filterTreeStringify }}</pre>
     </div>
@@ -88,8 +89,9 @@ stories.add('with some variables available', () => ({
       filterTree: {
         column: 'my_col',
         operator: 'in',
-        value: '{{ someArray }}',
+        value: ['{{ someArray }}'],
       },
+      variableDelimiters: { start: '{{', end: '}}' },
       defaultValue: { column: '', value: '', operator: 'eq' },
     };
   },

--- a/stories/step.js
+++ b/stories/step.js
@@ -1,15 +1,8 @@
-import {
-  Step
-} from '../dist/storybook/components';
+import { Step, registerModule } from '../dist/storybook/components';
 
-import {
-  withKnobs,
-  text
-} from '@storybook/addon-knobs';
+import { withKnobs, text } from '@storybook/addon-knobs';
 
-import {
-  storiesOf
-} from '@storybook/vue';
+import { storiesOf } from '@storybook/vue';
 
 const stories = storiesOf('Step', module);
 
@@ -21,42 +14,84 @@ stories
   .addDecorator(withKnobs)
   .add('default', () => ({
     components: {
-      Step
+      Step,
     },
     props: {
       step: {
         default: {
-          name: text('Step name', 'Default step name'),
+          name: text('Step name', 'custom'),
         },
       },
     },
     template: '<step :step="step"></step>',
+    store: new Vuex.Store(),
+    created: function() {
+      registerModule(this.$store, {
+        backendMessages: [],
+        dataset: { headers: [], data: [] },
+      });
+    },
   }))
 
   .add('first', () => ({
     components: {
-      Step
+      Step,
     },
     data() {
       return {
         step: {
-          name: 'Sample step',
+          name: 'custom',
         },
       };
     },
     template: '<step is-first :step="step"></step>',
+    store: new Vuex.Store(),
+    created: function() {
+      registerModule(this.$store, {
+        backendMessages: [],
+        dataset: { headers: [], data: [] },
+      });
+    },
   }))
 
   .add('last', () => ({
     components: {
-      Step
+      Step,
     },
     data() {
       return {
         step: {
-          name: 'Sample step',
+          name: 'custom',
         },
       };
     },
     template: '<step is-last :step="step"></step>',
+    store: new Vuex.Store(),
+    created: function() {
+      registerModule(this.$store, {
+        backendMessages: [],
+        dataset: { headers: [], data: [] },
+      });
+    },
+  }))
+
+  .add('error', () => ({
+    components: {
+      Step,
+    },
+    data() {
+      return {
+        step: {
+          name: 'custom',
+        },
+      };
+    },
+    template: '<step :indexInPipeline="2" :step="step"></step>',
+    store: new Vuex.Store(),
+    created: function() {
+      registerModule(this.$store, {
+        backendMessages: [{ index: 2, message: 'I am an error', type: 'error' }],
+        dataset: { headers: [], data: [] },
+      });
+    },
   }));

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -207,4 +207,37 @@ describe('Pipeline.vue', () => {
       });
     });
   });
+
+  describe('reorder steps', () => {
+    let wrapper: Wrapper<PipelineComponent>, commitSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      const pipeline: Pipeline = [
+        { name: 'domain', domain: 'GoT' },
+        { name: 'rename', toRename: [['foo', 'bar']] },
+        { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
+      ];
+      const store = setupMockStore(buildStateWithOnePipeline(pipeline));
+      commitSpy = jest.spyOn(store, 'commit');
+      wrapper = shallowMount(PipelineComponent, { store, localVue });
+    });
+
+    it('should have a draggable steps list as pipeline', () => {
+      expect(wrapper.find('Draggable-stub').exists()).toBe(true);
+    });
+    it('should rerender pipeline when steps position are updated', async () => {
+      const reorderedPipeline = [
+        { name: 'domain', domain: 'GoT' },
+        { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
+        { name: 'rename', toRename: [['foo', 'bar']] },
+      ];
+      wrapper.find('draggable-stub').vm.$emit('input', reorderedPipeline); // fake drag/drop step action
+      await wrapper.vm.$nextTick();
+      expect(commitSpy).toHaveBeenCalledWith(
+        VQBnamespace('setPipeline'),
+        { pipeline: reorderedPipeline },
+        undefined,
+      );
+    });
+  });
 });

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -31,6 +31,7 @@ describe('Pipeline.vue', () => {
       isFirst: true,
       isLast: false,
       toDelete: false,
+      isEditable: true,
       indexInPipeline: 0,
     });
     expect(step2).toEqual({
@@ -41,6 +42,7 @@ describe('Pipeline.vue', () => {
       isFirst: false,
       isLast: false,
       toDelete: false,
+      isEditable: true,
       indexInPipeline: 1,
     });
     expect(step3).toEqual({
@@ -51,6 +53,7 @@ describe('Pipeline.vue', () => {
       isFirst: false,
       isLast: true,
       toDelete: false,
+      isEditable: true,
       indexInPipeline: 2,
     });
   });
@@ -113,6 +116,10 @@ describe('Pipeline.vue', () => {
         expect(wrapper.find('.query-pipeline__delete-steps').text()).toContain(
           'Delete [2] selected',
         );
+      });
+      it('should make steps uneditable', () => {
+        const steps = wrapper.findAll('step-stub');
+        steps.wrappers.map(stub => expect(stub.props().isEditable).toBe(false));
       });
     });
 

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -229,51 +229,29 @@ describe('Pipeline.vue', () => {
     it('should have a draggable steps list as pipeline', () => {
       expect(wrapper.find('Draggable-stub').exists()).toBe(true);
     });
-    it('should rerender pipeline when steps position are updated', async () => {
-      const reorderedPipeline = [
+    describe('when steps position are arranged', () => {
+      const reorderedPipeline: Pipeline = [
         { name: 'domain', domain: 'GoT' },
-        { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
         { name: 'rename', toRename: [['foo', 'bar']] },
         { name: 'sort', columns: [{ column: 'death', order: 'desc' }] },
+        { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
       ];
-      wrapper.find('draggable-stub').vm.$emit('input', reorderedPipeline); // fake drag/drop step action
-      await wrapper.vm.$nextTick();
-      expect(commitSpy).toHaveBeenCalledWith(
-        VQBnamespace('setPipeline'),
-        { pipeline: reorderedPipeline },
-        undefined,
-      );
-    });
-    it('should reselect step based on new index if dropped step was already selected one', async () => {
-      wrapper.find('draggable-stub').vm.$emit('end', { oldIndex: 3, newIndex: 1 }); // fake drop end action
-      expect(dispatchSpy).toHaveBeenCalledWith(VQBnamespace('selectStep'), { index: 1 });
-    });
-    it('should not reselect step if selected step index has not changed', async () => {
-      wrapper.find('draggable-stub').vm.$emit('end', { oldIndex: 3, newIndex: 3 }); // fake drop end action
-      expect(dispatchSpy).not.toHaveBeenCalled();
-    });
-    describe('balance step index when amount of steps before/after has changed', () => {
-      beforeEach(() => {
-        // fake move current selected step to middle of pipeline
-        wrapper.find('draggable-stub').vm.$emit('end', { oldIndex: 3, newIndex: 1 });
+
+      beforeEach(async () => {
+        wrapper.find('draggable-stub').vm.$emit('input', reorderedPipeline); // fake drag/drop step action
+        await wrapper.vm.$nextTick();
       });
-      it('should balance with more items before selected step', () => {
-        // Before: [1, current, 3, 4] : current = 1
-        // After: [1, 3, current, 4] : current = 2
-        wrapper.find('draggable-stub').vm.$emit('end', { oldIndex: 2, newIndex: 1 });
+
+      it('should rerender pipeline', () => {
+        expect(commitSpy).toHaveBeenCalledWith(
+          VQBnamespace('setPipeline'),
+          { pipeline: reorderedPipeline },
+          undefined,
+        );
+      });
+
+      it('should update active step index', () => {
         expect(dispatchSpy).toHaveBeenCalledWith(VQBnamespace('selectStep'), { index: 2 });
-      });
-      it('should balance with more items after selected step', () => {
-        // Before: [1, current, 3, 4] : current = 1
-        // After: [current, 3, 1, 4] : current = 0
-        wrapper.find('draggable-stub').vm.$emit('end', { oldIndex: 0, newIndex: 2 });
-        expect(dispatchSpy).toHaveBeenCalledWith(VQBnamespace('selectStep'), { index: 0 });
-      });
-      it('should keep unchanged with same quantity', () => {
-        // Before: [1, current, 3, 4] : current = 1
-        // After: [1, current, 4, 3] : current = 1
-        wrapper.find('draggable-stub').vm.$emit('end', { oldIndex: 2, newIndex: 3 });
-        expect(dispatchSpy).toHaveBeenCalledWith(VQBnamespace('selectStep'), { index: 1 });
       });
     });
   });

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -209,7 +209,9 @@ describe('Pipeline.vue', () => {
   });
 
   describe('reorder steps', () => {
-    let wrapper: Wrapper<PipelineComponent>, commitSpy: jest.SpyInstance;
+    let wrapper: Wrapper<PipelineComponent>,
+      commitSpy: jest.SpyInstance,
+      dispatchSpy: jest.SpyInstance;
 
     beforeEach(async () => {
       const pipeline: Pipeline = [
@@ -219,6 +221,7 @@ describe('Pipeline.vue', () => {
       ];
       const store = setupMockStore(buildStateWithOnePipeline(pipeline));
       commitSpy = jest.spyOn(store, 'commit');
+      dispatchSpy = jest.spyOn(store, 'dispatch');
       wrapper = shallowMount(PipelineComponent, { store, localVue });
     });
 
@@ -238,6 +241,14 @@ describe('Pipeline.vue', () => {
         { pipeline: reorderedPipeline },
         undefined,
       );
+    });
+    it('should reselect step based on new index if dropped step was already selected one', async () => {
+      wrapper.find('draggable-stub').vm.$emit('end', { oldIndex: 2, newIndex: 1 }); // fake drop end action
+      expect(dispatchSpy).toHaveBeenCalledWith(VQBnamespace('selectStep'), { index: 1 });
+    });
+    it('should not reselect step if dropped step was not already selected one', async () => {
+      wrapper.find('draggable-stub').vm.$emit('end', { oldIndex: 1, newIndex: 2 }); // fake drop end action
+      expect(dispatchSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -60,6 +60,22 @@ describe('Step.vue', () => {
     expect(wrapper.emitted()).toEqual({ toggleDelete: [[]] });
   });
 
+  it('should enable to drag step to other pipeline index', async () => {
+    const wrapper = createStepWrapper({
+      propsData: {
+        key: 0,
+        isActive: true,
+        isLastActive: true,
+        isDisabled: false,
+        isFirst: false,
+        isLast: true,
+        step: { name: 'domain', domain: 'GoT' },
+        indexInPipeline: 0,
+      },
+    });
+    expect(wrapper.find('.query-pipeline-step__action--handle').exists()).toBe(true);
+  });
+
   it('should not enable to delete domain step', async () => {
     const wrapper = createStepWrapper({
       propsData: {
@@ -77,6 +93,23 @@ describe('Step.vue', () => {
     await localVue.nextTick();
     expect(wrapper.emitted().toggleDelete).toBeUndefined();
   });
+
+  it('should not enable to drag domain step to other pipeline index', async () => {
+    const wrapper = createStepWrapper({
+      propsData: {
+        key: 0,
+        isActive: true,
+        isLastActive: true,
+        isDisabled: false,
+        isFirst: true,
+        isLast: true,
+        step: { name: 'domain', domain: 'GoT' },
+        indexInPipeline: 0,
+      },
+    });
+    expect(wrapper.find('.query-pipeline-step__action--handle').exists()).toBe(false);
+  });
+
   it('should render a stepLabel with the variable names', () => {
     const wrapper = createStepWrapper({
       propsData: {

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -1,4 +1,4 @@
-import { createLocalVue, mount, shallowMount } from '@vue/test-utils';
+import { createLocalVue, mount, shallowMount, Wrapper } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import PipelineComponent from '@/components/Pipeline.vue';
@@ -200,6 +200,29 @@ describe('Step.vue', () => {
       const replaceStep = stepsArray.at(1);
       expect(replaceStep.find('.query-pipeline-step__footer').exists()).toBe(false);
       expect(replaceStep.classes()).not.toContain('query-pipeline-step__container--errors');
+    });
+  });
+
+  describe('when step is not editable (delete mode)', () => {
+    let wrapper: Wrapper<Step>;
+    beforeEach(() => {
+      wrapper = createStepWrapper({
+        propsData: {
+          key: 0,
+          isActive: true,
+          isDisabled: false,
+          isFirst: false,
+          isLast: true,
+          isEditable: false,
+          step: { name: 'rename', toRename: [['foo', 'bar']] },
+          indexInPipeline: 2,
+        },
+      });
+    });
+    it('should disable actions buttons', () => {
+      expect(wrapper.find('.query-pipeline-step__actions').classes()).toContain(
+        'query-pipeline-step__actions--disabled',
+      );
     });
   });
 });

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -778,25 +778,28 @@ describe('action tests', () => {
       const commitSpy = jest.spyOn(store, 'commit');
 
       await store.dispatch(VQBnamespace('updateDataset'));
-      expect(commitSpy).toHaveBeenCalledTimes(6);
-      // call 1 :
-      expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('setLoading'));
-      expect(commitSpy.mock.calls[0][1]).toEqual({ type: 'dataset', isLoading: true });
+      expect(commitSpy).toHaveBeenCalledTimes(7);
+      // call 1 (clear backend messages) :
+      expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('logBackendMessages'));
+      expect(commitSpy.mock.calls[0][1]).toEqual({ backendMessages: [] });
       // call 2 :
-      expect(commitSpy.mock.calls[1][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
-      expect(commitSpy.mock.calls[1][1]).toEqual({ isRequestOnGoing: true });
+      expect(commitSpy.mock.calls[1][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[1][1]).toEqual({ type: 'dataset', isLoading: true });
       // call 3 :
-      expect(commitSpy.mock.calls[2][0]).toEqual(VQBnamespace('logBackendMessages'));
-      expect(commitSpy.mock.calls[2][1]).toEqual({ backendMessages: [] });
+      expect(commitSpy.mock.calls[2][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[2][1]).toEqual({ isRequestOnGoing: true });
       // call 4 :
-      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('setDataset'));
-      expect(commitSpy.mock.calls[3][1]).toEqual({ dataset: dummyDatasetWithUniqueComputed });
+      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('logBackendMessages'));
+      expect(commitSpy.mock.calls[3][1]).toEqual({ backendMessages: [] });
       // call 5 :
-      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
-      expect(commitSpy.mock.calls[4][1]).toEqual({ isRequestOnGoing: false });
+      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('setDataset'));
+      expect(commitSpy.mock.calls[4][1]).toEqual({ dataset: dummyDatasetWithUniqueComputed });
       // call 6 :
-      expect(commitSpy.mock.calls[5][0]).toEqual(VQBnamespace('setLoading'));
-      expect(commitSpy.mock.calls[5][1]).toEqual({ type: 'dataset', isLoading: false });
+      expect(commitSpy.mock.calls[5][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[5][1]).toEqual({ isRequestOnGoing: false });
+      // call 7 :
+      expect(commitSpy.mock.calls[6][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[6][1]).toEqual({ type: 'dataset', isLoading: false });
     });
 
     it('updateDataset with error from service', async () => {
@@ -817,24 +820,27 @@ describe('action tests', () => {
       const commitSpy = jest.spyOn(store, 'commit');
 
       await store.dispatch(VQBnamespace('updateDataset'));
-      expect(commitSpy).toHaveBeenCalledTimes(5);
-      // call 1 :
-      expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('setLoading'));
-      expect(commitSpy.mock.calls[0][1]).toEqual({ type: 'dataset', isLoading: true });
+      expect(commitSpy).toHaveBeenCalledTimes(6);
+      // call 1 (clear backend messages) :
+      expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('logBackendMessages'));
+      expect(commitSpy.mock.calls[0][1]).toEqual({ backendMessages: [] });
       // call 2 :
-      expect(commitSpy.mock.calls[1][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
-      expect(commitSpy.mock.calls[1][1]).toEqual({ isRequestOnGoing: true });
+      expect(commitSpy.mock.calls[1][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[1][1]).toEqual({ type: 'dataset', isLoading: true });
       // call 3 :
-      expect(commitSpy.mock.calls[2][0]).toEqual(VQBnamespace('logBackendMessages'));
-      expect(commitSpy.mock.calls[2][1]).toEqual({
+      expect(commitSpy.mock.calls[2][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[2][1]).toEqual({ isRequestOnGoing: true });
+      // call 4 :
+      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('logBackendMessages'));
+      expect(commitSpy.mock.calls[3][1]).toEqual({
         backendMessages: [{ message: 'OMG an error happens', type: 'error' }],
       });
-      // call 4 :
-      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
-      expect(commitSpy.mock.calls[3][1]).toEqual({ isRequestOnGoing: false });
       // call 5 :
-      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('setLoading'));
-      expect(commitSpy.mock.calls[4][1]).toEqual({ type: 'dataset', isLoading: false });
+      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[4][1]).toEqual({ isRequestOnGoing: false });
+      // call 6 :
+      expect(commitSpy.mock.calls[5][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[5][1]).toEqual({ type: 'dataset', isLoading: false });
     });
 
     it('updateDataset with uncaught error from service', async () => {
@@ -858,24 +864,27 @@ describe('action tests', () => {
         expect(e).toEqual('Katastrophe!');
       }
 
-      expect(commitSpy).toHaveBeenCalledTimes(5);
-      // call 1 :
-      expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('setLoading'));
-      expect(commitSpy.mock.calls[0][1]).toEqual({ type: 'dataset', isLoading: true });
+      expect(commitSpy).toHaveBeenCalledTimes(6);
+      // call 1 (clear backend messages) :
+      expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('logBackendMessages'));
+      expect(commitSpy.mock.calls[0][1]).toEqual({ backendMessages: [] });
       // call 2 :
-      expect(commitSpy.mock.calls[1][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
-      expect(commitSpy.mock.calls[1][1]).toEqual({ isRequestOnGoing: true });
+      expect(commitSpy.mock.calls[1][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[1][1]).toEqual({ type: 'dataset', isLoading: true });
       // call 3 :
-      expect(commitSpy.mock.calls[2][0]).toEqual(VQBnamespace('logBackendMessages'));
-      expect(commitSpy.mock.calls[2][1]).toEqual({
+      expect(commitSpy.mock.calls[2][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[2][1]).toEqual({ isRequestOnGoing: true });
+      // call 4 :
+      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('logBackendMessages'));
+      expect(commitSpy.mock.calls[3][1]).toEqual({
         backendMessages: [{ message: 'Katastrophe!', type: 'error' }],
       });
-      // call 4 :
-      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
-      expect(commitSpy.mock.calls[3][1]).toEqual({ isRequestOnGoing: false });
       // call 5 :
-      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('setLoading'));
-      expect(commitSpy.mock.calls[4][1]).toEqual({ type: 'dataset', isLoading: false });
+      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[4][1]).toEqual({ isRequestOnGoing: false });
+      // call 6 :
+      expect(commitSpy.mock.calls[5][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[5][1]).toEqual({ type: 'dataset', isLoading: false });
     });
 
     it('updateDataset with specific step error from service', async () => {
@@ -896,24 +905,27 @@ describe('action tests', () => {
       const commitSpy = jest.spyOn(store, 'commit');
 
       await store.dispatch(VQBnamespace('updateDataset'));
-      expect(commitSpy).toHaveBeenCalledTimes(5);
-      // call 1 :
-      expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('setLoading'));
-      expect(commitSpy.mock.calls[0][1]).toEqual({ type: 'dataset', isLoading: true });
+      expect(commitSpy).toHaveBeenCalledTimes(6);
+      // call 1 (clear backend messages) :
+      expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('logBackendMessages'));
+      expect(commitSpy.mock.calls[0][1]).toEqual({ backendMessages: [] });
       // call 2 :
-      expect(commitSpy.mock.calls[1][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
-      expect(commitSpy.mock.calls[1][1]).toEqual({ isRequestOnGoing: true });
+      expect(commitSpy.mock.calls[1][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[1][1]).toEqual({ type: 'dataset', isLoading: true });
       // call 3 :
-      expect(commitSpy.mock.calls[2][0]).toEqual(VQBnamespace('logBackendMessages'));
-      expect(commitSpy.mock.calls[2][1]).toEqual({
+      expect(commitSpy.mock.calls[2][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[2][1]).toEqual({ isRequestOnGoing: true });
+      // call 4 :
+      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('logBackendMessages'));
+      expect(commitSpy.mock.calls[3][1]).toEqual({
         backendMessages: [{ type: 'error', index: 1, message: 'Specific error for step' }],
       });
-      // call 4 :
-      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
-      expect(commitSpy.mock.calls[3][1]).toEqual({ isRequestOnGoing: false });
       // call 5 :
-      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('setLoading'));
-      expect(commitSpy.mock.calls[4][1]).toEqual({ type: 'dataset', isLoading: false });
+      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[4][1]).toEqual({ isRequestOnGoing: false });
+      // call 6 :
+      expect(commitSpy.mock.calls[5][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[5][1]).toEqual({ type: 'dataset', isLoading: false });
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11708,6 +11708,11 @@ sockjs-client@1.4.0:
     json3 "^3.3.2"
     url-parse "^1.4.3"
 
+sortablejs@1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.10.2.tgz#6e40364d913f98b85a14f6678f92b5c1221f5290"
+  integrity sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -13084,6 +13089,13 @@ vue@^2.6.10:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
   integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==
+
+vuedraggable@^2.24.3:
+  version "2.24.3"
+  resolved "https://registry.yarnpkg.com/vuedraggable/-/vuedraggable-2.24.3.tgz#43c93849b746a24ce503e123d5b259c701ba0d19"
+  integrity sha512-6/HDXi92GzB+Hcs9fC6PAAozK1RLt1ewPTLjK0anTYguXLAeySDmcnqE8IC0xa7shvSzRjQXq3/+dsZ7ETGF3g==
+  dependencies:
+    sortablejs "1.10.2"
 
 vuejs-paginate@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Before: Plop nothing!

After:
Important: We don't want user to reorder this steps while deleting mode is active (we retrieve steps to delete based on indexes). So we added a disabled mode on actions when deleting steps

![after](https://user-images.githubusercontent.com/59559689/116286954-1d155a80-a790-11eb-9ae2-f6522011a82b.gif)

