### PR TITLE
fix(code-editor): move fixed height to container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Code editor: move static height to container to avoid css override
+
 ## [0.49.1] - 2021-06-09
 
 ### Fixed

--- a/src/components/stepforms/widgets/CodeEditorWidget.vue
+++ b/src/components/stepforms/widgets/CodeEditorWidget.vue
@@ -88,6 +88,7 @@ export default class CodeEditorWidget extends Mixins(FormWidget) {
 
 .widget-code-editor__container {
   @extend %form-widget__container;
+  height: 300px;
 }
 
 .widget-code-editor {
@@ -95,7 +96,7 @@ export default class CodeEditorWidget extends Mixins(FormWidget) {
   transition: border 0.25s;
   margin: 5px 0px;
   width: 100%;
-  height: 300px;
+  height: 100%;
   resize: none;
   font-size: 15px;
 }


### PR DESCRIPTION
There is some new css code in our other repository that override the height: 300px of the code editor, we should move it to the container and keep a 100% height logic to be similar on both repository (behaviour is the same that before)

Before:
(You can see that height: 300% is override byt height: 100%)
![before](https://user-images.githubusercontent.com/59559689/121893799-aec82f80-cd1e-11eb-8554-eef9aabb13bd.png)

After:
![after](https://user-images.githubusercontent.com/59559689/121893816-b2f44d00-cd1e-11eb-9701-8e195234e5a9.png)

(No impact on custom step because it was 300px height too, same behaviour than before :ok_hand: )