### PR TITLE
fix(join): fix join step

### DIFF
--- a/server/weaverbird/backends/sql_translator/steps/join.py
+++ b/server/weaverbird/backends/sql_translator/steps/join.py
@@ -65,6 +65,7 @@ def translate_join(
 
     # 5 build the final query string
     join_part = f"{'AND'.join([f'{query.query_name}.{keys[0]} = {right_query_name}.{keys[1]}' for keys in step.on])}"
+
     transformed_query = f"""{transformed_query}, {query_name} AS (SELECT {query.metadata_manager.retrieve_query_metadata_columns_as_str()} FROM {query.query_name} {how} JOIN {right_query_name} ON {join_part})"""
 
     log.debug(

--- a/server/weaverbird/backends/sql_translator/steps/join.py
+++ b/server/weaverbird/backends/sql_translator/steps/join.py
@@ -74,7 +74,7 @@ def translate_join(
         '############################################################'
     )
 
-    return SQLQuery(
+    new_query = SQLQuery(
         query_name=query_name,
         transformed_query=transformed_query,
         selection_query=build_selection_query(
@@ -82,3 +82,12 @@ def translate_join(
         ),
         metadata_manager=query.metadata_manager,
     )
+
+    # Rename query metadata columns by their alias
+    for col in query.metadata_manager.retrieve_query_metadata_columns().values():
+        query.metadata_manager.update_query_metadata_column_name(
+            column_name=col.name,
+            dest_column_name=col.alias,
+        )
+        query.metadata_manager.remove_query_metadata_column_alias(col.alias)
+    return new_query


### PR DESCRIPTION
Fix issue on metadata management for join step.
The issue was that within the join step a column was aliased but this alias was not made available to the selection query. 
So for now, each time we alias a column with a step, we have to make sure to rename the column with its alias before building the selection query.

