### PR TITLE
install via make target installs weaverbird

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN yarn
 WORKDIR /weaverbird/server
 # Install back-end package dependencies
 COPY server/pyproject.toml ./
-RUN poetry install
+COPY server /weaverbird/server
+RUN make install
 
 WORKDIR /weaverbird
 # Build front-end package


### PR DESCRIPTION
Fixes https://github.com/ToucanToco/weaverbird/issues/1035

Tested:

```
docker build -t peanutbutter:latest .
docker run --rm --name peanutbutter -p 3000:3000 peanutbutter
```


```
yarn run v1.22.5
$ /weaverbird/node_modules/.bin/concurrently 'yarn start' 'cd server; FLASK_APP=playground FLASK_RUN_HOST=0.0.0.0 FLASK_RUN_PORT=5000 poetry run flask run'
[0] $ node playground/server.js
[0] [HPM] Proxy created: /pandas-backend  -> http://localhost:5000
[0] [HPM] Proxy rewrite rule created: "^/pandas-backend" ~> ""
[0] (node:52) Warning: Accessing non-existent property 'count' of module exports inside circular dependency
[0] (Use `node --trace-warnings ...` to show where the warning was created)
[0] (node:52) Warning: Accessing non-existent property 'findOne' of module exports inside circular dependency
[0] (node:52) Warning: Accessing non-existent property 'remove' of module exports inside circular dependency
[0] (node:52) Warning: Accessing non-existent property 'updateOne' of module exports inside circular dependency
[0] VQB playground app listening on port 3000!
[1]  * Serving Flask app "playground"
[1]  * Environment: production
[1]    WARNING: This is a development server. Do not use it in a production deployment.
[1]    Use a production WSGI server instead.
[1]  * Debug mode: off
[1]  * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
[1] 127.0.0.1 - - [27/Aug/2021 17:57:53] "GET / HTTP/1.1" 200 -
[1] 127.0.0.1 - - [27/Aug/2021 17:57:53] "POST /?limit=50&offset=0 HTTP/1.1" 200 -
```

![image](https://user-images.githubusercontent.com/722880/131170063-941b2c59-0847-41b3-a1f3-9bca70ecaf1b.png)
Can see csv data in the table now.