### PR TITLE
fix(search): display search correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Display search correctly in chrome browser
+
 ## [0.53.0] - 2021-07-15
 
 ### Added

--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -223,7 +223,6 @@ export default class ActionMenu extends Vue {
   background-color: #fff;
   box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.25);
   color: $base-color;
-  overflow: hidden;
 }
 
 .action-menu__panel {

--- a/src/components/ActionToolbarSearch.vue
+++ b/src/components/ActionToolbarSearch.vue
@@ -167,6 +167,9 @@ export default class SearchActions extends Vue {
     height: 16px;
   }
 }
+.action-toolbar-search__popover .multiselect--active .multiselect__content-wrapper {
+  max-height: 280px !important;
+}
 .action-toolbar-search__popover .multiselect--active .multiselect__tags {
   box-shadow: none;
   border-color: #2665a3;


### PR DESCRIPTION
Due to overflow hidden, the search was not display correctly. But as search height by default is going over the popover, we need to fix it with important (added dynamically to DOM by multiselect plugin, force it by css using !important).

Before:
![before](https://user-images.githubusercontent.com/59559689/126340973-73e1a243-2b8a-4b2e-8391-cad027fcc386.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/126340982-9aed1f43-997d-4de4-b9fa-f86a2e0c1c73.gif)

After FF:
![after-firefox](https://user-images.githubusercontent.com/59559689/126340957-79f487d4-5503-4904-97ad-cd9864a309d6.gif)
