### PR TITLE
fix: prevent uint32 in date extract results

### DIFF
--- a/server/tests/steps/test_date_extract.py
+++ b/server/tests/steps/test_date_extract.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 from pandas import DataFrame, to_datetime
+from pandas.core.arrays.integer import UInt32Dtype
 
 from tests.utils import assert_column_equals, assert_dataframes_equals
 from weaverbird.steps import DateExtractStep
@@ -265,6 +266,9 @@ def test_date_extract_(sample_df: DataFrame):
         }
     )
     assert_dataframes_equals(df_result, expected_result)
+
+    # Ensure there are no unsigned int types in result:
+    assert UInt32Dtype() not in list(df_result.dtypes)
 
 
 def test_benchmark_dateextract(benchmark):

--- a/server/weaverbird/steps/date_extract.py
+++ b/server/weaverbird/steps/date_extract.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 from typing import List, Literal, Optional, Union
 
 from pandas import DataFrame, to_datetime, to_timedelta
@@ -6,6 +7,8 @@ from pydantic import Field
 from weaverbird.render_variables import StepWithVariablesMixin
 from weaverbird.steps.base import BaseStep
 from weaverbird.types import ColumnName
+
+from .convert import cast_to_int
 
 BASIC_DATE_PARTS = Literal[
     'year',
@@ -182,6 +185,12 @@ class DateExtractStep(BaseStep):
             else:
                 operation = OPERATIONS_MAPPING.get(dt_info, dt_info)
                 result = getattr(serie_dt, operation)
+
+            # Handle unsigned integers:
+            with suppress(AttributeError):
+                if result.dtype.is_unsigned_integer:
+                    result = cast_to_int(result)
+
             df = df.assign(**{new_col: result})
 
         return df


### PR DESCRIPTION
Cast them to int64, so we don't have problems when exporting to json.