### PR TITLE
feat(range-calendar): add a new range calendar component

### DIFF
--- a/.storybook/bundle.ts
+++ b/.storybook/bundle.ts
@@ -38,6 +38,7 @@ import TotalDimensions from '../src/components/stepforms/widgets/TotalDimensions
 import Popover from '../src/components/Popover.vue';
 import Calendar from '../src/components/Calendar.vue';
 import Tabs from '../src/components/Tabs.vue';
+import RangeCalendar from '../src/components/RangeCalendar.vue';
 
 export {
   FilterEditor,
@@ -74,7 +75,8 @@ export {
   TotalDimensions,
   Popover,
   Calendar,
-  Tabs
+  Tabs,
+  RangeCalendar,
 };
 export { setupStore, registerModule, VQBnamespace } from '../src/store';
 export { resizable } from '../src/directives/resizable/resizable';

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -2,6 +2,7 @@
   <DatePicker
     :value="value"
     :availableDates="availableDates"
+    :attributes="highlights"
     :select-attribute="selectedDatesStyle"
     :drag-attribute="rangeSelectedDatesStyle"
     :is-range="isRange"
@@ -26,6 +27,9 @@ export default class Calendar extends Vue {
   @Prop({ default: undefined })
   value!: Date | DateRange | undefined;
 
+  @Prop({ default: undefined })
+  highlightedDates!: DateRange | undefined;
+
   @Prop({ default: () => ({ start: undefined, end: undefined }) })
   availableDates!: DateRange;
 
@@ -48,6 +52,18 @@ export default class Calendar extends Vue {
         contentClass: 'calendar-content',
       },
     };
+  }
+
+  // style to apply to dates to highlight to fake a range selected behaviour
+  get highlights(): DatePickerHighlight[] {
+    if (!this.highlightedDates) return [];
+    return [
+      {
+        key: 'highlighted',
+        highlight: this.rangeSelectedDatesStyle.highlight,
+        dates: this.highlightedDates,
+      },
+    ];
   }
 
   /* istanbul ignore next */

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -1,6 +1,7 @@
 <template>
   <DatePicker
     :value="value"
+    :availableDates="availableDates"
     :select-attribute="selectedDatesStyle"
     :drag-attribute="rangeSelectedDatesStyle"
     :is-range="isRange"
@@ -24,6 +25,9 @@ import { DatePickerHighlight, DateRange } from '@/lib/dates';
 export default class Calendar extends Vue {
   @Prop({ default: undefined })
   value!: Date | DateRange | undefined;
+
+  @Prop({ default: () => ({ start: undefined, end: undefined }) })
+  availableDates!: DateRange;
 
   @Prop({ default: false })
   isRange!: boolean;

--- a/src/components/RangeCalendar.vue
+++ b/src/components/RangeCalendar.vue
@@ -3,11 +3,13 @@
     <Calendar
       :value="value.start"
       :availableDates="getAvailableDates('start')"
+      :highlightedDates="highlightedDates"
       @input="onInput($event, 'start')"
     />
     <Calendar
       :value="value.end"
       :availableDates="getAvailableDates('end')"
+      :highlightedDates="highlightedDates"
       @input="onInput($event, 'end')"
     />
   </div>
@@ -29,6 +31,11 @@ import Calendar from './Calendar.vue';
 export default class RangeCalendar extends Vue {
   @Prop({ default: () => ({}) })
   value!: DateRange;
+
+  // dates to highlight in calendar to fake a range mode
+  get highlightedDates(): DateRange | undefined {
+    return this.value.start && this.value.end ? this.value : undefined;
+  }
 
   getAvailableDates(prop: DateRangeSide): DateRange {
     if (prop === 'start') {

--- a/src/components/RangeCalendar.vue
+++ b/src/components/RangeCalendar.vue
@@ -1,12 +1,14 @@
 <template>
-  <div>
+  <div class="range-calendar">
     <Calendar
+      class="range-calendar__calendar range-calendar__calendar--first"
       :value="value.start"
       :availableDates="getAvailableDates('start')"
       :highlightedDates="highlightedDates"
       @input="onInput($event, 'start')"
     />
     <Calendar
+      class="range-calendar__calendar range-calendar__calendar--last"
       :value="value.end"
       :availableDates="getAvailableDates('end')"
       :highlightedDates="highlightedDates"
@@ -58,3 +60,12 @@ export default class RangeCalendar extends Vue {
   }
 }
 </script>
+<style scoped lang="scss">
+.range-calendar {
+  display: flex;
+  flex-direction: row;
+}
+.range-calendar__calendar--last {
+  margin-left: -1px; // avoid double border
+}
+</style>

--- a/src/components/RangeCalendar.vue
+++ b/src/components/RangeCalendar.vue
@@ -23,7 +23,13 @@ export default class RangeCalendar extends Vue {
   value!: DateRange;
 
   onInput(value: Date | null, prop: DateRangeSide): void {
-    this.$emit('input', { ...this.value, [prop]: value });
+    if (value) {
+      this.$emit('input', { ...this.value, [prop]: value });
+    } else {
+      const newValue = { ...this.value };
+      delete newValue[prop];
+      this.$emit('input', newValue);
+    }
   }
 }
 </script>

--- a/src/components/RangeCalendar.vue
+++ b/src/components/RangeCalendar.vue
@@ -53,6 +53,7 @@ export default class RangeCalendar extends Vue {
     if (value) {
       this.$emit('input', { ...this.value, [prop]: value });
     } else {
+      // calendar can emit null value when clicking on already selected date
       const newValue = { ...this.value };
       delete newValue[prop];
       this.$emit('input', newValue);

--- a/src/components/RangeCalendar.vue
+++ b/src/components/RangeCalendar.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>
+    <Calendar :value="value.start" @input="onInput($event, 'start')" />
+    <Calendar :value="value.end" @input="onInput($event, 'end')" />
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+import { DateRange, DateRangeSide } from '@/lib/dates';
+
+import Calendar from './Calendar.vue';
+
+@Component({
+  name: 'range-calendar',
+  components: {
+    Calendar,
+  },
+})
+export default class RangeCalendar extends Vue {
+  @Prop({ default: () => ({}) })
+  value!: DateRange;
+
+  onInput(value: Date | null, prop: DateRangeSide): void {
+    this.$emit('input', { ...this.value, [prop]: value });
+  }
+}
+</script>

--- a/src/components/RangeCalendar.vue
+++ b/src/components/RangeCalendar.vue
@@ -1,7 +1,15 @@
 <template>
   <div>
-    <Calendar :value="value.start" @input="onInput($event, 'start')" />
-    <Calendar :value="value.end" @input="onInput($event, 'end')" />
+    <Calendar
+      :value="value.start"
+      :availableDates="getAvailableDates('start')"
+      @input="onInput($event, 'start')"
+    />
+    <Calendar
+      :value="value.end"
+      :availableDates="getAvailableDates('end')"
+      @input="onInput($event, 'end')"
+    />
   </div>
 </template>
 
@@ -21,6 +29,16 @@ import Calendar from './Calendar.vue';
 export default class RangeCalendar extends Vue {
   @Prop({ default: () => ({}) })
   value!: DateRange;
+
+  getAvailableDates(prop: DateRangeSide): DateRange {
+    if (prop === 'start') {
+      // start value can be anything before end value
+      return { start: undefined, end: this.value.end };
+    } else {
+      // end value can be anything after start value
+      return { start: this.value.start, end: undefined };
+    }
+  }
 
   onInput(value: Date | null, prop: DateRangeSide): void {
     if (value) {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,4 +1,5 @@
 export type DateRange = { start?: Date; end?: Date };
+export type DateRangeSide = 'start' | 'end';
 export type DatePickerHighlight = {
   highlight: {
     class?: string;

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,8 +1,10 @@
 export type DateRange = { start?: Date; end?: Date };
 export type DateRangeSide = 'start' | 'end';
 export type DatePickerHighlight = {
+  key?: string;
   highlight: {
     class?: string;
     contentClass?: string;
   };
+  dates?: DateRange;
 };

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,5 +1,5 @@
 export type DateRange = { start?: Date; end?: Date };
-export type DateRangeSide = 'start' | 'end';
+export type DateRangeSide = keyof DateRange;
 export type DatePickerHighlight = {
   key?: string;
   highlight: {

--- a/stories/calendar.js
+++ b/stories/calendar.js
@@ -63,3 +63,33 @@ stories.add('range', () => ({
     </div>
   `,
 }));
+
+stories.add('with highlighted dates', () => ({
+  components: { Calendar },
+  data() {
+    return { 
+      value: new Date('01/01/2021'),
+      highlightedDates: { start: new Date('02/01/2021'), end: new Date('01/01/2021') } 
+    };
+  },
+  computed: {
+    formattedValue() {
+      return formatValue(this.value);
+    },
+  },
+  methods: {
+    input(value) {
+      this.value = value;
+    },
+  },
+  template: `
+    <div>
+      <Calendar 
+        :value="value"
+        :highlightedDates="highlightedDates"
+        @input="input"
+      />
+      <pre>{{ formattedValue }}</pre>
+    </div>
+  `,
+}));

--- a/stories/range-calendar.js
+++ b/stories/range-calendar.js
@@ -1,0 +1,39 @@
+import { storiesOf } from '@storybook/vue';
+
+import { RangeCalendar } from '../dist/storybook/components';
+
+const stories = storiesOf('RangeCalendar', module);
+
+
+const formatValue = (value) => {
+  return value != null && value instanceof Date ? value.toUTCString() : value;
+}
+
+stories.add('simple', () => ({
+  components: { RangeCalendar },
+  data() {
+    return { value: { start: undefined, end: undefined } };
+  },
+  computed: {
+    formattedValue() {
+      return {
+        start: formatValue(this.value.start),
+        end: formatValue(this.value.end),
+      };
+    },
+  },
+  methods: {
+    input(value) {
+      this.value = value;
+    },
+  },
+  template: `
+    <div>
+      <RangeCalendar 
+        :value="value"
+        @input="input"
+      />
+      <pre>{{ formattedValue }}</pre>
+    </div>
+  `,
+}));

--- a/tests/unit/calendar.spec.ts
+++ b/tests/unit/calendar.spec.ts
@@ -19,7 +19,7 @@ describe('Calendar', () => {
     if (wrapper) wrapper.destroy();
   });
 
-  describe('simple', () => {
+  describe('default', () => {
     const defaultValue = new Date();
     beforeEach(() => {
       createWrapper({ value: defaultValue });
@@ -38,6 +38,10 @@ describe('Calendar', () => {
       const value = new Date(1);
       wrapper.find('DatePicker-stub').vm.$emit('input', value);
       expect(wrapper.emitted('input')[0][0]).toStrictEqual(value);
+    });
+    it('should not display highlighted dates', () => {
+      const attributes = (wrapper.vm as any).highlights;
+      expect(attributes).toHaveLength(0);
     });
   });
 
@@ -59,6 +63,22 @@ describe('Calendar', () => {
       const value = { start: new Date(), end: new Date(2) };
       wrapper.find('DatePicker-stub').vm.$emit('input', value);
       expect(wrapper.emitted('input')[0][0]).toStrictEqual(value);
+    });
+  });
+
+  describe('with highlighted dates', () => {
+    const highlightedDates = [new Date(1), new Date(2)];
+    beforeEach(() => {
+      createWrapper({
+        value: new Date(),
+        highlightedDates,
+      });
+    });
+    it('should display highlighted dates', () => {
+      const attributes = (wrapper.vm as any).highlights;
+      expect(attributes).toHaveLength(1);
+      expect(attributes[0].key).toBe('highlighted');
+      expect(attributes[0].dates).toStrictEqual(highlightedDates);
     });
   });
 });

--- a/tests/unit/range-calendar.spec.ts
+++ b/tests/unit/range-calendar.spec.ts
@@ -34,6 +34,11 @@ describe('RangeCalendar', () => {
     expect(calendars.at(0).props().value).toStrictEqual(value.start);
     expect(calendars.at(1).props().value).toStrictEqual(value.end);
   });
+  it('should pass correct available dates to Calendar components', () => {
+    const calendars = wrapper.findAll('Calendar-stub');
+    expect(calendars.at(0).props().availableDates).toStrictEqual({ ...value, start: undefined }); // value can't be greater than end
+    expect(calendars.at(1).props().availableDates).toStrictEqual({ ...value, end: undefined }); // value can't be lower than start
+  });
   it('should emit modified start range when first Calendar is updated', () => {
     const date = new Date(1);
     const calendars = wrapper.findAll('Calendar-stub');

--- a/tests/unit/range-calendar.spec.ts
+++ b/tests/unit/range-calendar.spec.ts
@@ -15,61 +15,70 @@ describe('RangeCalendar', () => {
     });
   };
 
-  beforeEach(() => {
-    createWrapper();
-  });
-
   afterEach(() => {
-    wrapper.destroy();
+    if (wrapper) wrapper.destroy();
   });
 
-  it('should instantiate', () => {
-    expect(wrapper.exists()).toBe(true);
-  });
-  it('should instantiate 2 Calendar components', () => {
-    expect(wrapper.findAll('Calendar-stub')).toHaveLength(2);
-  });
-  it('should pass correct values to Calendar components', () => {
-    const calendars = wrapper.findAll('Calendar-stub');
-    expect(calendars.at(0).props().value).toStrictEqual(value.start);
-    expect(calendars.at(1).props().value).toStrictEqual(value.end);
-  });
-  it('should pass correct available dates to Calendar components', () => {
-    const calendars = wrapper.findAll('Calendar-stub');
-    expect(calendars.at(0).props().availableDates).toStrictEqual({ ...value, start: undefined }); // value can't be greater than end
-    expect(calendars.at(1).props().availableDates).toStrictEqual({ ...value, end: undefined }); // value can't be lower than start
-  });
-  it('should emit modified start range when first Calendar is updated', () => {
-    const date = new Date(1);
-    const calendars = wrapper.findAll('Calendar-stub');
-    calendars.at(0).vm.$emit('input', date);
-    expect(wrapper.emitted('input')[0][0]).toStrictEqual({ ...value, start: date });
-  });
-  it('should emit modified end range when last Calendar is updated', () => {
-    const date = new Date(2);
-    const calendars = wrapper.findAll('Calendar-stub');
-    calendars.at(1).vm.$emit('input', date);
-    expect(wrapper.emitted('input')[0][0]).toStrictEqual({ ...value, end: date });
-  });
-  it('should remove property if Calendar updated value is undefined', () => {
-    const date = undefined;
-    const calendars = wrapper.findAll('Calendar-stub');
-    calendars.at(1).vm.$emit('input', date);
-    expect(wrapper.emitted('input')[0][0]).toStrictEqual({ start: value.start });
-  });
-  it('should pass range included dates to highlight in Calendar', () => {
-    const calendar = wrapper.find('Calendar-stub');
-    expect(calendar.props().highlightedDates).toStrictEqual(value);
+  describe('default', () => {
+    beforeEach(() => {
+      createWrapper();
+    });
+    it('should instantiate', () => {
+      expect(wrapper.exists()).toBe(true);
+    });
+    it('should instantiate 2 Calendar components', () => {
+      expect(wrapper.findAll('Calendar-stub')).toHaveLength(2);
+    });
+    it('should pass correct values to Calendar components', () => {
+      const calendars = wrapper.findAll('Calendar-stub');
+      expect(calendars.at(0).props().value).toStrictEqual(value.start);
+      expect(calendars.at(1).props().value).toStrictEqual(value.end);
+    });
+    it('should pass correct available dates to Calendar components', () => {
+      const calendars = wrapper.findAll('Calendar-stub');
+      expect(calendars.at(0).props().availableDates).toStrictEqual({ ...value, start: undefined }); // value can't be greater than end
+      expect(calendars.at(1).props().availableDates).toStrictEqual({ ...value, end: undefined }); // value can't be lower than start
+    });
+    it('should emit modified start range when first Calendar is updated', () => {
+      const date = new Date(1);
+      const calendars = wrapper.findAll('Calendar-stub');
+      calendars.at(0).vm.$emit('input', date);
+      expect(wrapper.emitted('input')[0][0]).toStrictEqual({ ...value, start: date });
+    });
+    it('should emit modified end range when last Calendar is updated', () => {
+      const date = new Date(2);
+      const calendars = wrapper.findAll('Calendar-stub');
+      calendars.at(1).vm.$emit('input', date);
+      expect(wrapper.emitted('input')[0][0]).toStrictEqual({ ...value, end: date });
+    });
+    it('should remove property if Calendar updated value is undefined', () => {
+      const date = undefined;
+      const calendars = wrapper.findAll('Calendar-stub');
+      calendars.at(1).vm.$emit('input', date);
+      expect(wrapper.emitted('input')[0][0]).toStrictEqual({ start: value.start });
+    });
+    it('should pass range included dates to highlight in Calendar', () => {
+      const calendar = wrapper.find('Calendar-stub');
+      expect(calendar.props().highlightedDates).toStrictEqual(value);
+    });
   });
 
   describe('when range is not complete', () => {
-    beforeEach(async () => {
-      wrapper.setProps({ value: { start: new Date() } }); // no end date
-      wrapper.vm.$nextTick();
+    beforeEach(() => {
+      createWrapper({ value: { start: new Date() } });
     });
     it('should not pass range included dates to highlight in Calendar', () => {
       const calendar = wrapper.find('Calendar-stub');
       expect(calendar.props().highlightedDates).toStrictEqual(undefined);
+    });
+  });
+
+  describe('when range is undefined', () => {
+    beforeEach(() => {
+      createWrapper({ value: undefined });
+    });
+    it('should set value to {} by default', () => {
+      expect((wrapper.vm as any).value).toStrictEqual({});
     });
   });
 });

--- a/tests/unit/range-calendar.spec.ts
+++ b/tests/unit/range-calendar.spec.ts
@@ -57,4 +57,19 @@ describe('RangeCalendar', () => {
     calendars.at(1).vm.$emit('input', date);
     expect(wrapper.emitted('input')[0][0]).toStrictEqual({ start: value.start });
   });
+  it('should pass range included dates to highlight in Calendar', () => {
+    const calendar = wrapper.find('Calendar-stub');
+    expect(calendar.props().highlightedDates).toStrictEqual(value);
+  });
+
+  describe('when range is not complete', () => {
+    beforeEach(async () => {
+      wrapper.setProps({ value: { start: new Date() } }); // no end date
+      wrapper.vm.$nextTick();
+    });
+    it('should not pass range included dates to highlight in Calendar', () => {
+      const calendar = wrapper.find('Calendar-stub');
+      expect(calendar.props().highlightedDates).toStrictEqual(undefined);
+    });
+  });
 });

--- a/tests/unit/range-calendar.spec.ts
+++ b/tests/unit/range-calendar.spec.ts
@@ -1,0 +1,49 @@
+import { shallowMount, Wrapper } from '@vue/test-utils';
+
+import RangeCalendar from '@/components/RangeCalendar.vue';
+
+describe('RangeCalendar', () => {
+  let wrapper: Wrapper<RangeCalendar>;
+  const value = { start: new Date(), end: new Date(1) };
+  const createWrapper = (props: any = {}): void => {
+    wrapper = shallowMount(RangeCalendar, {
+      sync: false,
+      propsData: {
+        value,
+        ...props,
+      },
+    });
+  };
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper.destroy();
+  });
+
+  it('should instantiate', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+  it('should instantiate 2 Calendar components', () => {
+    expect(wrapper.findAll('Calendar-stub')).toHaveLength(2);
+  });
+  it('should pass correct values to Calendar components', () => {
+    const calendars = wrapper.findAll('Calendar-stub');
+    expect(calendars.at(0).props().value).toStrictEqual(value.start);
+    expect(calendars.at(1).props().value).toStrictEqual(value.end);
+  });
+  it('should emit modified start range when first Calendar is updated', () => {
+    const date = new Date(1);
+    const calendars = wrapper.findAll('Calendar-stub');
+    calendars.at(0).vm.$emit('input', date);
+    expect(wrapper.emitted('input')[0][0]).toStrictEqual({ ...value, start: date });
+  });
+  it('should emit modified end range when last Calendar is updated', () => {
+    const date = new Date(2);
+    const calendars = wrapper.findAll('Calendar-stub');
+    calendars.at(1).vm.$emit('input', date);
+    expect(wrapper.emitted('input')[0][0]).toStrictEqual({ ...value, end: date });
+  });
+});

--- a/tests/unit/range-calendar.spec.ts
+++ b/tests/unit/range-calendar.spec.ts
@@ -46,4 +46,10 @@ describe('RangeCalendar', () => {
     calendars.at(1).vm.$emit('input', date);
     expect(wrapper.emitted('input')[0][0]).toStrictEqual({ ...value, end: date });
   });
+  it('should remove property if Calendar updated value is undefined', () => {
+    const date = undefined;
+    const calendars = wrapper.findAll('Calendar-stub');
+    calendars.at(1).vm.$emit('input', date);
+    expect(wrapper.emitted('input')[0][0]).toStrictEqual({ start: value.start });
+  });
 });


### PR DESCRIPTION
Add a new range-calendar component to select a range between two dates display on two calendar one for start one for end
To have same behaviour that range in v-calendar we use v-calendar attributes to highlight dates between start and end in the calendars
Also added an availableDates logic to disable dates that are not able to be selected due to range side (start, end)

Design:
![range](https://user-images.githubusercontent.com/59559689/129215282-6c9cb345-3e7f-4e39-9d30-b2495d39b7a6.png)

Usage:
![range](https://user-images.githubusercontent.com/59559689/129215297-63bf59d3-3694-4d53-ae1d-8af682013a72.gif)
