### PR TITLE
feat(translators): hide actions from interface if no steps are supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 - `empty` translator (domain only)
+- Pipeline: hide pipeline tips when there is no supported steps
+- DataViewer: hide header cell actions when there is no supported steps
+- ActionToolbar: hide actions and search when there is no supported steps
 
 ## [0.49.2] - 2021-06-15
 

--- a/src/components/ActionToolbar.vue
+++ b/src/components/ActionToolbar.vue
@@ -1,19 +1,21 @@
 <template>
   <div class="action-toolbar__container">
     <div class="action-toolbar">
-      <action-toolbar-button
-        v-for="(button, index) in formattedButtons"
-        :icon="button.icon"
-        :label="button.label"
-        :key="button.icon"
-        :category="button.category"
-        :is-active="button.isActionToolbarMenuOpened"
-        :class="button.class"
-        @actionClicked="actionClicked"
-        @click.native.stop="openPopover(index)"
-        @closed="closePopover()"
-      />
-      <search-bar @actionClicked="actionClicked" />
+      <template v-if="hasSupportedButtons">
+        <action-toolbar-button
+          v-for="(button, index) in formattedButtons"
+          :icon="button.icon"
+          :label="button.label"
+          :key="button.icon"
+          :category="button.category"
+          :is-active="button.isActionToolbarMenuOpened"
+          :class="button.class"
+          @actionClicked="actionClicked"
+          @click.native.stop="openPopover(index)"
+          @closed="closePopover()"
+        />
+        <search-bar @actionClicked="actionClicked" />
+      </template>
     </div>
   </div>
 </template>
@@ -47,6 +49,10 @@ export default class ActionToolbar extends Vue {
 
   openPopover(index: number) {
     this.isActiveActionToolbarButton = index;
+  }
+
+  get hasSupportedButtons(): boolean {
+    return this.supportedButtons.length > 0;
   }
 
   // Filter buttons that contains at least one supported step

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -53,7 +53,11 @@
                   }"
                   >{{ column.name }}</span
                 >
-                <span class="data-viewer__header-action" @click.stop="openMenu(column.name)">
+                <span
+                  class="data-viewer__header-action"
+                  @click.stop="openMenu(column.name)"
+                  v-if="hasSupportedActions"
+                >
                   <ActionMenu
                     :column-name="column.name"
                     :visible="column.isActionMenuOpened"
@@ -130,6 +134,7 @@ export default class DataViewer extends Vue {
   @VQBModule.Getter columnHeaders!: DataSetColumn[];
   @VQBModule.Getter translator!: string;
   @VQBModule.Getter pipeline?: Pipeline;
+  @VQBModule.Getter supportedSteps!: PipelineStepName[];
 
   @VQBModule.Mutation createStepForm!: ({
     stepName,
@@ -143,6 +148,10 @@ export default class DataViewer extends Vue {
 
   activeActionMenuColumnName = '';
   activeDataTypeMenuColumnName = '';
+
+  get hasSupportedActions(): boolean {
+    return this.supportedSteps.filter(step => step !== 'domain').length > 0;
+  }
 
   /**
    * @description Get our columns with their names and linked classes

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -167,6 +167,7 @@ export default class DataViewer extends Vue {
         isDataTypeMenuOpened: this.activeDataTypeMenuColumnName === d.name,
         class: {
           'data-viewer__header-cell': true,
+          'data-viewer__header-cell--disabled': !this.hasSupportedActions,
           'data-viewer__header-cell--active': this.isSelected(d.name),
         },
       };
@@ -369,6 +370,15 @@ export default class DataViewer extends Vue {
 
   .data-viewer__header-icon--active:hover {
     color: $active-color;
+  }
+}
+
+.data-viewer__header-cell--disabled {
+  .data-viewer__header-label {
+    white-space: nowrap;
+  }
+  .data-viewer__header-icon {
+    pointer-events: none;
   }
 }
 

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -30,7 +30,7 @@
         Delete [{{ selectedSteps.length }}] selected
       </div>
     </div>
-    <div class="query-pipeline__tips-container">
+    <div class="query-pipeline__tips-container" v-if="hasSupportedSteps">
       <div class="query-pipeline__tips">
         Interact with the widgets and table on the right to add steps
       </div>
@@ -51,7 +51,7 @@ import { Component } from 'vue-property-decorator';
 import Draggable from 'vuedraggable';
 
 import { copyToClipboard, pasteFromClipboard } from '@/lib/clipboard';
-import { DomainStep, isPipelineStep, Pipeline, PipelineStep } from '@/lib/steps';
+import { DomainStep, isPipelineStep, Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
 import { VariableDelimiters } from '@/lib/variables';
 import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
@@ -80,11 +80,16 @@ export default class PipelineComponent extends Vue {
   @VQBModule.Getter('pipeline') steps!: Pipeline;
   @VQBModule.Getter('isPipelineEmpty') onlyDomainStepIsPresent!: boolean;
   @VQBModule.Getter('isStepDisabled') isDisabled!: (index: number) => boolean;
+  @VQBModule.Getter supportedSteps!: PipelineStepName[];
 
   @VQBModule.Action selectStep!: ({ index }: { index: number }) => void;
   @VQBModule.Action deleteSteps!: (payload: { indexes: number[] }) => void;
   @VQBModule.Action addSteps!: (payload: { steps: PipelineStep[] }) => void;
   @VQBModule.Mutation setPipeline!: MutationCallbacks['setPipeline'];
+
+  get hasSupportedSteps(): boolean {
+    return this.supportedSteps.filter(step => step !== 'domain').length > 0;
+  }
 
   get arrangedSteps(): Pipeline {
     return this.steps;

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -151,6 +151,10 @@ const getters: GetterTree<VQBState, any> = {
    * Return the unsupported steps by the current translator
    */
   unsupportedSteps: (state: VQBState) => getTranslator(state.translator).unsupportedSteps,
+  /**
+   * Return the supported steps by the current translator
+   */
+  supportedSteps: (state: VQBState) => getTranslator(state.translator).supportedSteps,
 };
 
 export default getters;

--- a/tests/unit/action-toolbar.spec.ts
+++ b/tests/unit/action-toolbar.spec.ts
@@ -5,7 +5,7 @@ import ActionToolbar from '@/components/ActionToolbar.vue';
 import ActionToolbarButton from '@/components/ActionToolbarButton.vue';
 import { CATEGORY_BUTTONS } from '@/components/constants';
 
-import { setupMockStore } from './utils';
+import { buildStateWithOnePipeline, setupMockStore } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -126,5 +126,37 @@ describe('ActionToolbar', () => {
     });
     const searchBar = wrapper.findAll('search-bar-stub');
     expect(searchBar.exists()).toBeTruthy();
+  });
+
+  it('should hide action toolbar content without supported actions', () => {
+    const store = setupMockStore(
+      buildStateWithOnePipeline([], {
+        translator: 'empty', // there is no supported actions in empty translator
+        dataset: {
+          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+          data: [['value1', 'value2', 'value3']],
+          paginationContext: {
+            totalCount: 10,
+            pagesize: 10,
+            pageno: 1,
+          },
+        },
+      }),
+    );
+    const wrapper = shallowMount(ActionToolbar, {
+      propsData: {
+        buttons: [
+          {
+            category: 'filter',
+            icon: 'filter',
+            label: 'Filter',
+          },
+        ],
+      },
+      localVue,
+      store,
+    });
+    expect(wrapper.find('search-bar-stub').exists()).toBeFalsy();
+    expect(wrapper.findAll('action-toolbar-button-stub')).toHaveLength(0);
   });
 });

--- a/tests/unit/data-viewer.spec.ts
+++ b/tests/unit/data-viewer.spec.ts
@@ -605,5 +605,12 @@ describe('Data Viewer', () => {
     it('should remove data viewer header actions', () => {
       expect(wrapper.findAll('.data-viewer__header-action')).toHaveLength(0);
     });
+
+    it('should add a specific class to disable data viewer header', () => {
+      const dataViewerHeaderCells = wrapper.findAll('.data-viewer__header-cell');
+      dataViewerHeaderCells.wrappers.forEach(wrapper => {
+        expect(wrapper.classes()).toContain('data-viewer__header-cell--disabled');
+      });
+    });
   });
 });

--- a/tests/unit/data-viewer.spec.ts
+++ b/tests/unit/data-viewer.spec.ts
@@ -577,4 +577,33 @@ describe('Data Viewer', () => {
       expect(openStepFormStub).toBeCalledWith({ stepName: 'rename' });
     });
   });
+
+  describe('without supported actions (empty supported steps)', () => {
+    let wrapper: Wrapper<DataViewer>;
+    beforeEach(() => {
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          translator: 'empty', // there is no supported actions in empty translator
+          dataset: {
+            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+            data: [['value1', 'value2', 'value3']],
+            paginationContext: {
+              totalCount: 10,
+              pagesize: 10,
+              pageno: 1,
+            },
+          },
+        }),
+      );
+      wrapper = shallowMount(DataViewer, { store, localVue });
+    });
+
+    afterEach(() => {
+      if (wrapper) wrapper.destroy();
+    });
+
+    it('should remove data viewer header actions', () => {
+      expect(wrapper.findAll('.data-viewer__header-action')).toHaveLength(0);
+    });
+  });
 });

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -361,4 +361,28 @@ describe('Pipeline.vue', () => {
       });
     });
   });
+  describe('without supported steps', () => {
+    let wrapper: Wrapper<PipelineComponent>;
+    beforeEach(() => {
+      const store = setupMockStore(
+        buildStateWithOnePipeline([], {
+          translator: 'empty', // there is no supported actions in empty translator
+          dataset: {
+            headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+            data: [['value1', 'value2', 'value3']],
+            paginationContext: {
+              totalCount: 10,
+              pagesize: 10,
+              pageno: 1,
+            },
+          },
+        }),
+      );
+      wrapper = shallowMount(PipelineComponent, { store, localVue });
+    });
+
+    it('should hide the pipeline tips', () => {
+      expect(wrapper.find('.query-pipeline__tips-container').exists()).toBeFalsy();
+    });
+  });
 });

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -381,6 +381,13 @@ describe('getter tests', () => {
       expect(getters.unsupportedSteps(state, {}, {}, {})).toEqual(['convert']);
     });
   });
+
+  describe('supportedSteps', () => {
+    it('should return the list of steps supported by the translator', () => {
+      const state = buildState({ translator: 'empty' });
+      expect(getters.supportedSteps(state, {}, {}, {})).toEqual(['domain']);
+    });
+  });
 });
 
 describe('mutation tests', () => {


### PR DESCRIPTION
In case where we use a translator without supported steps (except domain that is not launch by actions buttons, we should disabled the interface buttons to avoid using unsupported steps).

1. Add a getter to retrieve supported steps (exsiting one was only for unsupported steps)
2. Hide toggle menu button and prevent using action in data viewer header cells (css) (disabled type changing 'ABC', '123' icons click)
3. Hide action toolbar
4. Hide pipeline tips

Before:
![before](https://user-images.githubusercontent.com/59559689/121917899-d7a7ef00-cd35-11eb-809b-8bb443930cff.png)

After:
![after](https://user-images.githubusercontent.com/59559689/121917909-daa2df80-cd35-11eb-9626-34374a09c720.png)
