### PR TITLE
RollupStep : Make the aggregation optional (usefull for requesters)

### DIFF
--- a/src/components/stepforms/RollupStepForm.vue
+++ b/src/components/stepforms/RollupStepForm.vue
@@ -19,7 +19,7 @@
     <ListWidget
       class="aggregationsInput"
       addFieldName="Add aggregation"
-      name="Columns to aggregate:"
+      name="(Optional) Columns to aggregate:"
       v-model="aggregations"
       :defaultItem="defaultAggregation"
       :widget="widgetAggregation"

--- a/src/components/stepforms/schemas/rollup.ts
+++ b/src/components/stepforms/schemas/rollup.ts
@@ -21,7 +21,46 @@ export default {
         placeholder: 'Add columns',
       },
     },
-    aggregations,
+    aggregations: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          columns: {
+            type: 'array',
+            minItems: 1,
+            items: {
+              type: 'string',
+              minLength: 1,
+            },
+          },
+          column: {
+            // deprecated
+            type: 'string',
+            minLength: 1,
+          },
+          aggfunction: {
+            type: 'string',
+            enum: ['sum', 'avg', 'count', 'count distinct', 'min', 'max', 'first', 'last'],
+          },
+          newcolumns: {
+            type: 'array',
+            minItems: 1,
+            items: {
+              type: 'string',
+              minLength: 1,
+            },
+          },
+          newcolumn: {
+            // deprecated
+            type: 'string',
+            minLength: 1,
+          },
+        },
+      },
+      title: 'Aggregations',
+      description: 'The aggregations to be performed',
+    },
     groupby: {
       type: 'array',
       items: {
@@ -62,6 +101,6 @@ export default {
       },
     },
   },
-  required: ['name', 'hierarchy', 'aggregations'],
+  required: ['name', 'hierarchy'],
   additionalProperties: false,
 };

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -345,7 +345,7 @@ export type RollupStep = {
   /** the list of hierarchical columns from lowest to highest level */
   hierarchy: string[];
   /** the list of columnns to aggregate, with related aggregation function to use */
-  aggregations: Aggregation[];
+  aggregations?: Aggregation[];
   /** Groupby columns if rollup has to be performed by groups */
   groupby?: string[];
   /** To give a custom name to the output label column */

--- a/tests/unit/rollup-step-form.spec.ts
+++ b/tests/unit/rollup-step-form.spec.ts
@@ -117,21 +117,22 @@ describe('Rollup Step Form', () => {
         errors: [{ keyword: 'minLength', dataPath: '.groupby[0]' }],
       },
       {
-        testlabel: '"columns" and "newcolumns" parameters include empty strings',
+        testlabel: '"columns", "newcolumns" and "aggfunction" parameters include empty strings',
         props: {
           initialStepValue: {
             name: 'rollup',
             hierarchy: ['column1'],
             aggregations: [
               {
-                newcolumns: [''],
-                aggfunction: 'sum',
+                aggfunction: '',
                 columns: [''],
+                newcolumns: ['']
               },
             ],
           },
         },
         errors: [
+          { keyword: 'enum', dataPath: '.aggregations[0].aggfunction' },
           { keyword: 'minLength', dataPath: '.aggregations[0].columns[0]' },
           { keyword: 'minLength', dataPath: '.aggregations[0].newcolumns[0]' },
         ],
@@ -223,7 +224,21 @@ describe('Rollup Step Form', () => {
       },
     });
 
-    it('should call teh setAggregationsNewColumnsInStep function with editedStep as input', () => {
+    runner.testValidate({
+      testlabel: 'submitted data is valid without aggregation',
+      props: {
+        initialStepValue: {
+          name: 'rollup',
+          hierarchy: ['foo'],
+          aggregations: [],
+          labelCol: 'label',
+          levelCol: 'label',
+          parentLabelCol: 'label',
+        },
+      },
+    });
+
+    it('should call the setAggregationsNewColumnsInStep function with editedStep as input', () => {
       const editedStep = {
         name: 'rollup',
         hierarchy: ['foo'],


### PR DESCRIPTION
Hi Toucan,

As a conceptor, I use the rollup step to generate the requesters.
The aggregation is required, that is confusing...

So here is my PR to avoid putting a dummy column in the aggregation form ;)

Have a nice day,

Charles