### PR TITLE
ci: use only snowflake password from en variables

### DIFF
--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -53,11 +53,5 @@ jobs:
 
     - name: Test
       env:
-        SNOWFLAKE_USER: '${{ secrets.SNOWFLAKE_USER }}'
         SNOWFLAKE_PASSWORD: '${{ secrets.SNOWFLAKE_PASSWORD }}'
-        SNOWFLAKE_ACCOUNT: '${{ secrets.SNOWFLAKE_ACCOUNT }}'
-        SNOWFLAKE_ROLE: '${{ secrets.SNOWFLAKE_ROLE }}'
-        SNOWFLAKE_DATABASE: '${{ secrets.SNOWFLAKE_DATABASE }}'
-        SNOWFLAKE_WAREHOUSE: '${{ secrets.SNOWFLAKE_WAREHOUSE }}'
-        SNOWFLAKE_SCHEMA: '${{ secrets.SNOWFLAKE_SCHEMA }}'
       run: poetry run make test

--- a/server/README.md
+++ b/server/README.md
@@ -17,6 +17,8 @@ Main commands are available through `make`:
     make upload # Publish on pypi
 
     make test # Execute the test suite and produce reports
+    /!\ To run Snowflake's e2e tests, the password needs to be exported to env variables
+    as such: export SNOWFLAKE_PASSWORD='XXXXXXXXXXX'. This password is available in lastpass (user: toucan_test)
 
 ### Playground server
 

--- a/server/tests/backends/sql_translator/test_snowflake_translator_steps.py
+++ b/server/tests/backends/sql_translator/test_snowflake_translator_steps.py
@@ -33,17 +33,24 @@ type_code_mapping = {
     13: 'boolean',
 }
 
+ACCOUNT = 'toucantocopartner.west-europe.azure'
+USER = 'toucan_test'
+WAREHOUSE = 'toucan_test'
+DATABASE = 'toucan_test'
+ROLE = 'toucan_test'
+SCHEMA = 'toucan_test'
+
 
 # Update this method to use snowflake connection
 def get_connection():
     con_params = {
-        'account': environ.get('SNOWFLAKE_ACCOUNT'),
-        'user': environ.get('SNOWFLAKE_USER'),
+        'account': ACCOUNT,
+        'user': USER,
         'password': environ.get('SNOWFLAKE_PASSWORD'),
-        'warehouse': environ.get('SNOWFLAKE_WAREHOUSE'),
-        'database': environ.get('SNOWFLAKE_DATABASE'),
-        'role': environ.get('SNOWFLAKE_ROLE'),
-        'schema': environ.get('SNOWFLAKE_SCHEMA'),
+        'warehouse': WAREHOUSE,
+        'database': DATABASE,
+        'role': ROLE,
+        'schema': SCHEMA,
         'authenticator': 'snowflake',
     }
     return snowflake.connector.connect(**con_params)
@@ -52,13 +59,13 @@ def get_connection():
 @pytest.fixture
 def get_engine():
     url = URL(
-        account=environ.get('SNOWFLAKE_ACCOUNT'),
-        user=environ.get('SNOWFLAKE_USER'),
+        account=ACCOUNT,
+        user=USER,
         password=environ.get('SNOWFLAKE_PASSWORD'),
-        warehouse=environ.get('SNOWFLAKE_WAREHOUSE'),
-        database=environ.get('SNOWFLAKE_DATABASE'),
-        role=environ.get('SNOWFLAKE_ROLE'),
-        schema=environ.get('SNOWFLAKE_SCHEMA'),
+        warehouse=WAREHOUSE,
+        database=DATABASE,
+        role=ROLE,
+        schema=SCHEMA,
         authenticator='snowflake',
     )
     engine = create_engine(url)


### PR DESCRIPTION
* Use only password from Github actions secrets in Snowflake's e2e tests. 
* Add doc about it. in Readme.md