### PR TITLE
fix(dates): use default toString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Variable chooser & data viewer : stop forcing date display in UTC/ISO, use default toString instead
+
 ### [0.60.5] - 2021-09-08
 
 ### Added

--- a/src/components/DataViewerCell.vue
+++ b/src/components/DataViewerCell.vue
@@ -27,7 +27,9 @@ export default {
   },
   methods: {
     getValue(value: any) {
-      return typeof value === 'object' ? JSON.stringify(value) : value.toString();
+      return typeof value === 'object' && !(value instanceof Date)
+        ? JSON.stringify(value)
+        : value.toString();
     },
   },
 };

--- a/src/components/stepforms/widgets/VariableInputs/VariableListOption.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableListOption.vue
@@ -47,7 +47,7 @@ export default class VariableListOption extends Vue {
   togglable!: boolean;
 
   get formattedValue(): string {
-    return this.value instanceof Date ? this.value.toUTCString() : this.value;
+    return this.value instanceof Date ? this.value.toString() : this.value;
   }
 
   get readableValue(): string {

--- a/tests/unit/data-viewer-cell.spec.ts
+++ b/tests/unit/data-viewer-cell.spec.ts
@@ -55,6 +55,19 @@ describe('Data Viewer Cell', () => {
       expect(wrapper.text()).toEqual('{"my_column":"my_value"}');
     });
   });
+  describe('value is a date', () => {
+    it('should display the value', () => {
+      const date = new Date();
+      const wrapper = shallowMount(DataViewerCell, {
+        context: {
+          props: {
+            value: date,
+          },
+        },
+      });
+      expect(wrapper.text()).toEqual(date.toString());
+    });
+  });
   it('should have specific class when selected', () => {
     const wrapper = shallowMount(DataViewerCell, {
       context: {

--- a/tests/unit/variable-list-option.spec.ts
+++ b/tests/unit/variable-list-option.spec.ts
@@ -63,9 +63,9 @@ describe('Variable List option', () => {
       });
       await wrapper.vm.$nextTick();
     });
-    it('should display date value in UTC timezone', () => {
+    it('should display date value with default toString', () => {
       expect(wrapper.find('.widget-variable-option__value').text()).toBe(
-        'Fri, 11 Jun 2021 08:09:17 GMT',
+        new Date(1623398957013).toString(),
       );
     });
   });
@@ -104,7 +104,7 @@ describe('Variable List option', () => {
       {
         type: 'date',
         value: new Date(1623398957013),
-        attendedValue: `"${new Date(1623398957013).toUTCString()}"`,
+        attendedValue: `"${new Date(1623398957013).toString()}"`,
       },
     ].forEach(
       ({ type, value, attendedValue }: { type: string; value: any; attendedValue: any }) => {


### PR DESCRIPTION
instead UTC or ISO (json) ones,
as we now overload the default Date.toString
beforehand to globaly control how dates are
displayed inside Toucan Toco