### PR TITLE
feat(relative-date-form): add new component

### DIFF
--- a/.storybook/bundle.ts
+++ b/.storybook/bundle.ts
@@ -41,6 +41,7 @@ import CustomVariableList from '../src/components/stepforms/widgets/DateComponen
 import Calendar from '../src/components/Calendar.vue';
 import Tabs from '../src/components/Tabs.vue';
 import RangeCalendar from '../src/components/RangeCalendar.vue';
+import RelativeDateForm from '../src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue';
 
 export {
   FilterEditor,
@@ -81,6 +82,7 @@ export {
   Calendar,
   Tabs,
   RangeCalendar,
+  RelativeDateForm,
 };
 export { setupStore, registerModule, VQBnamespace } from '../src/store';
 export { resizable } from '../src/directives/resizable/resizable';

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="widget-relative-date-form" />
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+import { VariablesBucket } from '@/lib/variables';
+/**
+ * This component return a relative date composed from a number and a "period" variable
+ */
+@Component({
+  name: 'relative-date-form',
+  components: {},
+})
+export default class CustomVariableList extends Vue {
+  @Prop({ default: () => [] })
+  availableVariables!: VariablesBucket;
+}
+</script>
+
+<style scoped lang="scss">
+@import '../../../../styles/variables';
+</style>

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -1,21 +1,33 @@
 <template>
-  <div class="widget-relative-date-form" />
+  <div class="widget-relative-date-form">
+    <InputNumberWidget :min="1" />
+    <AutocompleteWidget :options="durations" />
+  </div>
 </template>
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
+import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
+import InputNumberWidget from '@/components/stepforms/widgets/InputNumber.vue';
 import { VariablesBucket } from '@/lib/variables';
 /**
- * This component return a relative date composed from a number and a "period" variable
+ * This component return a relative date composed from a number and a "duration" variable
  */
 @Component({
   name: 'relative-date-form',
-  components: {},
+  components: {
+    InputNumberWidget,
+    AutocompleteWidget,
+  },
 })
 export default class CustomVariableList extends Vue {
   @Prop({ default: () => [] })
   availableVariables!: VariablesBucket;
+
+  get durations(): string[] {
+    return this.availableVariables.map(v => v.label);
+  }
 }
 </script>
 

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -5,6 +5,8 @@
       class="widget-relative-date-form__duration"
       v-model="duration"
       :options="durations"
+      trackBy="value"
+      label="label"
     />
   </div>
 </template>
@@ -14,8 +16,7 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputNumberWidget from '@/components/stepforms/widgets/InputNumber.vue';
-import { DEFAULT_DURATIONS, RelativeDate } from '@/lib/dates';
-import { VariablesBucket } from '@/lib/variables';
+import { DEFAULT_DURATIONS, DurationOption, RelativeDate } from '@/lib/dates';
 /**
  * This component return a relative date composed from a number and a "duration" variable
  */
@@ -27,34 +28,27 @@ import { VariablesBucket } from '@/lib/variables';
   },
 })
 export default class CustomVariableList extends Vue {
-  @Prop({ default: () => DEFAULT_DURATIONS })
-  availableVariables!: VariablesBucket;
-
-  @Prop({ default: () => ({ quantity: 1, duration: DEFAULT_DURATIONS[0].label }) })
+  @Prop({ default: () => ({ quantity: 1, duration: 'year' }) })
   value!: RelativeDate;
 
   get quantity(): number {
-    return this.value.quantity ?? 1;
+    return this.value.quantity;
   }
 
   set quantity(quantity: number) {
     this.$emit('input', { ...this.value, quantity });
   }
 
-  get durations(): string[] {
-    return this.availableVariables.map(v => v.label);
+  get durations(): DurationOption[] {
+    return DEFAULT_DURATIONS;
   }
 
-  // retrieve duration label to give correct value to autocomplete
-  get duration(): string | undefined {
-    const duration = this.availableVariables.find(v => v.identifier === this.value.duration)?.label;
-    return duration ?? this.durations[0];
+  get duration(): DurationOption | undefined {
+    return this.durations.find(v => v.value === this.value.duration);
   }
 
-  // retrieve duration identifier to give correct value on emit
-  set duration(label: string | undefined) {
-    const duration = this.availableVariables.find(v => v.label === label)?.identifier;
-    this.$emit('input', { ...this.value, duration });
+  set duration(duration: DurationOption | undefined) {
+    this.$emit('input', { ...this.value, duration: duration?.value });
   }
 }
 </script>

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -60,5 +60,55 @@ export default class CustomVariableList extends Vue {
 </script>
 
 <style scoped lang="scss">
-@import '../../../../styles/variables';
+$active-color: #16406a;
+$active-color-light: #dde6f0;
+$active-color-extra-light: #f8f7fa;
+
+.widget-relative-date-form {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.widget-relative-date-form__quantity {
+  flex: 1 25%;
+  margin: 0;
+  background: $active-color-extra-light;
+
+  ::v-deep .widget-input-number__container {
+    margin: 0;
+  }
+
+  ::v-deep .widget-input-number {
+    padding: 8px 12px;
+  }
+}
+.widget-relative-date-form__duration {
+  flex: 1 75%;
+  margin: 0 0 0 15px;
+  background: $active-color-extra-light;
+
+  ::v-deep .multiselect__tags {
+    padding: 8px 12px;
+  }
+
+  ::v-deep .multiselect__option {
+    border: none;
+    margin: 5px;
+    border-radius: 2px;
+    max-height: 30px;
+    padding: 8px 15px;
+    line-height: 25px;
+    box-shadow: none;
+  }
+
+  ::v-deep .multiselect__option--highlight {
+    background: $active-color-extra-light;
+    color: $active-color;
+  }
+
+  ::v-deep .multiselect__option--selected {
+    background: $active-color-light;
+    color: $active-color;
+  }
+}
 </style>

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="widget-relative-date-form">
-    <InputNumberWidget :min="1" />
-    <AutocompleteWidget :options="durations" />
+    <InputNumberWidget class="widget-relative-date-form__quantity" v-model="quantity" :min="1" />
+    <AutocompleteWidget
+      class="widget-relative-date-form__duration"
+      v-model="duration"
+      :options="durations"
+    />
   </div>
 </template>
 
@@ -10,6 +14,7 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputNumberWidget from '@/components/stepforms/widgets/InputNumber.vue';
+import { RelativeDate } from '@/lib/dates';
 import { VariablesBucket } from '@/lib/variables';
 /**
  * This component return a relative date composed from a number and a "duration" variable
@@ -25,8 +30,31 @@ export default class CustomVariableList extends Vue {
   @Prop({ default: () => [] })
   availableVariables!: VariablesBucket;
 
+  @Prop({ default: () => ({}) })
+  value!: RelativeDate;
+
+  get quantity(): number {
+    return this.value.quantity ?? 1;
+  }
+
+  set quantity(quantity: number) {
+    this.$emit('input', { ...this.value, quantity });
+  }
+
   get durations(): string[] {
     return this.availableVariables.map(v => v.label);
+  }
+
+  // retrieve duration label to give correct value to autocomplete
+  get duration(): string | undefined {
+    const duration = this.availableVariables.find(v => v.identifier === this.value.duration)?.label;
+    return duration ?? this.durations[0];
+  }
+
+  // retrieve duration identifier to give correct value on emit
+  set duration(label: string | undefined) {
+    const duration = this.availableVariables.find(v => v.label === label)?.identifier;
+    this.$emit('input', { ...this.value, duration });
   }
 }
 </script>

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -27,7 +27,7 @@ import { DEFAULT_DURATIONS, DurationOption, RelativeDate } from '@/lib/dates';
     AutocompleteWidget,
   },
 })
-export default class CustomVariableList extends Vue {
+export default class RelativeDateForm extends Vue {
   @Prop({ default: () => ({ quantity: 1, duration: DEFAULT_DURATIONS[0].value }) })
   value!: RelativeDate;
 

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -14,7 +14,7 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputNumberWidget from '@/components/stepforms/widgets/InputNumber.vue';
-import { RelativeDate } from '@/lib/dates';
+import { DEFAULT_DURATIONS, RelativeDate } from '@/lib/dates';
 import { VariablesBucket } from '@/lib/variables';
 /**
  * This component return a relative date composed from a number and a "duration" variable
@@ -27,10 +27,10 @@ import { VariablesBucket } from '@/lib/variables';
   },
 })
 export default class CustomVariableList extends Vue {
-  @Prop({ default: () => [] })
+  @Prop({ default: () => DEFAULT_DURATIONS })
   availableVariables!: VariablesBucket;
 
-  @Prop({ default: () => ({}) })
+  @Prop({ default: () => ({ quantity: 1, duration: DEFAULT_DURATIONS[0].label }) })
   value!: RelativeDate;
 
   get quantity(): number {

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -28,32 +28,22 @@ import { DEFAULT_DURATIONS, DurationOption, RelativeDate } from '@/lib/dates';
   },
 })
 export default class RelativeDateForm extends Vue {
-  @Prop({ default: () => ({ quantity: 1, duration: DEFAULT_DURATIONS[0].value }) })
+  @Prop({
+    default: () => ({ date: undefined, quantity: -1, duration: DEFAULT_DURATIONS[0].value }),
+  })
   value!: RelativeDate;
-
-  @Prop({ default: false })
-  isNegative!: boolean; // define if the quantity should be negative
 
   get quantity(): number {
     return Math.abs(this.value.quantity);
   }
 
   set quantity(quantity: number) {
-    const abs = this.isNegative ? -1 : 1;
-    this.$emit('input', { ...this.value, quantity: quantity * abs });
+    // duration is always past time so quantity should be negative
+    this.$emit('input', { ...this.value, quantity: quantity * -1 });
   }
 
   get durations(): DurationOption[] {
-    /* When quantity is negative we add "ago" to durations labels
-     in order to specify user that relative date refers to past */
-    if (this.isNegative) {
-      return [...DEFAULT_DURATIONS].map(opt => ({
-        ...opt,
-        label: opt.label + ' ago',
-      }));
-    } else {
-      return DEFAULT_DURATIONS;
-    }
+    return DEFAULT_DURATIONS;
   }
 
   get duration(): DurationOption | undefined {

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -28,19 +28,32 @@ import { DEFAULT_DURATIONS, DurationOption, RelativeDate } from '@/lib/dates';
   },
 })
 export default class CustomVariableList extends Vue {
-  @Prop({ default: () => ({ quantity: 1, duration: 'year' }) })
+  @Prop({ default: () => ({ quantity: 1, duration: DEFAULT_DURATIONS[0].value }) })
   value!: RelativeDate;
 
+  @Prop({ default: false })
+  isNegative!: boolean; // define if the quantity should be negative
+
   get quantity(): number {
-    return this.value.quantity;
+    return Math.abs(this.value.quantity);
   }
 
   set quantity(quantity: number) {
-    this.$emit('input', { ...this.value, quantity });
+    const abs = this.isNegative ? -1 : 1;
+    this.$emit('input', { ...this.value, quantity: quantity * abs });
   }
 
   get durations(): DurationOption[] {
-    return DEFAULT_DURATIONS;
+    /* When quantity is negative we add "ago" to durations labels
+     in order to specify user that relative date refers to past */
+    if (this.isNegative) {
+      return [...DEFAULT_DURATIONS].map(opt => ({
+        ...opt,
+        label: opt.label + ' ago',
+      }));
+    } else {
+      return DEFAULT_DURATIONS;
+    }
   }
 
   get duration(): DurationOption | undefined {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -8,3 +8,8 @@ export type DatePickerHighlight = {
   };
   dates?: DateRange;
 };
+export type RelativeDate = {
+  date?: Date;
+  quantity?: number; // can be negative or positive
+  duration?: any;
+};

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -16,15 +16,15 @@ export type DurationOption = {
 };
 
 export type RelativeDate = {
-  date?: Date | string;
+  date: Date | string | undefined;
   quantity: number; // can be negative or positive
   duration: Duration;
 };
 
 export const DEFAULT_DURATIONS: DurationOption[] = [
-  { label: 'Years', value: 'year' },
-  { label: 'Quarters', value: 'quarter' },
-  { label: 'Months', value: 'month' },
-  { label: 'Weeks', value: 'week' },
-  { label: 'Days', value: 'day' },
+  { label: 'Years ago', value: 'year' },
+  { label: 'Quarters ago', value: 'quarter' },
+  { label: 'Months ago', value: 'month' },
+  { label: 'Weeks ago', value: 'week' },
+  { label: 'Days ago', value: 'day' },
 ];

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -8,23 +8,23 @@ export type DatePickerHighlight = {
   };
   dates?: DateRange;
 };
-export type RelativeDate = {
-  date?: Date;
-  quantity?: number; // can be negative or positive
-  duration?: any;
+
+export type Duration = 'year' | 'quarter' | 'month' | 'week' | 'day';
+export type DurationOption = {
+  label: string;
+  value: Duration;
 };
 
-export const DEFAULT_DURATIONS = [
-  {
-    label: 'Years ago',
-    identifier: 'year',
-  },
-  {
-    label: 'Months ago',
-    identifier: 'month',
-  },
-  {
-    label: 'Days ago',
-    identifier: 'day',
-  },
+export type RelativeDate = {
+  date?: Date | string;
+  quantity: number; // can be negative or positive
+  duration: Duration;
+};
+
+export const DEFAULT_DURATIONS: DurationOption[] = [
+  { label: 'Years', value: 'year' },
+  { label: 'Quarters', value: 'quarter' },
+  { label: 'Months', value: 'month' },
+  { label: 'Weeks', value: 'week' },
+  { label: 'Days', value: 'day' },
 ];

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -13,3 +13,18 @@ export type RelativeDate = {
   quantity?: number; // can be negative or positive
   duration?: any;
 };
+
+export const DEFAULT_DURATIONS = [
+  {
+    label: 'Years ago',
+    identifier: 'year',
+  },
+  {
+    label: 'Months ago',
+    identifier: 'month',
+  },
+  {
+    label: 'Days ago',
+    identifier: 'day',
+  },
+];

--- a/stories/dates/relative-date-form.js
+++ b/stories/dates/relative-date-form.js
@@ -1,0 +1,44 @@
+import { RelativeDateForm } from '../../dist/storybook/components';
+import { storiesOf } from '@storybook/vue';
+
+const stories = storiesOf('Dates/RelativeDateForm', module);
+
+const SAMPLE_VARIABLES = [
+  {
+    label: 'Years',
+    identifier: 'years',
+  },
+  {
+    label: 'Months',
+    identifier: 'months',
+  },
+  {
+    label: 'Days',
+    identifier: 'days',
+  },
+];
+
+stories.add('simple', () => ({
+  template: `
+    <div>
+      <RelativeDateForm :available-variables="availableVariables" />
+      <pre>{{ value }}</pre>
+    </div>
+  `,
+
+  components: {
+    RelativeDateForm,
+  },
+
+  data() {
+    return {
+      availableVariables: SAMPLE_VARIABLES,
+      value: '',
+    };
+  },
+  methods: {
+    input(value) {
+      this.value = value;
+    },
+  },
+}));

--- a/stories/dates/relative-date-form.js
+++ b/stories/dates/relative-date-form.js
@@ -17,7 +17,7 @@ stories.add('simple', () => ({
 
   data() {
     return {
-      value: { quantity: 3, duration: 'month' },
+      value: { date: new Date(), quantity: -3, duration: 'month' },
     };
   },
 }));
@@ -37,25 +37,6 @@ stories.add('empty', () => ({
   data() {
     return {
       value: undefined,
-    };
-  },
-}));
-
-stories.add('isNegative', () => ({
-  template: `
-    <div>
-      <RelativeDateForm v-model="value" :isNegative="true" />
-      <pre>{{ value }}</pre>
-    </div>
-  `,
-
-  components: {
-    RelativeDateForm,
-  },
-
-  data() {
-    return {
-      value: { quantity: -2, duration: 'quarter' },
     };
   },
 }));

--- a/stories/dates/relative-date-form.js
+++ b/stories/dates/relative-date-form.js
@@ -40,3 +40,22 @@ stories.add('empty', () => ({
     };
   },
 }));
+
+stories.add('isNegative', () => ({
+  template: `
+    <div>
+      <RelativeDateForm v-model="value" :isNegative="true" />
+      <pre>{{ value }}</pre>
+    </div>
+  `,
+
+  components: {
+    RelativeDateForm,
+  },
+
+  data() {
+    return {
+      value: { quantity: -2, duration: 'quarter' },
+    };
+  },
+}));

--- a/stories/dates/relative-date-form.js
+++ b/stories/dates/relative-date-form.js
@@ -3,25 +3,10 @@ import { storiesOf } from '@storybook/vue';
 
 const stories = storiesOf('Dates/RelativeDateForm', module);
 
-const SAMPLE_VARIABLES = [
-  {
-    label: 'Years',
-    identifier: 'years',
-  },
-  {
-    label: 'Months',
-    identifier: 'months',
-  },
-  {
-    label: 'Days',
-    identifier: 'days',
-  },
-];
-
 stories.add('simple', () => ({
   template: `
     <div>
-      <RelativeDateForm :available-variables="availableVariables" v-model="value" />
+      <RelativeDateForm v-model="value" />
       <pre>{{ value }}</pre>
     </div>
   `,
@@ -32,8 +17,7 @@ stories.add('simple', () => ({
 
   data() {
     return {
-      availableVariables: SAMPLE_VARIABLES,
-      value: { quantity: 3, duration: SAMPLE_VARIABLES[1].identifier },
+      value: { quantity: 3, duration: 'month' },
     };
   },
 }));

--- a/stories/dates/relative-date-form.js
+++ b/stories/dates/relative-date-form.js
@@ -21,7 +21,7 @@ const SAMPLE_VARIABLES = [
 stories.add('simple', () => ({
   template: `
     <div>
-      <RelativeDateForm :available-variables="availableVariables" />
+      <RelativeDateForm :available-variables="availableVariables" v-model="value" />
       <pre>{{ value }}</pre>
     </div>
   `,
@@ -33,12 +33,7 @@ stories.add('simple', () => ({
   data() {
     return {
       availableVariables: SAMPLE_VARIABLES,
-      value: '',
+      value: { quantity: 3, duration: SAMPLE_VARIABLES[1].identifier },
     };
-  },
-  methods: {
-    input(value) {
-      this.value = value;
-    },
   },
 }));

--- a/stories/dates/relative-date-form.js
+++ b/stories/dates/relative-date-form.js
@@ -37,3 +37,22 @@ stories.add('simple', () => ({
     };
   },
 }));
+
+stories.add('empty', () => ({
+  template: `
+    <div>
+      <RelativeDateForm v-model="value" />
+      <pre>{{ value }}</pre>
+    </div>
+  `,
+
+  components: {
+    RelativeDateForm,
+  },
+
+  data() {
+    return {
+      value: undefined,
+    };
+  },
+}));

--- a/tests/unit/relative-date-form-widget.spec.ts
+++ b/tests/unit/relative-date-form-widget.spec.ts
@@ -36,7 +36,20 @@ describe('Relative date form', () => {
       });
     });
     it('should instantiate', () => {
-      expect(wrapper.exists()).toBeTruthy();
+      expect(wrapper.exists()).toBe(true);
+    });
+    it('should use a number input', () => {
+      expect(wrapper.find('InputNumberWidget-stub').exists()).toBe(true);
+    });
+    it('should use an autcomplete input', () => {
+      expect(wrapper.find('AutocompleteWidget-stub').exists()).toBe(true);
+    });
+    it('should pass durations options labels to autcomplete', () => {
+      expect(wrapper.find('AutocompleteWidget-stub').props().options).toStrictEqual([
+        'Today',
+        'Last month',
+        'This year',
+      ]);
     });
   });
 

--- a/tests/unit/relative-date-form-widget.spec.ts
+++ b/tests/unit/relative-date-form-widget.spec.ts
@@ -26,13 +26,15 @@ describe('Relative date form', () => {
   };
 
   afterEach(() => {
-    wrapper.destroy();
+    if (wrapper) wrapper.destroy();
   });
 
   describe('default', () => {
+    const value = { quantity: 20, duration: 'today' };
     beforeEach(() => {
       createWrapper({
         availableVariables: VARIABLES,
+        value,
       });
     });
     it('should instantiate', () => {
@@ -41,7 +43,7 @@ describe('Relative date form', () => {
     it('should use a number input', () => {
       expect(wrapper.find('InputNumberWidget-stub').exists()).toBe(true);
     });
-    it('should use an autcomplete input', () => {
+    it('should use an autocomplete input', () => {
       expect(wrapper.find('AutocompleteWidget-stub').exists()).toBe(true);
     });
     it('should pass durations options labels to autcomplete', () => {
@@ -51,6 +53,38 @@ describe('Relative date form', () => {
         'This year',
       ]);
     });
+    it('should pass quantity to input number', () => {
+      expect(wrapper.find('InputNumberWidget-stub').props().value).toBe(20);
+    });
+    it('should pass duration label to autocomplete', () => {
+      expect(wrapper.find('AutocompleteWidget-stub').props().value).toBe('Today');
+    });
+
+    describe('when quantity is updated', () => {
+      beforeEach(async () => {
+        wrapper.find('InputNumberWidget-stub').vm.$emit('input', 3);
+        await wrapper.vm.$nextTick();
+      });
+      it('should emit value with updated quantity', () => {
+        expect(wrapper.emitted().input[0][0]).toStrictEqual({
+          ...value,
+          quantity: 3,
+        });
+      });
+    });
+
+    describe('when duration is updated', () => {
+      beforeEach(async () => {
+        wrapper.find('AutocompleteWidget-stub').vm.$emit('input', 'Last month');
+        await wrapper.vm.$nextTick();
+      });
+      it('should emit value with updated duration', () => {
+        expect(wrapper.emitted().input[0][0]).toStrictEqual({
+          ...value,
+          duration: 'last_month',
+        });
+      });
+    });
   });
 
   describe('empty', () => {
@@ -59,6 +93,15 @@ describe('Relative date form', () => {
     });
     it('should set availableVariables to empty array', () => {
       expect((wrapper.vm as any).availableVariables).toStrictEqual([]);
+    });
+    it('should set value to empty object', () => {
+      expect((wrapper.vm as any).value).toStrictEqual({});
+    });
+    it('should set quantity to 1', () => {
+      expect(wrapper.find('InputNumberWidget-stub').props().value).toBe(1);
+    });
+    it('should set duration to undefined', () => {
+      expect(wrapper.find('AutocompleteWidget-stub').props().value).toBe('');
     });
   });
 });

--- a/tests/unit/relative-date-form-widget.spec.ts
+++ b/tests/unit/relative-date-form-widget.spec.ts
@@ -33,7 +33,7 @@ describe('Relative date form', () => {
     it('should use an autocomplete input', () => {
       expect(wrapper.find('AutocompleteWidget-stub').exists()).toBe(true);
     });
-    it('should pass durations options to autcomplete', () => {
+    it('should pass durations options to autocomplete', () => {
       expect(wrapper.find('AutocompleteWidget-stub').props().options).toStrictEqual(
         DEFAULT_DURATIONS,
       );
@@ -41,7 +41,7 @@ describe('Relative date form', () => {
     it('should pass quantity to input number', () => {
       expect(wrapper.find('InputNumberWidget-stub').props().value).toBe(20);
     });
-    it('should pass duration label to autocomplete', () => {
+    it('should pass duration to autocomplete', () => {
       expect(wrapper.find('AutocompleteWidget-stub').props().value).toBe(selectedDuration);
     });
 
@@ -68,6 +68,43 @@ describe('Relative date form', () => {
         expect(wrapper.emitted().input[0][0]).toStrictEqual({
           ...value,
           duration: selectedDuration.value,
+        });
+      });
+    });
+  });
+
+  describe('isNegative', () => {
+    const selectedDuration = DEFAULT_DURATIONS[1];
+    const value = { quantity: -20, duration: selectedDuration.value };
+    beforeEach(() => {
+      createWrapper({
+        value,
+        isNegative: true,
+      });
+    });
+    it('should pass negative durations options to autocomplete', () => {
+      const option = wrapper.find('AutocompleteWidget-stub').props().options[0];
+      const defaultOption = DEFAULT_DURATIONS[0];
+      expect(option.label).toStrictEqual(`${defaultOption.label} ago`);
+      expect(option.value).toStrictEqual(defaultOption.value);
+    });
+    it('should pass abs quantity to input number', () => {
+      expect(wrapper.find('InputNumberWidget-stub').props().value).toBe(20);
+    });
+    it('should pass negative duration to autocomplete', () => {
+      const duration = wrapper.find('AutocompleteWidget-stub').props().value;
+      expect(duration.label).toStrictEqual(`${selectedDuration.label} ago`);
+      expect(duration.value).toStrictEqual(selectedDuration.value);
+    });
+    describe('when quantity is updated', () => {
+      beforeEach(async () => {
+        wrapper.find('InputNumberWidget-stub').vm.$emit('input', 3);
+        await wrapper.vm.$nextTick();
+      });
+      it('should emit value with updated negative quantity', () => {
+        expect(wrapper.emitted().input[0][0]).toStrictEqual({
+          ...value,
+          quantity: -3,
         });
       });
     });

--- a/tests/unit/relative-date-form-widget.spec.ts
+++ b/tests/unit/relative-date-form-widget.spec.ts
@@ -1,6 +1,7 @@
 import { shallowMount, Wrapper } from '@vue/test-utils';
 
 import RelativeDateForm from '@/components/stepforms/widgets/DateComponents/RelativeDateForm.vue';
+import { DEFAULT_DURATIONS } from '@/lib/dates';
 
 describe('Relative date form', () => {
   let wrapper: Wrapper<RelativeDateForm>;
@@ -91,17 +92,22 @@ describe('Relative date form', () => {
     beforeEach(() => {
       createWrapper();
     });
-    it('should set availableVariables to empty array', () => {
-      expect((wrapper.vm as any).availableVariables).toStrictEqual([]);
+    it('should set availableVariables to default durations', () => {
+      expect((wrapper.vm as any).availableVariables).toStrictEqual(DEFAULT_DURATIONS);
     });
     it('should set value to empty object', () => {
-      expect((wrapper.vm as any).value).toStrictEqual({});
+      expect((wrapper.vm as any).value).toStrictEqual({
+        quantity: 1,
+        duration: DEFAULT_DURATIONS[0].label,
+      });
     });
     it('should set quantity to 1', () => {
       expect(wrapper.find('InputNumberWidget-stub').props().value).toBe(1);
     });
-    it('should set duration to undefined', () => {
-      expect(wrapper.find('AutocompleteWidget-stub').props().value).toBe('');
+    it('should set duration to first default duration', () => {
+      expect(wrapper.find('AutocompleteWidget-stub').props().value).toBe(
+        DEFAULT_DURATIONS[0].label,
+      );
     });
   });
 });

--- a/tests/unit/relative-date-form-widget.spec.ts
+++ b/tests/unit/relative-date-form-widget.spec.ts
@@ -5,20 +5,6 @@ import { DEFAULT_DURATIONS } from '@/lib/dates';
 
 describe('Relative date form', () => {
   let wrapper: Wrapper<RelativeDateForm>;
-  const VARIABLES = [
-    {
-      label: 'Today',
-      identifier: 'today',
-    },
-    {
-      label: 'Last month',
-      identifier: 'last_month',
-    },
-    {
-      label: 'This year',
-      identifier: 'this_year',
-    },
-  ];
   const createWrapper = (propsData: any = {}) => {
     wrapper = shallowMount(RelativeDateForm, {
       sync: false,
@@ -31,10 +17,10 @@ describe('Relative date form', () => {
   });
 
   describe('default', () => {
-    const value = { quantity: 20, duration: 'today' };
+    const selectedDuration = DEFAULT_DURATIONS[1];
+    const value = { quantity: 20, duration: selectedDuration.value };
     beforeEach(() => {
       createWrapper({
-        availableVariables: VARIABLES,
         value,
       });
     });
@@ -47,18 +33,16 @@ describe('Relative date form', () => {
     it('should use an autocomplete input', () => {
       expect(wrapper.find('AutocompleteWidget-stub').exists()).toBe(true);
     });
-    it('should pass durations options labels to autcomplete', () => {
-      expect(wrapper.find('AutocompleteWidget-stub').props().options).toStrictEqual([
-        'Today',
-        'Last month',
-        'This year',
-      ]);
+    it('should pass durations options to autcomplete', () => {
+      expect(wrapper.find('AutocompleteWidget-stub').props().options).toStrictEqual(
+        DEFAULT_DURATIONS,
+      );
     });
     it('should pass quantity to input number', () => {
       expect(wrapper.find('InputNumberWidget-stub').props().value).toBe(20);
     });
     it('should pass duration label to autocomplete', () => {
-      expect(wrapper.find('AutocompleteWidget-stub').props().value).toBe('Today');
+      expect(wrapper.find('AutocompleteWidget-stub').props().value).toBe(selectedDuration);
     });
 
     describe('when quantity is updated', () => {
@@ -75,39 +59,36 @@ describe('Relative date form', () => {
     });
 
     describe('when duration is updated', () => {
+      const selectedDuration = DEFAULT_DURATIONS[2];
       beforeEach(async () => {
-        wrapper.find('AutocompleteWidget-stub').vm.$emit('input', 'Last month');
+        wrapper.find('AutocompleteWidget-stub').vm.$emit('input', selectedDuration);
         await wrapper.vm.$nextTick();
       });
       it('should emit value with updated duration', () => {
         expect(wrapper.emitted().input[0][0]).toStrictEqual({
           ...value,
-          duration: 'last_month',
+          duration: selectedDuration.value,
         });
       });
     });
   });
 
   describe('empty', () => {
+    const defaultDuration = DEFAULT_DURATIONS[0];
     beforeEach(() => {
       createWrapper();
-    });
-    it('should set availableVariables to default durations', () => {
-      expect((wrapper.vm as any).availableVariables).toStrictEqual(DEFAULT_DURATIONS);
     });
     it('should set value to empty object', () => {
       expect((wrapper.vm as any).value).toStrictEqual({
         quantity: 1,
-        duration: DEFAULT_DURATIONS[0].label,
+        duration: defaultDuration.value,
       });
     });
     it('should set quantity to 1', () => {
       expect(wrapper.find('InputNumberWidget-stub').props().value).toBe(1);
     });
     it('should set duration to first default duration', () => {
-      expect(wrapper.find('AutocompleteWidget-stub').props().value).toBe(
-        DEFAULT_DURATIONS[0].label,
-      );
+      expect(wrapper.find('AutocompleteWidget-stub').props().value).toBe(defaultDuration);
     });
   });
 });

--- a/tests/unit/relative-date-form-widget.spec.ts
+++ b/tests/unit/relative-date-form-widget.spec.ts
@@ -1,0 +1,51 @@
+import { shallowMount, Wrapper } from '@vue/test-utils';
+
+import RelativeDateForm from '@/components/stepforms/widgets/DateComponents/RelativeDateForm.vue';
+
+describe('Relative date form', () => {
+  let wrapper: Wrapper<RelativeDateForm>;
+  const VARIABLES = [
+    {
+      label: 'Today',
+      identifier: 'today',
+    },
+    {
+      label: 'Last month',
+      identifier: 'last_month',
+    },
+    {
+      label: 'This year',
+      identifier: 'this_year',
+    },
+  ];
+  const createWrapper = (propsData: any = {}) => {
+    wrapper = shallowMount(RelativeDateForm, {
+      sync: false,
+      propsData,
+    });
+  };
+
+  afterEach(() => {
+    wrapper.destroy();
+  });
+
+  describe('default', () => {
+    beforeEach(() => {
+      createWrapper({
+        availableVariables: VARIABLES,
+      });
+    });
+    it('should instantiate', () => {
+      expect(wrapper.exists()).toBeTruthy();
+    });
+  });
+
+  describe('empty', () => {
+    beforeEach(() => {
+      createWrapper();
+    });
+    it('should set availableVariables to empty array', () => {
+      expect((wrapper.vm as any).availableVariables).toStrictEqual([]);
+    });
+  });
+});

--- a/tests/unit/relative-date-form-widget.spec.ts
+++ b/tests/unit/relative-date-form-widget.spec.ts
@@ -18,7 +18,7 @@ describe('Relative date form', () => {
 
   describe('default', () => {
     const selectedDuration = DEFAULT_DURATIONS[1];
-    const value = { quantity: 20, duration: selectedDuration.value };
+    const value = { date: new Date(), quantity: -20, duration: selectedDuration.value };
     beforeEach(() => {
       createWrapper({
         value,
@@ -38,7 +38,7 @@ describe('Relative date form', () => {
         DEFAULT_DURATIONS,
       );
     });
-    it('should pass quantity to input number', () => {
+    it('should pass abs quantity to input number', () => {
       expect(wrapper.find('InputNumberWidget-stub').props().value).toBe(20);
     });
     it('should pass duration to autocomplete', () => {
@@ -50,10 +50,10 @@ describe('Relative date form', () => {
         wrapper.find('InputNumberWidget-stub').vm.$emit('input', 3);
         await wrapper.vm.$nextTick();
       });
-      it('should emit value with updated quantity', () => {
+      it('should emit value with updated negative quantity', () => {
         expect(wrapper.emitted().input[0][0]).toStrictEqual({
           ...value,
-          quantity: 3,
+          quantity: -3,
         });
       });
     });
@@ -73,43 +73,6 @@ describe('Relative date form', () => {
     });
   });
 
-  describe('isNegative', () => {
-    const selectedDuration = DEFAULT_DURATIONS[1];
-    const value = { quantity: -20, duration: selectedDuration.value };
-    beforeEach(() => {
-      createWrapper({
-        value,
-        isNegative: true,
-      });
-    });
-    it('should pass negative durations options to autocomplete', () => {
-      const option = wrapper.find('AutocompleteWidget-stub').props().options[0];
-      const defaultOption = DEFAULT_DURATIONS[0];
-      expect(option.label).toStrictEqual(`${defaultOption.label} ago`);
-      expect(option.value).toStrictEqual(defaultOption.value);
-    });
-    it('should pass abs quantity to input number', () => {
-      expect(wrapper.find('InputNumberWidget-stub').props().value).toBe(20);
-    });
-    it('should pass negative duration to autocomplete', () => {
-      const duration = wrapper.find('AutocompleteWidget-stub').props().value;
-      expect(duration.label).toStrictEqual(`${selectedDuration.label} ago`);
-      expect(duration.value).toStrictEqual(selectedDuration.value);
-    });
-    describe('when quantity is updated', () => {
-      beforeEach(async () => {
-        wrapper.find('InputNumberWidget-stub').vm.$emit('input', 3);
-        await wrapper.vm.$nextTick();
-      });
-      it('should emit value with updated negative quantity', () => {
-        expect(wrapper.emitted().input[0][0]).toStrictEqual({
-          ...value,
-          quantity: -3,
-        });
-      });
-    });
-  });
-
   describe('empty', () => {
     const defaultDuration = DEFAULT_DURATIONS[0];
     beforeEach(() => {
@@ -117,7 +80,8 @@ describe('Relative date form', () => {
     });
     it('should set value to empty object', () => {
       expect((wrapper.vm as any).value).toStrictEqual({
-        quantity: 1,
+        date: undefined,
+        quantity: -1,
         duration: defaultDuration.value,
       });
     });


### PR DESCRIPTION
Add a new component to create a relative date from a quantity and a duration.

Design:
![créa](https://user-images.githubusercontent.com/59559689/129700743-662215e5-5023-41cc-83de-34d44607e495.png)

Usage:
![explain](https://user-images.githubusercontent.com/59559689/129745896-b532a7d6-d5d9-43a3-833e-a816fb98d84c.gif)
