### PR TITLE
chore(bump): from 0.7.8 to 0.7.9

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weaverbird"
-version = "0.7.8"
+version = "0.7.9"
 description = "Pandas engine for weaverbird data pipelines"
 authors = ["Toucan Toco <dev+weaverbird@toucantoco.com>"]
 license = "MIT"


### PR DESCRIPTION
# What
- fix on aggregate group by + keep granularity
- fix on top keep granularity
- fix on rank keep granularity
