### PR TITLE
fix(variable chooser): always display date in UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Variable chooser : stop displaying Date relative to user timezone
+
 ## [0.49.1] - 2021-06-09
 
 ### Fixed

--- a/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
@@ -32,7 +32,9 @@
             <span v-if="isMultiple" class="widget-variable-chooser__option-toggle" />
             <span class="widget-variable-chooser__option-name">{{ availableVariable.label }}</span>
           </div>
-          <span class="widget-variable-chooser__option-value">{{ availableVariable.value }}</span>
+          <span class="widget-variable-chooser__option-value">{{
+            formatIfDate(availableVariable.value)
+          }}</span>
         </div>
       </div>
       <div class="widget-advanced-variable" @click="addAdvancedVariable">
@@ -96,6 +98,13 @@ export default class VariableChooser extends Vue {
       }
       return categories;
     }, []);
+  }
+
+  formatIfDate(value: any): any {
+    if (value instanceof Date) {
+      return value.toUTCString();
+    }
+    return value;
   }
 
   /**

--- a/tests/unit/variable-chooser.spec.ts
+++ b/tests/unit/variable-chooser.spec.ts
@@ -34,6 +34,12 @@ describe('Variable Chooser', () => {
             value: '2020',
           },
           {
+            category: 'App variables',
+            label: 'date.today',
+            identifier: 'appRequesters.date.today',
+            value: new Date('2021/4/20'),
+          },
+          {
             category: 'Story variables',
             label: 'country',
             identifier: 'requestersManager.country',
@@ -74,7 +80,7 @@ describe('Variable Chooser', () => {
         .text(),
     ).toEqual('Story variables');
     const varsFromFirstSection = sections.at(0).findAll('.widget-variable-chooser__option');
-    expect(varsFromFirstSection).toHaveLength(3);
+    expect(varsFromFirstSection).toHaveLength(4);
   });
 
   it('should display variables current values along their names', () => {
@@ -155,7 +161,7 @@ describe('Variable Chooser', () => {
     });
 
     it('should display checkboxes before options', () => {
-      expect(wrapper.findAll('.widget-variable-chooser__option-toggle').length).toBe(5);
+      expect(wrapper.findAll('.widget-variable-chooser__option-toggle').length).toBe(6);
     });
 
     it('should highlight selected options', () => {

--- a/tests/unit/variable-chooser.spec.ts
+++ b/tests/unit/variable-chooser.spec.ts
@@ -37,7 +37,7 @@ describe('Variable Chooser', () => {
             category: 'App variables',
             label: 'date.today',
             identifier: 'appRequesters.date.today',
-            value: new Date('2021/4/20'),
+            value: new Date(1623398957013),
           },
           {
             category: 'Story variables',
@@ -90,6 +90,16 @@ describe('Variable Chooser', () => {
     });
   });
 
+  it('should display dates values in UTC timezone', () => {
+    expect(
+      wrapper
+        .findAll('.widget-variable-chooser__option')
+        .at(3)
+        .find('.widget-variable-chooser__option-value')
+        .text(),
+    ).toStrictEqual('Fri, 11 Jun 2021 08:09:17 GMT');
+  });
+
   describe('tooltip', () => {
     it('should display a value tooltip for each variable', () => {
       wrapper.findAll('.widget-variable-chooser__option').wrappers.forEach(w => {
@@ -103,6 +113,9 @@ describe('Variable Chooser', () => {
       expect((wrapper.vm as any).makeValueReadable(1)).toStrictEqual('1');
       expect((wrapper.vm as any).makeValueReadable('1')).toStrictEqual('"1"');
       expect((wrapper.vm as any).makeValueReadable(undefined)).toStrictEqual(undefined);
+      expect((wrapper.vm as any).makeValueReadable(new Date(1623398957013))).toStrictEqual(
+        '"2021-06-11T08:09:17.013Z"',
+      );
     });
   });
 


### PR DESCRIPTION
Before, tooltip & value where different (June 8 midnight vs June 7 22hours) : 

![variable_chooser-date-before](https://user-images.githubusercontent.com/3978482/121655645-0e180c80-ca9f-11eb-90f6-9c5675a26a5d.png)

After, tooltip & value are consistent : 

![variable_chooser-date-after](https://user-images.githubusercontent.com/3978482/121657122-6ac7f700-caa0-11eb-981b-2851ae70ad65.png)
