### PR TITLE
fix(filter-condition): enable to have undefined value

### DIFF
--- a/src/components/stepforms/schemas/filter.ts
+++ b/src/components/stepforms/schemas/filter.ts
@@ -128,7 +128,7 @@ export default {
           },
         },
       },
-      required: ['column', 'value', 'operator'],
+      required: ['column', 'operator'],
       additionalProperties: false,
     },
   },

--- a/src/components/stepforms/schemas/ifthenelse.ts
+++ b/src/components/stepforms/schemas/ifthenelse.ts
@@ -156,7 +156,7 @@ export default {
           },
         },
       },
-      required: ['column', 'value', 'operator'],
+      required: ['column', 'operator'],
       additionalProperties: false,
     },
     formula: {


### PR DESCRIPTION
In case of 'is null' or 'is not null' condition, we remove the value field and set value to 'null'. It seems that Pandas delete 'null' value field from properties.
So when you come back to edit step, you can't validate because value field is required.
We should not required 'value' field