### PR TITLE
fix(step): change drag & drop grip icon

### DIFF
--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -32,7 +32,7 @@
             v-if="!isFirst"
             @click.stop
           >
-            <i class="fa fa-align-justify" aria-hidden="true" />
+            <i class="fa fa-grip-vertical" aria-hidden="true" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Change step's drag handle icon to something more similar to the intended design.

Before : 

![weaverbird-handle-before](https://user-images.githubusercontent.com/3978482/123069192-dac86c80-d412-11eb-86f0-bec3fb53c0e1.png)

After : 

![image](https://user-images.githubusercontent.com/3978482/123069225-e1ef7a80-d412-11eb-88a8-c339e4768617.png)

