### PR TITLE
fix: fix white space in agg column names

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weaverbird"
-version = "0.6.6"
+version = "0.6.7"
 description = "Pandas engine for weaverbird data pipelines"
 authors = ["Toucan Toco <dev+weaverbird@toucantoco.com>"]
 license = "MIT"

--- a/server/tests/steps/sql_translator/test_aggregate.py
+++ b/server/tests/steps/sql_translator/test_aggregate.py
@@ -252,6 +252,25 @@ def test_count_distinct(query, sql_query_describer):
     )
 
 
+def test_count_distinct_whitespace_replace(query, sql_query_describer):
+    step = AggregateStep(
+        name='aggregate',
+        on=[],
+        aggregations=[
+            Aggregation(
+                aggfunction='count distinct',
+                columns=['Group'],
+                newcolumns=['Group CD'],
+            )
+        ],
+    )
+    sql_query = translate_aggregate(step, query, index=1, sql_query_describer=sql_query_describer)
+    assert (
+        sql_query.transformed_query
+        == 'WITH SELECT_STEP_0 AS (SELECT * FROM products), AGGREGATE_STEP_1 AS (SELECT COUNT(DISTINCT Group) AS Group_CD FROM SELECT_STEP_0)'
+    )
+
+
 def test_duplicate_aggregation_columns(query, sql_query_describer):
 
     with pytest.raises(DuplicateColumnError):

--- a/server/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
+++ b/server/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
@@ -149,7 +149,7 @@ def build_first_or_last_aggregation(aggregated_string, first_last_string, query,
 
 def prepare_aggregation_query(aggregated_cols, aggregated_string, query, step):
     for agg in step.aggregations:  # TODO the front should restrict - usage in column names
-        agg.new_columns = [x.replace('-', '_') for x in agg.new_columns]
+        agg.new_columns = [x.replace('-', '_').replace(' ', '_') for x in agg.new_columns]
     for aggregation in [
         aggregation
         for aggregation in step.aggregations


### PR DESCRIPTION
Fix this issue: 
```(AggregateStep(name='aggregate', on=['LOCATION', 'SEX_NUMERIC'], aggregations=[Aggregation(new_columns=['SEX_NUMERIC_count distinct'], agg_function='count distinct', columns=['SEX_NUMERIC'])], keep_original_granularity=False), 9, 001003 (42000): 019e6383-0200-aa6b-0000-2f19006dd256: SQL compilation error: syntax error line 1 at position 1,048 unexpected 'distinct'. syntax error line 1 at position 1,066 unexpected ','. syntax error line 1 at position 1,080 unexpected 'FROM'. syntax error line 1 at position 1,131 unexpected ')'.)```

-> Aggregated columns were renamed based on the agg function name. 
count distinct has a whitespace hence, it generated invalid queries like: 
```AGGREGATE_STEP_2 AS (SELECT COUNT(DISTINCT SEX_NUMERIC) AS SEX_NUMERIC_count distinct, LOCATION, SEX_NUMERIC FROM IFTHENELSE_STEP_1 GROUP BY LOCATION, SEX_NUMERIC) SELECT * FROM AGGREGATE_STEP_2``` 

Fix this by replacing ' ' by '_' in aggregated column names.

