### PR TITLE
fix(pipeline): enable delete shortcut only when no other input is focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Only enable current step delete shortcut when no other input is focused
 ## [0.53.0] - 2021-07-15
 
 ### Added

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -157,12 +157,13 @@ export default class PipelineComponent extends Vue {
     const isPasting: boolean = event.key == 'v' && (event.ctrlKey || event.metaKey);
     const isCopying: boolean = event.key == 'c' && (event.ctrlKey || event.metaKey);
     const isDeleting: boolean = event.key === 'Backspace';
+    const isNotFocusingAnyInput = document.activeElement === document.body;
 
     if (isCopying) {
       this.copySelectedSteps();
     } else if (isPasting) {
       this.pasteSelectedSteps();
-    } else if (isDeleting) {
+    } else if (isDeleting && isNotFocusingAnyInput) {
       this.openDeleteConfirmationModal();
     }
   }


### PR DESCRIPTION
Following #928 

Before, pressing backspace went editing a input trigger the current step deletion modal : 

![toucan_weaverbird_delete_shortcut-before](https://user-images.githubusercontent.com/3978482/126356806-3c3402b1-3988-4cca-bcb2-6f1be5493546.gif)

After, it's only triggered when not input field are focused : 

![toucan_weaverbird_delete_shortcut-after](https://user-images.githubusercontent.com/3978482/126356862-bde9b8a7-1112-400c-8b2e-452720054cd6.gif)
