### PR TITLE
chore(backend version): bump to 0.7.6

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weaverbird"
-version = "0.7.5"
+version = "0.7.6"
 description = "Pandas engine for weaverbird data pipelines"
 authors = ["Toucan Toco <dev+weaverbird@toucantoco.com>"]
 license = "MIT"


### PR DESCRIPTION
Bump to 0.7.6 for two fixes:
- UNION ALL in SQL append Step instead of UNION
- TOP N without group by keeps granularity.