### PR TITLE
chore: register snowflake translator & available steps

### DIFF
--- a/src/lib/translators/index.ts
+++ b/src/lib/translators/index.ts
@@ -15,6 +15,7 @@ import { Mongo40Translator } from './mongo4';
 import { Mongo42Translator } from './mongo42';
 import { PandasTranslator } from './pandas';
 import { PandasNoJoinsTranslator } from './pandas-no_joins';
+import { SnowflakeTranslator } from './snowflake';
 
 const TRANSLATORS: { [backend: string]: typeof BaseTranslator } = {};
 
@@ -68,6 +69,7 @@ registerTranslator('mongo42', Mongo42Translator);
 registerTranslator('pandas', PandasTranslator);
 registerTranslator('pandas-no_joins', PandasNoJoinsTranslator);
 registerTranslator('empty', EmptyTranslator);
+registerTranslator('snowflake', SnowflakeTranslator);
 
 /**
  * Initialize variable delimiters for all translators

--- a/src/lib/translators/snowflake.ts
+++ b/src/lib/translators/snowflake.ts
@@ -1,0 +1,88 @@
+/**
+ * This translator is not really one: it won't translate the pipeline steps into pandas' code.
+ * The pandas engine to execute pipeline exists as a python package in the `server/` folder.
+ *
+ * This module's sole mission is to declare which steps are supported by the pandas engine, and leave the pipeline
+ * steps unchanged.
+ * */
+
+import * as S from '@/lib/steps';
+
+import { BaseTranslator } from './base';
+
+/* istanbul ignore next */
+export class SnowflakeTranslator extends BaseTranslator {
+  static label = 'Pandas';
+
+  aggregate(step: Readonly<S.AggregateStep>) {
+    return step;
+  }
+
+  append(step: Readonly<S.AppendStep>) {
+    return step;
+  }
+
+  convert(step: Readonly<S.ConvertStep>) {
+    return step;
+  }
+
+  domain(step: Readonly<S.DomainStep>) {
+    return step;
+  }
+
+  filter(step: Readonly<S.FilterStep>) {
+    return step;
+  }
+
+  formula(step: Readonly<S.FormulaStep>) {
+    return step;
+  }
+
+  fromdate(step: Readonly<S.FromDateStep>) {
+    return step;
+  }
+
+  ifthenelse(step: Readonly<S.IfThenElseStep>) {
+    return step;
+  }
+
+  join(step: Readonly<S.JoinStep>) {
+    return step;
+  }
+
+  lowercase(step: Readonly<S.ToLowerStep>) {
+    return step;
+  }
+
+  rename(step: Readonly<S.RenameStep>) {
+    return step;
+  }
+
+  replace(step: Readonly<S.ReplaceStep>) {
+    return step;
+  }
+
+  select(step: Readonly<S.SelectStep>) {
+    return step;
+  }
+
+  sort(step: Readonly<S.SortStep>) {
+    return step;
+  }
+
+  text(step: Readonly<S.AddTextColumnStep>) {
+    return step;
+  }
+
+  todate(step: Readonly<S.ToDateStep>) {
+    return step;
+  }
+
+  top(step: Readonly<S.TopStep>) {
+    return step;
+  }
+
+  uppercase(step: Readonly<S.ToUpperStep>) {
+    return step;
+  }
+}

--- a/src/lib/translators/snowflake.ts
+++ b/src/lib/translators/snowflake.ts
@@ -1,8 +1,7 @@
 /**
- * This translator is not really one: it won't translate the pipeline steps into pandas' code.
- * The pandas engine to execute pipeline exists as a python package in the `server/` folder.
- *
- * This module's sole mission is to declare which steps are supported by the pandas engine, and leave the pipeline
+ * This translator is allow an app maker to visually perfom data preparation and converts the result to a Snowflake
+ * valid SQL Query. *
+ * This module's sole mission is to declare which steps are supported by the Snowflake translator, and leave the pipeline
  * steps unchanged.
  * */
 

--- a/tests/unit/translator.spec.ts
+++ b/tests/unit/translator.spec.ts
@@ -80,6 +80,7 @@ describe('translator registration', () => {
       'mongo42',
       'pandas',
       'pandas-no_joins',
+      'snowflake',
     ]);
     expect(backendsSupporting('domain')).toEqual([
       'dummy',
@@ -89,9 +90,22 @@ describe('translator registration', () => {
       'mongo42',
       'pandas',
       'pandas-no_joins',
+      'snowflake',
     ]);
-    expect(backendsSupporting('append')).toEqual(['mongo36', 'mongo40', 'mongo42', 'pandas']);
-    expect(backendsSupporting('join')).toEqual(['mongo36', 'mongo40', 'mongo42', 'pandas']);
+    expect(backendsSupporting('append')).toEqual([
+      'mongo36',
+      'mongo40',
+      'mongo42',
+      'pandas',
+      'snowflake',
+    ]);
+    expect(backendsSupporting('join')).toEqual([
+      'mongo36',
+      'mongo40',
+      'mongo42',
+      'pandas',
+      'snowflake',
+    ]);
   });
 
   it('should throw an error if backend is not available', () => {
@@ -109,6 +123,7 @@ describe('translator registration', () => {
       'mongo42',
       'pandas',
       'pandas-no_joins',
+      'snowflake',
     ]);
   });
 });


### PR DESCRIPTION
As of now, we we were using the pandas-no joins frontend translator for SQL VQB. 
With this PR it's over! 