### PR TITLE
fix(backend-errors): use same message key for errmsg formatted error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Backend errors: use `message` as returned key for all type of errors
+
 ## [0.49.1] - 2021-06-09
 
 ### Fixed

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -31,7 +31,7 @@ function loading(type: 'dataset' | 'uniqueValues') {
 export function formatError(error: any): BackendError {
   return typeof error === 'string'
     ? { type: 'error', message: error.toString() }
-    : { type: 'error', ...error };
+    : { type: 'error', ...error, message: error.message ?? error.errmsg };
 }
 
 /**

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -1161,5 +1161,21 @@ describe('action tests', () => {
         message: 'Step specific error',
       });
     });
+    it('should format an object error with errmsg to a correct BackendError object', () => {
+      const error = {
+        code: 241,
+        codeName: 'ConversionFailure',
+        errmsg: 'global error message',
+        ok: 0,
+      };
+      expect(formatError(error)).toStrictEqual({
+        code: 241,
+        type: 'error',
+        codeName: 'ConversionFailure',
+        errmsg: 'global error message',
+        message: 'global error message', // use the same key object to retrieve error message than in other errors
+        ok: 0,
+      });
+    });
   });
 });


### PR DESCRIPTION
Some mongo errors seems to have different interfaces than other errors (string, object with index to associate a specific step, or mongo error with code and errmsg property).
To be sure to use the same key to retrieve message outside of weaverbird, we add the message key to the backendError object associated with errmsg property coming from Mongo lib

Current Mongo error is : 
`{
        code: 241,
        codeName: 'ConversionFailure',
        errmsg: 'global error message',
        ok: 0,
      }`
      
 Panda error is:
 `{ message: 'step specific error message', index: 1  }`
 
 Other error can be only a string:
 `ConversionFailure: global error message`
      
 We should have a `message` property to be able to retrieve the message based on a similar value for each errors