### PR TITLE
fix(formula): avoid Infinity in resulting dataframe

### DIFF
--- a/server/tests/steps/test_formula.py
+++ b/server/tests/steps/test_formula.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from pandas import DataFrame
 
@@ -34,3 +35,12 @@ def test_bad_formula(sample_df: DataFrame, bad_expression):
     bad_step = FormulaStep(name='formula', new_column='z', formula=bad_expression)
     with pytest.raises(Exception):
         bad_step.execute(sample_df)
+
+
+def test_formula_infinity(sample_df: DataFrame):
+    df_result = FormulaStep(name='formula', new_column='z', formula='`col B` / (colA - 1)').execute(
+        sample_df
+    )
+
+    expected_result = sample_df.assign(z=[np.nan, 20.0 / 9])
+    assert_dataframes_equals(df_result, expected_result)

--- a/server/weaverbird/formula.py
+++ b/server/weaverbird/formula.py
@@ -1,5 +1,6 @@
 import re
 
+import numpy as np
 from pandas import DataFrame
 
 COLUMN_PATTERN = re.compile(r'(\`[^\`]*\`)')
@@ -30,7 +31,12 @@ def clean_formula(formula: str) -> str:
 
 def eval_formula(df: DataFrame, formula: str) -> DataFrame:
     try:
-        return df.eval(formula)
+        result = df.eval(formula)
     except Exception:
         # for all cases not handled by NumExpr
-        return df.eval(formula, engine='python')
+        result = df.eval(formula, engine='python')
+
+    # eval can introduce Infinity values (when dividing by 0),
+    # which do not have a JSON representation.
+    # Let's replace them by NaN:
+    return result.replace([np.inf, -np.inf], np.nan)

--- a/server/weaverbird/formula.py
+++ b/server/weaverbird/formula.py
@@ -36,7 +36,11 @@ def eval_formula(df: DataFrame, formula: str) -> DataFrame:
         # for all cases not handled by NumExpr
         result = df.eval(formula, engine='python')
 
-    # eval can introduce Infinity values (when dividing by 0),
-    # which do not have a JSON representation.
-    # Let's replace them by NaN:
-    return result.replace([np.inf, -np.inf], np.nan)
+    try:
+        # eval can introduce Infinity values (when dividing by 0),
+        # which do not have a JSON representation.
+        # Let's replace them by NaN:
+        return result.replace([np.inf, -np.inf], np.nan)
+    except Exception:
+        # `result` is not a Series
+        return result


### PR DESCRIPTION
The `formula` step of the python package could lead to `Infinity` in the resulting dataframe (after a division by 0).
`Infinity` does not have a json representation so it was sent as "null" to the frontend, which was misleading (dropna or fillna didn't work on these values).

Now, we replace these values by regular `np.nan`.