### PR TITLE
fix(popover): put z-index: 2 to popover

### DIFF
--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -177,5 +177,6 @@ export default class Popover extends Vue {
   font-family: 'Montserrat', sans-serif;
   position: absolute;
   visibility: visible;
+  z-index: 2; 
 }
 </style>


### PR DESCRIPTION
## Description
This z-index is needed in order to display the popovers in the embed. 