### PR TITLE
fix(front): do not capitalize tooltips

### DIFF
--- a/src/styles/utils/v-tooltip.scss
+++ b/src/styles/utils/v-tooltip.scss
@@ -44,10 +44,6 @@
     text-align: center;
   }
 
-  .tooltip-inner::first-letter {
-    text-transform: uppercase;
-  }
-
   .tooltip-inner a {
     color: white;
   }


### PR DESCRIPTION
Misleading e.g. when we use tooltips for variables values