### PR TITLE
feat(mongo): division by zero and null in formulas

### DIFF
--- a/server/tests/steps/test_formula.py
+++ b/server/tests/steps/test_formula.py
@@ -16,6 +16,7 @@ def sample_df() -> DataFrame:
             'col B': [2, 20],
             'col C': [3, 30],
             '[col D]': [4, 40],
+            'colE': [0, np.nan],
         }
     )
 
@@ -39,9 +40,9 @@ def test_bad_formula(sample_df: DataFrame, bad_expression):
         execute_formula(bad_step, sample_df)
 
 
-def test_formula_infinity(sample_df: DataFrame):
-    step = FormulaStep(name='formula', new_column='z', formula='`col B` / (colA - 1)')
+def test_formula_division_by_zero_o_null(sample_df: DataFrame):
+    step = FormulaStep(name='formula', new_column='z', formula='colA / colE')
     df_result = execute_formula(step, sample_df)
 
-    expected_result = sample_df.assign(z=[np.nan, 20.0 / 9])
+    expected_result = sample_df.assign(z=[np.nan, np.nan])
     assert_dataframes_equals(df_result, expected_result)

--- a/server/weaverbird/backends/pandas_executor/pipeline_executor.py
+++ b/server/weaverbird/backends/pandas_executor/pipeline_executor.py
@@ -80,7 +80,7 @@ def preview_pipeline(
 
 
 class PipelineExecutionFailure(Exception):
-    """ Raised when a error happens during the execution of the pipeline """
+    """Raised when a error happens during the execution of the pipeline"""
 
     def __init__(self, step: PipelineStep, index: int, original_exception: Exception):
         self.step = step


### PR DESCRIPTION
Hi Toucan,

As a conceptor, I need to divide 2 columns but it may crash during data refresh because of division by zero or null.
So here is my PR to allow division by zero or null.

Notes :
- In Pandas, the code was working but I reshaped the unit test

Have a nice day,

Charles