### PR TITLE
feat(pipeline): copy/paste steps with clipboard

### DIFF
--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -24,10 +24,10 @@
         @toggleDelete="toggleStepToDelete({ index })"
       />
     </Draggable>
-    <div class="query-pipeline__delete-steps-container" v-if="stepsToDelete.length">
+    <div class="query-pipeline__delete-steps-container" v-if="selectedSteps.length">
       <div class="query-pipeline__delete-steps" @click="openDeleteConfirmationModal">
         <i aria-hidden="true" class="fas fa-trash" />
-        Delete [{{ stepsToDelete.length }}] selected
+        Delete [{{ selectedSteps.length }}] selected
       </div>
     </div>
     <div class="query-pipeline__tips-container">
@@ -68,7 +68,7 @@ import Step from './Step.vue';
 })
 export default class PipelineComponent extends Vue {
   // pipeline steps to delete based on their indexes
-  stepsToDelete: number[] = [];
+  selectedSteps: number[] = [];
   deleteConfirmationModalIsOpened = false;
 
   @VQBModule.State domains!: string[];
@@ -93,7 +93,7 @@ export default class PipelineComponent extends Vue {
   }
 
   get isDeletingSteps(): boolean {
-    return this.stepsToDelete.length > 0;
+    return this.selectedSteps.length > 0;
   }
 
   editStep(step: PipelineStep, index: number) {
@@ -101,12 +101,12 @@ export default class PipelineComponent extends Vue {
   }
 
   toDelete({ index }: { index: number }): boolean {
-    return this.stepsToDelete.indexOf(index) !== -1;
+    return this.selectedSteps.indexOf(index) !== -1;
   }
 
   toggleStepToDelete({ index }: { index: number }): void {
     // toggle step to delete using its index in pipeline
-    this.stepsToDelete = _xor(this.stepsToDelete, [index]);
+    this.selectedSteps = _xor(this.selectedSteps, [index]);
   }
 
   openDeleteConfirmationModal(): void {
@@ -118,9 +118,9 @@ export default class PipelineComponent extends Vue {
   }
 
   deleteSelectedSteps(): void {
-    this.deleteSteps({ indexes: this.stepsToDelete });
+    this.deleteSteps({ indexes: this.selectedSteps });
     // clean steps to delete
-    this.stepsToDelete = [];
+    this.selectedSteps = [];
     this.closeDeleteConfirmationModal();
   }
 

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -99,10 +99,12 @@ export default class PipelineComponent extends Vue {
   }
 
   created() {
+    /* istanbul ignore next */
     document.addEventListener('keydown', this.keyDownEventHandler);
   }
 
   destroyed() {
+    /* istanbul ignore next */
     document.removeEventListener('keydown', this.keyDownEventHandler);
   }
 

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -173,11 +173,12 @@ export default class PipelineComponent extends Vue {
     // retrieve data from clipboard
     const stepsFromClipBoard: string = await pasteFromClipboard();
     // parse steps string
-    const parsedSteps: PipelineStep[] = JSON.parse(stepsFromClipBoard) ?? [];
+    const parsedSteps: any = JSON.parse(stepsFromClipBoard) ?? [];
     // verify is steps object are well formatted
-    const checkStepFormat: boolean = parsedSteps.every(step => isPipelineStep(step));
-    // add new steps to pipeline
-    if (checkStepFormat) this.addSteps({ steps: parsedSteps });
+    if (Array.isArray(parsedSteps) && parsedSteps.every(step => isPipelineStep(step))) {
+      // add new steps to pipeline
+      this.addSteps({ steps: parsedSteps });
+    }
   }
 }
 </script>

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,42 @@
+//Parser works like an id, to make sure that data copied/pasted from clipboard is coming from weaverbird
+export const CLIPBOARD_PARSER = '<<<Weaverbird>>>';
+
+/**
+ * Verify if retrieved data from clipboard is coming from weaverbird based on parser
+ * Then remove parser from string
+ */
+export function parseTextFromClipboard(text: string | undefined, parser: string): string {
+  if (!text || !(text.startsWith(parser) && text.endsWith(parser))) {
+    return '';
+  }
+  const regex = new RegExp(parser, 'g');
+  const textWithoutParser = text.replace(regex, '');
+  return textWithoutParser;
+}
+
+/**
+ * Add parser to string before sending text to clipboard
+ */
+export function parseTextForClipboard(text: string, parser: string): string {
+  return text ? `${parser}${text}${parser}` : text;
+}
+
+/**
+ *
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+  if (!navigator.clipboard) return;
+  // Add parser to string
+  const parsedText = parseTextForClipboard(text, CLIPBOARD_PARSER);
+  // Send string to clipboard
+  await navigator.clipboard.writeText(parsedText);
+}
+
+export async function pasteFromClipboard(): Promise<string> {
+  if (!navigator.clipboard) return '';
+  // Retrieve string from clipboard
+  const text: string | undefined = await navigator.clipboard.readText();
+  // Remove parser from string
+  const unparsedText = parseTextFromClipboard(text, CLIPBOARD_PARSER);
+  return unparsedText;
+}

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,21 +1,21 @@
-//Validator works like an id, to make sure that data copied/pasted from clipboard is coming from weaverbird
-export const CLIPBOARD_VALIDATOR = '<<<Weaverbird>>>';
+//Flag works like an id, to make sure that data copied/pasted from clipboard is coming from weaverbird
+export const CLIPBOARD_FLAG = '<<<Weaverbird>>>';
 
 /**
- * Verify if retrieved data from clipboard is coming from weaverbird based on validator
- * Then remove validator from string
+ * Verify if retrieved data from clipboard is coming from weaverbird based on flag
+ * Then remove flag from string
  */
-export function validateClipboardText(text: string | undefined, validator: string): string {
-  if (!text || !(text.startsWith(validator) && text.endsWith(validator))) return '';
-  const regex = new RegExp(validator, 'g');
+export function validateAndRemoveTextFlag(text: string | undefined, flag: string): string {
+  if (!text || !(text.startsWith(flag) && text.endsWith(flag))) return '';
+  const regex = new RegExp(flag, 'g');
   return text.replace(regex, '');
 }
 
 /**
- * Add validator to string before sending text to clipboard
+ * Add flag to string before sending text to clipboard
  */
-export function addTextValidator(text: string, validator: string): string {
-  return text ? `${validator}${text}${validator}` : text;
+export function addTextFlag(text: string, flag: string): string {
+  return text ? `${flag}${text}${flag}` : text;
 }
 
 /**
@@ -23,19 +23,19 @@ export function addTextValidator(text: string, validator: string): string {
  */
 export async function copyToClipboard(text: string): Promise<void> {
   if (!navigator.clipboard) return;
-  // Add validator to string
-  const textWithValidator = addTextValidator(text, CLIPBOARD_VALIDATOR);
+  // Add flag to string
+  const textWithValidator = addTextFlag(text, CLIPBOARD_FLAG);
   // Send string to clipboard
   await navigator.clipboard.writeText(textWithValidator);
 }
 
 /**
- * Retrieve text from clipboard, return an empty string if validator is not in string
+ * Retrieve text from clipboard, return an empty string if flag is not in string
  */
 export async function pasteFromClipboard(): Promise<string> {
   if (!navigator.clipboard) return '';
   // Retrieve string from clipboard
   const textFromClipboard: string | undefined = await navigator.clipboard.readText();
-  // Remove validator from string
-  return validateClipboardText(textFromClipboard, CLIPBOARD_VALIDATOR);
+  // Remove flag from string
+  return validateAndRemoveTextFlag(textFromClipboard, CLIPBOARD_FLAG);
 }

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,42 +1,41 @@
-//Parser works like an id, to make sure that data copied/pasted from clipboard is coming from weaverbird
-export const CLIPBOARD_PARSER = '<<<Weaverbird>>>';
+//Validator works like an id, to make sure that data copied/pasted from clipboard is coming from weaverbird
+export const CLIPBOARD_VALIDATOR = '<<<Weaverbird>>>';
 
 /**
- * Verify if retrieved data from clipboard is coming from weaverbird based on parser
- * Then remove parser from string
+ * Verify if retrieved data from clipboard is coming from weaverbird based on validator
+ * Then remove validator from string
  */
-export function parseTextFromClipboard(text: string | undefined, parser: string): string {
-  if (!text || !(text.startsWith(parser) && text.endsWith(parser))) {
-    return '';
-  }
-  const regex = new RegExp(parser, 'g');
-  const textWithoutParser = text.replace(regex, '');
-  return textWithoutParser;
+export function validateClipboardText(text: string | undefined, validator: string): string {
+  if (!text || !(text.startsWith(validator) && text.endsWith(validator))) return '';
+  const regex = new RegExp(validator, 'g');
+  return text.replace(regex, '');
 }
 
 /**
- * Add parser to string before sending text to clipboard
+ * Add validator to string before sending text to clipboard
  */
-export function parseTextForClipboard(text: string, parser: string): string {
-  return text ? `${parser}${text}${parser}` : text;
+export function addTextValidator(text: string, validator: string): string {
+  return text ? `${validator}${text}${validator}` : text;
 }
 
 /**
- *
+ * Copy selected text to clipboard
  */
 export async function copyToClipboard(text: string): Promise<void> {
   if (!navigator.clipboard) return;
-  // Add parser to string
-  const parsedText = parseTextForClipboard(text, CLIPBOARD_PARSER);
+  // Add validator to string
+  const textWithValidator = addTextValidator(text, CLIPBOARD_VALIDATOR);
   // Send string to clipboard
-  await navigator.clipboard.writeText(parsedText);
+  await navigator.clipboard.writeText(textWithValidator);
 }
 
+/**
+ * Retrieve text from clipboard, return an empty string if validator is not in string
+ */
 export async function pasteFromClipboard(): Promise<string> {
   if (!navigator.clipboard) return '';
   // Retrieve string from clipboard
-  const text: string | undefined = await navigator.clipboard.readText();
-  // Remove parser from string
-  const unparsedText = parseTextFromClipboard(text, CLIPBOARD_PARSER);
-  return unparsedText;
+  const textFromClipboard: string | undefined = await navigator.clipboard.readText();
+  // Remove validator from string
+  return validateClipboardText(textFromClipboard, CLIPBOARD_VALIDATOR);
 }

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -51,6 +51,10 @@ export function isReference(pipelineOrReference: Reference): pipelineOrReference
   return typeof pipelineOrReference === 'string';
 }
 
+export function isPipelineStep(step: any): step is PipelineStep {
+  return typeof step === 'object' && 'name' in step;
+}
+
 export type AddMissingDatesStep = {
   name: 'addmissingdates';
   datesColumn: string;

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -3,7 +3,7 @@ import { ActionContext, ActionTree } from 'vuex';
 import { BackendError } from '@/lib/backend';
 import { addLocalUniquesToDataset, updateLocalUniquesFromDatabase } from '@/lib/dataset/helpers.ts';
 import { pageOffset } from '@/lib/dataset/pagination';
-import { Pipeline } from '@/lib/steps';
+import { Pipeline, PipelineStep } from '@/lib/steps';
 
 import { VQBState } from './state';
 
@@ -110,6 +110,14 @@ class Actions {
     { indexes }: { indexes: number[] },
   ) {
     commit('deleteSteps', { indexes });
+    dispatch('updateDataset');
+  }
+
+  addSteps(
+    { commit, dispatch }: ActionContext<VQBState, any>,
+    { steps }: { steps: PipelineStep[] },
+  ) {
+    commit('addSteps', { steps });
     dispatch('updateDataset');
   }
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -208,9 +208,15 @@ class Mutations {
     if (state.currentPipelineName === undefined || pipeline === undefined) {
       return;
     }
-    const newPipeline = [...pipeline, ...steps];
+    const newPipeline = Array.from(pipeline);
+    // add steps just after selected steps
+    // but always after domain
+    const addIndex = state.selectedStepIndex >= 0 ? state.selectedStepIndex + 1 : 1;
+    newPipeline.splice(addIndex, 0, ...steps);
     state.pipelines[state.currentPipelineName] = newPipeline;
-    state.selectedStepIndex = newPipeline.length - 1;
+    const lastAddedStepIndex = addIndex + steps.length - 1;
+    // select last added step
+    state.selectedStepIndex = lastAddedStepIndex;
   }
   /**
    * change current selected domain and reset pipeline accordingly.

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -200,6 +200,19 @@ class Mutations {
     state.selectedStepIndex = pipelineWithDeletedSteps.length - 1;
   }
   /**
+   * Add selected steps to pipeline.
+   */
+  @resetPagination
+  addSteps(state: VQBState, { steps }: { steps: PipelineStep[] }) {
+    const pipeline = currentPipeline(state);
+    if (state.currentPipelineName === undefined || pipeline === undefined) {
+      return;
+    }
+    const newPipeline = [...pipeline, ...steps];
+    state.pipelines[state.currentPipelineName] = newPipeline;
+    state.selectedStepIndex = newPipeline.length - 1;
+  }
+  /**
    * change current selected domain and reset pipeline accordingly.
    */
   @resetPagination

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -200,7 +200,7 @@ class Mutations {
     state.selectedStepIndex = pipelineWithDeletedSteps.length - 1;
   }
   /**
-   * Add selected steps to pipeline.
+   * Add multiple steps to current pipeline.
    */
   @resetPagination
   addSteps(state: VQBState, { steps }: { steps: PipelineStep[] }) {

--- a/tests/unit/lib/clipboard.spec.ts
+++ b/tests/unit/lib/clipboard.spec.ts
@@ -1,0 +1,76 @@
+import {
+  CLIPBOARD_PARSER,
+  copyToClipboard,
+  parseTextForClipboard,
+  parseTextFromClipboard,
+  pasteFromClipboard,
+} from '@/lib/clipboard';
+
+const TEXT = 'TOTO';
+const TEXT_WITH_PARSERS = `${CLIPBOARD_PARSER}TOTO${CLIPBOARD_PARSER}`;
+
+const writeTextStub = jest.fn(),
+  readTextStub = jest.fn();
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: writeTextStub,
+    readText: readTextStub,
+  },
+});
+
+describe('parseTextFromClipboard', () => {
+  it('should return string without parsers', () => {
+    const value = parseTextFromClipboard(`PARSERTOTOPARSER`, 'PARSER');
+    expect(value).toStrictEqual('TOTO');
+  });
+  it('should return empty string if passed value is undefined', () => {
+    const value = parseTextFromClipboard(undefined, 'PARSER');
+    expect(value).toStrictEqual('');
+  });
+  it('should return empty string if string was already empty', () => {
+    const value = parseTextFromClipboard('', 'PARSER');
+    expect(value).toStrictEqual('');
+  });
+  it('should return empty string if passed value has no parsers', () => {
+    const value = parseTextFromClipboard(`OTHERTOTOOTHER`, 'PARSER');
+    expect(value).toStrictEqual('');
+  });
+});
+describe('parseTextForClipboard', () => {
+  it('should return string with parsers', () => {
+    const value = parseTextForClipboard('TOTO', 'PARSER');
+    expect(value).toStrictEqual(`PARSERTOTOPARSER`);
+  });
+  it('should return empty string if string was already empty', () => {
+    const value = parseTextForClipboard('', 'PARSER');
+    expect(value).toStrictEqual('');
+  });
+});
+
+describe('copyToClipboard', () => {
+  it('should copy updated string with parsers to clipboard', async () => {
+    await copyToClipboard(TEXT);
+    expect(writeTextStub).toHaveBeenCalledWith(TEXT_WITH_PARSERS);
+  });
+});
+
+describe('pasteFromClipboard', () => {
+  beforeEach(async () => {
+    readTextStub.mockResolvedValue(TEXT_WITH_PARSERS);
+  });
+  it('should return retrieved data without parsers', async () => {
+    const value = await pasteFromClipboard();
+    expect(readTextStub).toHaveBeenCalled();
+    expect(value).toStrictEqual(TEXT);
+  });
+  describe('when paste value is not coming from weaverbird', () => {
+    beforeEach(async () => {
+      readTextStub.mockResolvedValue('IamBAD');
+    });
+    it('should return an empty string', async () => {
+      const value = await pasteFromClipboard();
+      expect(value).toStrictEqual('');
+    });
+  });
+});

--- a/tests/unit/lib/clipboard.spec.ts
+++ b/tests/unit/lib/clipboard.spec.ts
@@ -1,13 +1,13 @@
 import {
-  addTextValidator,
-  CLIPBOARD_VALIDATOR,
+  addTextFlag,
+  CLIPBOARD_FLAG,
   copyToClipboard,
   pasteFromClipboard,
-  validateClipboardText,
+  validateAndRemoveTextFlag,
 } from '@/lib/clipboard';
 
 const TEXT = 'TOTO';
-const TEXT_WITH_VALIDATOR = `${CLIPBOARD_VALIDATOR}TOTO${CLIPBOARD_VALIDATOR}`;
+const TEXT_WITH_VALIDATOR = `${CLIPBOARD_FLAG}TOTO${CLIPBOARD_FLAG}`;
 
 const writeTextStub = jest.fn(),
   readTextStub = jest.fn();
@@ -19,37 +19,37 @@ Object.assign(navigator, {
   },
 });
 
-describe('validateClipboardText', () => {
-  it('should return string without validator', () => {
-    const value = validateClipboardText(`PARSERTOTOPARSER`, 'PARSER');
+describe('validateAndRemoveTextFlag', () => {
+  it('should return a string without flag', () => {
+    const value = validateAndRemoveTextFlag(`FLAGTOTOFLAG`, 'FLAG');
     expect(value).toStrictEqual('TOTO');
   });
-  it('should return empty string if passed value is undefined', () => {
-    const value = validateClipboardText(undefined, 'PARSER');
+  it('should return an empty string if passed value is undefined', () => {
+    const value = validateAndRemoveTextFlag(undefined, 'FLAG');
     expect(value).toStrictEqual('');
   });
-  it('should return empty string if string was already empty', () => {
-    const value = validateClipboardText('', 'PARSER');
+  it('should return an empty string if string was already empty', () => {
+    const value = validateAndRemoveTextFlag('', 'FLAG');
     expect(value).toStrictEqual('');
   });
-  it('should return empty string if passed value has no validator', () => {
-    const value = validateClipboardText(`OTHERTOTOOTHER`, 'PARSER');
+  it('should return an empty string if passed value has no flag', () => {
+    const value = validateAndRemoveTextFlag(`OTHERTOTOOTHER`, 'FLAG');
     expect(value).toStrictEqual('');
   });
 });
-describe('addTextValidator', () => {
-  it('should return string with validator', () => {
-    const value = addTextValidator('TOTO', 'PARSER');
-    expect(value).toStrictEqual(`PARSERTOTOPARSER`);
+describe('addTextFlag', () => {
+  it('should return string with flag', () => {
+    const value = addTextFlag('TOTO', 'FLAG');
+    expect(value).toStrictEqual(`FLAGTOTOFLAG`);
   });
   it('should return empty string if string was already empty', () => {
-    const value = addTextValidator('', 'PARSER');
+    const value = addTextFlag('', 'FLAG');
     expect(value).toStrictEqual('');
   });
 });
 
 describe('copyToClipboard', () => {
-  it('should copy updated string with validator to clipboard', async () => {
+  it('should copy updated string with flag to clipboard', async () => {
     await copyToClipboard(TEXT);
     expect(writeTextStub).toHaveBeenCalledWith(TEXT_WITH_VALIDATOR);
   });
@@ -59,7 +59,7 @@ describe('pasteFromClipboard', () => {
   beforeEach(async () => {
     readTextStub.mockResolvedValue(TEXT_WITH_VALIDATOR);
   });
-  it('should return retrieved data without validator', async () => {
+  it('should return retrieved data without flag', async () => {
     const value = await pasteFromClipboard();
     expect(readTextStub).toHaveBeenCalled();
     expect(value).toStrictEqual(TEXT);

--- a/tests/unit/lib/clipboard.spec.ts
+++ b/tests/unit/lib/clipboard.spec.ts
@@ -1,13 +1,13 @@
 import {
-  CLIPBOARD_PARSER,
+  addTextValidator,
+  CLIPBOARD_VALIDATOR,
   copyToClipboard,
-  parseTextForClipboard,
-  parseTextFromClipboard,
   pasteFromClipboard,
+  validateClipboardText,
 } from '@/lib/clipboard';
 
 const TEXT = 'TOTO';
-const TEXT_WITH_PARSERS = `${CLIPBOARD_PARSER}TOTO${CLIPBOARD_PARSER}`;
+const TEXT_WITH_VALIDATOR = `${CLIPBOARD_VALIDATOR}TOTO${CLIPBOARD_VALIDATOR}`;
 
 const writeTextStub = jest.fn(),
   readTextStub = jest.fn();
@@ -19,47 +19,47 @@ Object.assign(navigator, {
   },
 });
 
-describe('parseTextFromClipboard', () => {
-  it('should return string without parsers', () => {
-    const value = parseTextFromClipboard(`PARSERTOTOPARSER`, 'PARSER');
+describe('validateClipboardText', () => {
+  it('should return string without validator', () => {
+    const value = validateClipboardText(`PARSERTOTOPARSER`, 'PARSER');
     expect(value).toStrictEqual('TOTO');
   });
   it('should return empty string if passed value is undefined', () => {
-    const value = parseTextFromClipboard(undefined, 'PARSER');
+    const value = validateClipboardText(undefined, 'PARSER');
     expect(value).toStrictEqual('');
   });
   it('should return empty string if string was already empty', () => {
-    const value = parseTextFromClipboard('', 'PARSER');
+    const value = validateClipboardText('', 'PARSER');
     expect(value).toStrictEqual('');
   });
-  it('should return empty string if passed value has no parsers', () => {
-    const value = parseTextFromClipboard(`OTHERTOTOOTHER`, 'PARSER');
+  it('should return empty string if passed value has no validator', () => {
+    const value = validateClipboardText(`OTHERTOTOOTHER`, 'PARSER');
     expect(value).toStrictEqual('');
   });
 });
-describe('parseTextForClipboard', () => {
-  it('should return string with parsers', () => {
-    const value = parseTextForClipboard('TOTO', 'PARSER');
+describe('addTextValidator', () => {
+  it('should return string with validator', () => {
+    const value = addTextValidator('TOTO', 'PARSER');
     expect(value).toStrictEqual(`PARSERTOTOPARSER`);
   });
   it('should return empty string if string was already empty', () => {
-    const value = parseTextForClipboard('', 'PARSER');
+    const value = addTextValidator('', 'PARSER');
     expect(value).toStrictEqual('');
   });
 });
 
 describe('copyToClipboard', () => {
-  it('should copy updated string with parsers to clipboard', async () => {
+  it('should copy updated string with validator to clipboard', async () => {
     await copyToClipboard(TEXT);
-    expect(writeTextStub).toHaveBeenCalledWith(TEXT_WITH_PARSERS);
+    expect(writeTextStub).toHaveBeenCalledWith(TEXT_WITH_VALIDATOR);
   });
 });
 
 describe('pasteFromClipboard', () => {
   beforeEach(async () => {
-    readTextStub.mockResolvedValue(TEXT_WITH_PARSERS);
+    readTextStub.mockResolvedValue(TEXT_WITH_VALIDATOR);
   });
-  it('should return retrieved data without parsers', async () => {
+  it('should return retrieved data without validator', async () => {
     const value = await pasteFromClipboard();
     expect(readTextStub).toHaveBeenCalled();
     expect(value).toStrictEqual(TEXT);

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -347,5 +347,18 @@ describe('Pipeline.vue', () => {
         });
       });
     });
+
+    describe('when passed steps are not an array', () => {
+      const stepsFromClipboard = 'TOTO';
+      beforeEach(async () => {
+        pasteFromClipboardStub.mockResolvedValue(JSON.stringify(stepsFromClipboard));
+        ctrlV();
+      });
+      it('should not add steps to pipeline', () => {
+        expect(dispatchSpy).not.toHaveBeenCalledWith(VQBnamespace('addSteps'), {
+          steps: stepsFromClipboard,
+        });
+      });
+    });
   });
 });

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -85,7 +85,7 @@ describe('Pipeline.vue', () => {
     });
 
     it('should add step index to steps to delete', () => {
-      expect((wrapper.vm as any).stepsToDelete).toContain(1);
+      expect((wrapper.vm as any).selectedSteps).toContain(1);
     });
     it('should apply delete class to step', () => {
       expect(stepToDelete.props().toDelete).toBe(true);
@@ -97,7 +97,7 @@ describe('Pipeline.vue', () => {
         await wrapper.vm.$nextTick();
       });
       it('should remove step index from step to delete', () => {
-        expect((wrapper.vm as any).stepsToDelete).not.toContain(1);
+        expect((wrapper.vm as any).selectedSteps).not.toContain(1);
       });
       it('should remove delete class from step', () => {
         expect(stepToDelete.props().toDelete).toBe(false);
@@ -106,7 +106,7 @@ describe('Pipeline.vue', () => {
 
     describe('when there is steps selected', () => {
       beforeEach(async () => {
-        wrapper.setData({ stepsToDelete: [1, 2] });
+        wrapper.setData({ selectedSteps: [1, 2] });
         await wrapper.vm.$nextTick();
       });
       it('should show the delete steps button', () => {
@@ -125,7 +125,7 @@ describe('Pipeline.vue', () => {
 
     describe('when there is no steps to delete', () => {
       beforeEach(async () => {
-        wrapper.setData({ stepsToDelete: [] });
+        wrapper.setData({ selectedSteps: [] });
         await wrapper.vm.$nextTick();
       });
       it('should hide the delete steps button', () => {
@@ -148,7 +148,7 @@ describe('Pipeline.vue', () => {
 
   describe('clicking on the delete button', () => {
     let wrapper: Wrapper<PipelineComponent>, modal: Wrapper<any>, dispatchSpy: jest.SpyInstance;
-    const stepsToDelete = [1, 2];
+    const selectedSteps = [1, 2];
 
     beforeEach(async () => {
       const pipeline: Pipeline = [
@@ -159,7 +159,7 @@ describe('Pipeline.vue', () => {
       const store = setupMockStore(buildStateWithOnePipeline(pipeline));
       dispatchSpy = jest.spyOn(store, 'dispatch');
       wrapper = mount(PipelineComponent, { store, localVue });
-      wrapper.setData({ stepsToDelete });
+      wrapper.setData({ selectedSteps });
       wrapper.find('.query-pipeline__delete-steps').trigger('click');
       await wrapper.vm.$nextTick();
       modal = wrapper.find(DeleteConfirmationModal);
@@ -183,7 +183,7 @@ describe('Pipeline.vue', () => {
         expect(dispatchSpy).not.toHaveBeenCalled();
       });
       it('should keep the selected steps unchanged', () => {
-        expect((wrapper.vm as any).stepsToDelete).toStrictEqual(stepsToDelete);
+        expect((wrapper.vm as any).selectedSteps).toStrictEqual(selectedSteps);
       });
     });
 
@@ -199,11 +199,11 @@ describe('Pipeline.vue', () => {
       });
       it('should delete the selected steps', () => {
         expect(dispatchSpy).toHaveBeenCalledWith(VQBnamespace('deleteSteps'), {
-          indexes: stepsToDelete,
+          indexes: selectedSteps,
         });
       });
       it('should clean the selected steps', () => {
-        expect((wrapper.vm as any).stepsToDelete).toStrictEqual([]);
+        expect((wrapper.vm as any).selectedSteps).toStrictEqual([]);
       });
     });
   });

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -442,6 +442,44 @@ describe('mutation tests', () => {
     });
   });
 
+  describe('addSteps', function() {
+    it('should do nothing if no pipeline is selected', () => {
+      const state = buildState({});
+      mutations.addSteps(state, {
+        steps: [
+          { name: 'rename', toRename: [['foo', 'bar']] },
+          { name: 'rename', toRename: [['baz', 'spam']] },
+        ],
+      });
+      expect(currentPipeline(state)).toBeUndefined();
+    });
+
+    it('should add selected steps to pipeline and select the last available one', () => {
+      const pipeline: Pipeline = [{ name: 'domain', domain: 'foo' }];
+      const state = buildStateWithOnePipeline(pipeline, {
+        dataset: {
+          headers: [],
+          data: [],
+          paginationContext: { pageno: 2, pagesize: 10, totalCount: 10 },
+        },
+      });
+      mutations.addSteps(state, {
+        steps: [
+          { name: 'rename', toRename: [['foo', 'bar']] },
+          { name: 'rename', toRename: [['baz', 'spam']] },
+        ],
+      });
+      expect(currentPipeline(state)).toEqual([
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', toRename: [['foo', 'bar']] },
+        { name: 'rename', toRename: [['baz', 'spam']] },
+      ]);
+      expect(state.selectedStepIndex).toEqual(2);
+      // make sure the pagination is reset
+      expect(state.dataset.paginationContext?.pageno).toEqual(1);
+    });
+  });
+
   it('sets current domain on empty pipeline', () => {
     const state = buildStateWithOnePipeline([], { currentDomain: 'foo' });
     expect(state.currentDomain).toEqual('foo');

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -454,8 +454,14 @@ describe('mutation tests', () => {
       expect(currentPipeline(state)).toBeUndefined();
     });
 
-    it('should add selected steps to pipeline and select the last available one', () => {
-      const pipeline: Pipeline = [{ name: 'domain', domain: 'foo' }];
+    it('should add selected steps to pipeline at selected index and select the last added step', () => {
+      const pipeline: Pipeline = [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', toRename: [['foo', 'bar']] },
+        { name: 'rename', toRename: [['baz', 'spam']] },
+        { name: 'rename', toRename: [['bobo', 'babar']] },
+        { name: 'rename', toRename: [['bibi', 'bubu']] },
+      ];
       const state = buildStateWithOnePipeline(pipeline, {
         dataset: {
           headers: [],
@@ -463,16 +469,57 @@ describe('mutation tests', () => {
           paginationContext: { pageno: 2, pagesize: 10, totalCount: 10 },
         },
       });
+      mutations.selectStep(state, { index: 2 }); // select step 2
       mutations.addSteps(state, {
         steps: [
-          { name: 'rename', toRename: [['foo', 'bar']] },
-          { name: 'rename', toRename: [['baz', 'spam']] },
+          { name: 'rename', toRename: [['lalalolilol', 'lol']] },
+          { name: 'rename', toRename: [['trololol', 'lala']] },
         ],
       });
       expect(currentPipeline(state)).toEqual([
         { name: 'domain', domain: 'foo' },
         { name: 'rename', toRename: [['foo', 'bar']] },
         { name: 'rename', toRename: [['baz', 'spam']] },
+        { name: 'rename', toRename: [['lalalolilol', 'lol']] },
+        { name: 'rename', toRename: [['trololol', 'lala']] },
+        { name: 'rename', toRename: [['bobo', 'babar']] },
+        { name: 'rename', toRename: [['bibi', 'bubu']] },
+      ]);
+      expect(state.selectedStepIndex).toEqual(4);
+      // make sure the pagination is reset
+      expect(state.dataset.paginationContext?.pageno).toEqual(1);
+    });
+
+    it('should never add  selected steps before domain step', () => {
+      const pipeline: Pipeline = [
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', toRename: [['foo', 'bar']] },
+        { name: 'rename', toRename: [['baz', 'spam']] },
+        { name: 'rename', toRename: [['bobo', 'babar']] },
+        { name: 'rename', toRename: [['bibi', 'bubu']] },
+      ];
+      const state = buildStateWithOnePipeline(pipeline, {
+        dataset: {
+          headers: [],
+          data: [],
+          paginationContext: { pageno: 2, pagesize: 10, totalCount: 10 },
+        },
+      });
+      mutations.selectStep(state, { index: -1 }); // select step 2
+      mutations.addSteps(state, {
+        steps: [
+          { name: 'rename', toRename: [['lalalolilol', 'lol']] },
+          { name: 'rename', toRename: [['trololol', 'lala']] },
+        ],
+      });
+      expect(currentPipeline(state)).toEqual([
+        { name: 'domain', domain: 'foo' },
+        { name: 'rename', toRename: [['lalalolilol', 'lol']] },
+        { name: 'rename', toRename: [['trololol', 'lala']] },
+        { name: 'rename', toRename: [['foo', 'bar']] },
+        { name: 'rename', toRename: [['baz', 'spam']] },
+        { name: 'rename', toRename: [['bobo', 'babar']] },
+        { name: 'rename', toRename: [['bibi', 'bubu']] },
       ]);
       expect(state.selectedStepIndex).toEqual(2);
       // make sure the pagination is reset

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -505,7 +505,7 @@ describe('mutation tests', () => {
           paginationContext: { pageno: 2, pagesize: 10, totalCount: 10 },
         },
       });
-      mutations.selectStep(state, { index: -1 }); // select step 2
+      mutations.selectStep(state, { index: -1 }); // select step -1
       mutations.addSteps(state, {
         steps: [
           { name: 'rename', toRename: [['lalalolilol', 'lol']] },


### PR DESCRIPTION
Select some steps with delete steps tool logics will provide a list of steps.
When user use ctrl+c, we copy the steps content as string and add a parser (to make sure retrieved date come from weaverbird).
Then user can ctrl + v to another (or current) pipeline to add copied steps to it
Not working on all networks check https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API

![copy](https://user-images.githubusercontent.com/59559689/117832798-18fc3900-b276-11eb-9a46-de33e9a9dc25.gif)

