### PR TITLE
fix(sql append): use union all in append step

### DIFF
--- a/server/tests/backends/fixtures/append/simple.json
+++ b/server/tests/backends/fixtures/append/simple.json
@@ -165,6 +165,11 @@
         "NAME": "plop",
         "AGE": 666,
         "SCORE": 12
+      },
+      {
+        "NAME": "plop",
+        "AGE": 666,
+        "SCORE": 12
       }
     ]
   }

--- a/server/tests/steps/sql_translator/test_append.py
+++ b/server/tests/steps/sql_translator/test_append.py
@@ -53,7 +53,7 @@ def test_append(
     )
     expected_transformed = 'WITH SELECT_STEP_0 AS (SELECT * FROM CUSTOMERS_1),\
  APPEND_STEP_UNION_0 AS (SELECT * FROM CUSTOMERS_2), APPEND_STEP_1 AS\
- (SELECT ID, NAME, NULL AS COUNTRY FROM SELECT_STEP_0 UNION SELECT ID, NAME, COUNTRY FROM APPEND_STEP_UNION_0)'
+ (SELECT ID, NAME, NULL AS COUNTRY FROM SELECT_STEP_0 UNION ALL SELECT ID, NAME, COUNTRY FROM APPEND_STEP_UNION_0)'
     expect_selection = 'SELECT ID, NAME, COUNTRY FROM APPEND_STEP_1'
     assert query_result.transformed_query == expected_transformed
     assert query_result.selection_query == expect_selection

--- a/server/tests/steps/sql_translator/utils/test_query_transformation.py
+++ b/server/tests/steps/sql_translator/utils/test_query_transformation.py
@@ -253,7 +253,7 @@ def test_build_union_query():
     res = build_union_query(s, 'SELECT_STEP_0', ['table_2'])
     assert (
         res
-        == """SELECT COLUMN_1_1, COLUMN_1_2, COLUMN_1_3, COLUMN_1_4 FROM SELECT_STEP_0 UNION SELECT\
+        == """SELECT COLUMN_1_1, COLUMN_1_2, COLUMN_1_3, COLUMN_1_4 FROM SELECT_STEP_0 UNION ALL SELECT\
  COLUMN_2_1, COLUMN_2_2, COLUMN_2_3, COLUMN_2_4 FROM table_2"""
     )
 
@@ -275,7 +275,7 @@ def test_build_union_query_first_smaller():
     res = build_union_query(s, 'SELECT_STEP_0', ['table_2'])
     assert (
         res
-        == """SELECT COLUMN_1_1, COLUMN_1_2, COLUMN_1_3, NULL AS COLUMN_2_4 FROM SELECT_STEP_0 UNION SELECT\
+        == """SELECT COLUMN_1_1, COLUMN_1_2, COLUMN_1_3, NULL AS COLUMN_2_4 FROM SELECT_STEP_0 UNION ALL SELECT\
  COLUMN_2_1, COLUMN_2_2, COLUMN_2_3, COLUMN_2_4 FROM table_2"""
     )
 
@@ -297,6 +297,6 @@ def test_build_union_query_second_smaller():
     res = build_union_query(s, 'SELECT_STEP_0', ['table_2'])
     assert (
         res
-        == """SELECT COLUMN_1_1, COLUMN_1_2, COLUMN_1_3, COLUMN_1_4 FROM SELECT_STEP_0 UNION SELECT\
+        == """SELECT COLUMN_1_1, COLUMN_1_2, COLUMN_1_3, COLUMN_1_4 FROM SELECT_STEP_0 UNION ALL SELECT\
  COLUMN_2_1, COLUMN_2_2, COLUMN_2_3, NULL FROM table_2"""
     )

--- a/server/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
+++ b/server/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
@@ -250,7 +250,7 @@ def build_union_query(
         table_columns = query_metadata_manager.retrieve_columns_as_list(t)
         missing_columns = max_column_number - len(table_columns)
         all_columns = table_columns + ['NULL'] * missing_columns
-        new_query += f" UNION SELECT {', '.join(all_columns)} FROM {t}"
+        new_query += f" UNION ALL SELECT {', '.join(all_columns)} FROM {t}"
     return new_query
 
 


### PR DESCRIPTION
To have the same behavior as the Pandas append step, we need to use UNION ALL keyword in Snowflake instead of just Union.