### PR TITLE
v0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
-### - 2021-08-26
+
+### [0.57.0] - 2021-08-26
+
+### Added
 
 - Mongo translator: `notnull` and `isnull` condition operator now always compare to literal null.
+- Vqb: Added UnuiqueGroup Step to snowflake
 
 ## [0.56.0] - 2021-08-24
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
     "url": "https://github.com/ToucanToco/weaverbird/issues",


### PR DESCRIPTION
# What
- Mongo translator: `notnull` and `isnull` condition operator now always compare to literal null.
- Vqb: Added UnuiqueGroup Step to snowflake

From 0.56.0 to 0.57.0