### PR TITLE
refactor(popover): prefix css class to avoid collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Popover: prefix class name to avoid collision when embedded in other apps
+
 ## [0.58.0] - 2021-08-27
 
 - SQL VQB: Added Unpivot & Pivot Step to Snowflake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
-### [0.58.0] - 2021-08-27
+## [0.58.0] - 2021-08-27
 
 - SQL VQB: Added Unpivot & Pivot Step to Snowflake
 
-### [0.57.0] - 2021-08-26
+## [0.57.0] - 2021-08-26
 
 ### Added
 

--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -1,5 +1,5 @@
 <template>
-  <span class="popover" data-cy="weaverbird-popover" :style="elementStyle" @click.stop>
+  <span class="weaverbird-popover" data-cy="weaverbird-popover" :style="elementStyle" @click.stop>
     <slot />
   </span>
 </template>
@@ -174,7 +174,7 @@ export default class Popover extends Vue {
 }
 </script>
 <style lang="scss" scoped>
-.popover {
+.weaverbird-popover {
   font-family: 'Montserrat', sans-serif;
   position: absolute;
   visibility: visible;

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -112,7 +112,7 @@ describe('Action Menu', () => {
   it('should instantiate with popover', async () => {
     const { wrapper } = await mountWrapper(false, true);
     expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.classes()).toContain('popover');
+    expect(wrapper.classes()).toContain('weaverbird-popover');
   });
 
   it('should not display the apply filter button', async () => {

--- a/tests/unit/data-types-menu.spec.ts
+++ b/tests/unit/data-types-menu.spec.ts
@@ -18,7 +18,7 @@ describe('Data Types Menu', () => {
     });
     const wrapper = mount(DataTypesMenu, { store, localVue });
     expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.classes()).toContain('popover');
+    expect(wrapper.classes()).toContain('weaverbird-popover');
   });
 
   it('should contain the right set of data types', () => {


### PR DESCRIPTION
The popover is using a simple `.popover` class.
This name is so generic that collision have been reported by customers using Weaverbird via Toucan Embeds.
Let's avoid that.