### PR TITLE
feat(resizable): adapt col width to fit max char per col option

### DIFF
--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -13,7 +13,7 @@
           data-cy="weaverbird-data-viewer-table"
           v-resizable="{
             columns: columnNames,
-            labelClass: 'data-viewer__header-label',
+            labelTargetClass: 'data-viewer__header-label',
             classes: {
               table: 'data-viewer-table--resizable',
               handler: 'data-viewer__header-cell--resizable',

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -354,6 +354,7 @@ export default class DataViewer extends Vue {
   cursor: pointer;
   font-weight: bold;
   padding: 6px 8px;
+  padding-right: 23px;
 }
 
 .data-viewer__header-cell--active {
@@ -375,9 +376,6 @@ export default class DataViewer extends Vue {
 }
 
 .data-viewer__header-cell--disabled {
-  .data-viewer__header-label {
-    white-space: nowrap;
-  }
   .data-viewer__header-icon {
     pointer-events: none;
   }
@@ -389,7 +387,7 @@ export default class DataViewer extends Vue {
   text-overflow: ellipsis;
   max-width: calc(100% - 40px);
   overflow: hidden;
-  padding-right: 23px;
+  white-space: nowrap;
 }
 
 .data-viewer__header-icon {

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -13,6 +13,7 @@
           data-cy="weaverbird-data-viewer-table"
           v-resizable="{
             columns: columnNames,
+            labelClass: 'data-viewer__header-label',
             classes: {
               table: 'data-viewer-table--resizable',
               handler: 'data-viewer__header-cell--resizable',

--- a/src/directives/resizable/ResizableTable.ts
+++ b/src/directives/resizable/ResizableTable.ts
@@ -12,9 +12,9 @@ export const DEFAULT_OPTIONS: ResizableTableOptions = {
     handler: 'table__handler',
   },
   columns: [],
-  charsPerCol: 7.5,
+  firstDisplayCharsPerCol: 7.5,
   maxCharsPerCol: 20,
-  labelClass: '',
+  labelTargetClass: '',
 };
 
 export interface ResizableTableOptions {
@@ -23,9 +23,9 @@ export interface ResizableTableOptions {
     handler: string; // class applied to col handler
   };
   columns: string[] | number[]; // the columns associated to cols handlers
-  charsPerCol: number; // The actual number of chars displayed per col
+  firstDisplayCharsPerCol: number; // The number of chars per col display on first render
   maxCharsPerCol: number; // The max number of chars to display per col
-  labelClass: string; // class to select label in col
+  labelTargetClass: string; // DOM class to select label in col
 }
 
 export default class ResizableTable {
@@ -87,23 +87,23 @@ export default class ResizableTable {
   // Add some more px to display chars if some are cropped
   adaptWidthToContent(colElement: HTMLElement, index: number): number {
     const contentChars = this.options.columns[index].toString().length;
-    if (!this.options.labelClass || contentChars <= this.options.charsPerCol)
+    if (!this.options.labelTargetClass || contentChars <= this.options.firstDisplayCharsPerCol)
       return colElement.offsetWidth;
 
     // Retrieve the label DOM element
     const labelElement = colElement.getElementsByClassName(
-      this.options.labelClass,
+      this.options.labelTargetClass,
     )[0] as HTMLElement;
     if (!labelElement) return colElement.offsetWidth;
     // Find the padding width in total col width
     const padding = colElement.offsetWidth - labelElement.offsetWidth;
     // Find the pixel width for a char based on label width and actual chars per col
-    const pixelPerChar = labelElement.offsetWidth / this.options.charsPerCol;
+    const pixelPerChar = labelElement.offsetWidth / this.options.firstDisplayCharsPerCol;
     // Calculate needed width for col based on chars in content
     const contentWidth = pixelPerChar * contentChars;
     // Calculate max available width for col based on max chars per col
     const maxWidth = pixelPerChar * this.options.maxCharsPerCol;
-    return padding + Math.ceil(contentWidth < maxWidth ? contentWidth : maxWidth);
+    return padding + Math.ceil(Math.min(contentWidth, maxWidth));
   }
 
   // apply default style and add handler to each DOM col

--- a/src/directives/resizable/ResizableTable.ts
+++ b/src/directives/resizable/ResizableTable.ts
@@ -72,6 +72,11 @@ export default class ResizableTable {
     this.setColHandlers();
   }
 
+  // Add some more px to display chars if some are cropped
+  adaptWidthToContent(colElement: HTMLElement): number {
+    return colElement.offsetWidth;
+  }
+
   // Get ths of current table in DOM
   getCols(table: HTMLElement): HTMLCollection {
     const rows: HTMLCollection = table.getElementsByTagName('tr');
@@ -82,14 +87,16 @@ export default class ResizableTable {
     this.destroy(); // remove all previous handlers before adding new ones
     for (const col of this.cols) {
       const colElement = col as HTMLElement;
+      // Retrieve the adapted width depending on content length (in characters)
+      const colWidth = this.adaptWidthToContent(colElement);
       // there is sometimes an issue with small table that is solved by adding width to col (otherwise min-width is not set correctly)
-      colElement.style.width = `${colElement.offsetWidth}px`;
+      colElement.style.width = `${colWidth}px`;
       // minWidth override maxWidth css property so we use it to expand table and cols without having to touch to table width
-      colElement.style.minWidth = `${colElement.offsetWidth}px`;
+      colElement.style.minWidth = `${colWidth}px`;
 
       const colHandlerOptions: ResizableColHandlerOptions = {
         height: this.table.offsetHeight,
-        minWidth: colElement.offsetWidth,
+        minWidth: colWidth,
         className: this.options.classes.handler,
       };
       const colHandler: ResizableColHandler = new ResizableColHandler(colHandlerOptions);

--- a/src/directives/resizable/ResizableTable.ts
+++ b/src/directives/resizable/ResizableTable.ts
@@ -78,6 +78,12 @@ export default class ResizableTable {
     this.setColHandlers();
   }
 
+  // Get ths of current table in DOM
+  getCols(table: HTMLElement): HTMLCollection {
+    const rows: HTMLCollection = table.getElementsByTagName('tr');
+    return rows[0].children;
+  }
+
   // Add some more px to display chars if some are cropped
   adaptWidthToContent(colElement: HTMLElement, index: number): number {
     const contentChars = this.options.columns[index].toString().length;
@@ -100,11 +106,6 @@ export default class ResizableTable {
     return padding + Math.ceil(contentWidth < maxWidth ? contentWidth : maxWidth);
   }
 
-  // Get ths of current table in DOM
-  getCols(table: HTMLElement): HTMLCollection {
-    const rows: HTMLCollection = table.getElementsByTagName('tr');
-    return rows[0].children;
-  }
   // apply default style and add handler to each DOM col
   setColHandlers(): void {
     this.destroy(); // remove all previous handlers before adding new ones

--- a/src/directives/resizable/ResizableTable.ts
+++ b/src/directives/resizable/ResizableTable.ts
@@ -14,6 +14,7 @@ export const DEFAULT_OPTIONS: ResizableTableOptions = {
   columns: [],
   charsPerCol: 7.5,
   maxCharsPerCol: 20,
+  labelClass: '',
 };
 
 export interface ResizableTableOptions {
@@ -24,6 +25,7 @@ export interface ResizableTableOptions {
   columns: string[] | number[]; // the columns associated to cols handlers
   charsPerCol: number; // The actual number of chars displayed per col
   maxCharsPerCol: number; // The max number of chars to display per col
+  labelClass: string; // class to select label in col
 }
 
 export default class ResizableTable {
@@ -79,14 +81,23 @@ export default class ResizableTable {
   // Add some more px to display chars if some are cropped
   adaptWidthToContent(colElement: HTMLElement, index: number): number {
     const contentChars = this.options.columns[index].toString().length;
-    if (contentChars <= this.options.charsPerCol) return colElement.offsetWidth;
-    // Find the pixel width for a char based on content width and actual chars per col
-    const pixelPerChar = colElement.offsetWidth / this.options.charsPerCol;
+    if (!this.options.labelClass || contentChars <= this.options.charsPerCol)
+      return colElement.offsetWidth;
+
+    // Retrieve the label DOM element
+    const labelElement = colElement.getElementsByClassName(
+      this.options.labelClass,
+    )[0] as HTMLElement;
+    if (!labelElement) return colElement.offsetWidth;
+    // Find the padding width in total col width
+    const padding = colElement.offsetWidth - labelElement.offsetWidth;
+    // Find the pixel width for a char based on label width and actual chars per col
+    const pixelPerChar = labelElement.offsetWidth / this.options.charsPerCol;
     // Calculate needed width for col based on chars in content
     const contentWidth = pixelPerChar * contentChars;
     // Calculate max available width for col based on max chars per col
     const maxWidth = pixelPerChar * this.options.maxCharsPerCol;
-    return Math.ceil(contentWidth < maxWidth ? contentWidth : maxWidth);
+    return padding + Math.ceil(contentWidth < maxWidth ? contentWidth : maxWidth);
   }
 
   // Get ths of current table in DOM

--- a/src/directives/resizable/ResizableTable.ts
+++ b/src/directives/resizable/ResizableTable.ts
@@ -85,7 +85,7 @@ export default class ResizableTable {
   }
 
   // Add some more px to display chars if some are cropped
-  adaptWidthToContent(colElement: HTMLElement, index: number): number {
+  /* istanbul ignore next */ adaptWidthToContent(colElement: HTMLElement, index: number): number {
     const contentChars = this.options.columns[index].toString().length;
     if (!this.options.labelTargetClass || contentChars <= this.options.firstDisplayCharsPerCol)
       return colElement.offsetWidth;

--- a/tests/unit/resizable.spec.ts
+++ b/tests/unit/resizable.spec.ts
@@ -51,6 +51,7 @@ describe('Resizable directive', () => {
         update: jest.spyOn(ResizableTable.prototype, 'update'),
         updateCols: jest.spyOn(ResizableTable.prototype, 'updateCols'),
         updateRows: jest.spyOn(ResizableTable.prototype, 'updateRows'),
+        adaptWidthToContent: jest.spyOn(ResizableTable.prototype, 'adaptWidthToContent'),
       };
       wrapper = shallowMount(FakeTableComponent, { attachToDocument: true });
       handler = wrapper.findAll(defaultHandlerClass).at(0);
@@ -60,6 +61,10 @@ describe('Resizable directive', () => {
       wrapper.findAll('th').wrappers.map((col: Wrapper<any>) => {
         expect(col.element.style.minWidth).not.toBeUndefined();
       });
+    });
+
+    it('should adapt min-width for cols with very long label', () => {
+      expect(ResizableTableStub.adaptWidthToContent).toHaveBeenCalledTimes(3);
     });
 
     it('should add handlers to cols', () => {


### PR DESCRIPTION
Add an option to v-resizable table to display a certain amount of chars
Add another option to inform about the current chars displayed in col (can't be calculated due to white space no-wrap) that will cropp label
Add another option to target label in DOM

Adapt width of col based on max chars to display (retrieve pixel size for current chars and add missingwidth to fit the missing chars).
Adapt css to fit the new behaviour.

Tests:
We can't really tests DOM events (width with jest so we just test that function is correctly called)

Before:
![before](https://user-images.githubusercontent.com/59559689/127887393-f5b0d7a3-1d63-4a75-b39a-0ef8bd80eaae.png)
![before](https://user-images.githubusercontent.com/59559689/127887196-359b9792-327f-410e-8f86-d115f771c1cd.gif)

After (more characters display (20 at max)):
![after](https://user-images.githubusercontent.com/59559689/127887404-065f37ac-c441-4ce9-8916-822bc58f2d43.png)
![after](https://user-images.githubusercontent.com/59559689/127887209-420d4545-7454-469c-8e85-de7a2a824488.gif)
