### PR TITLE
chore(bump): from 0.7.9 to 0.8.0

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weaverbird"
-version = "0.7.9"
+version = "0.8.0"
 description = "Pandas engine for weaverbird data pipelines"
 authors = ["Toucan Toco <dev+weaverbird@toucantoco.com>"]
 license = "MIT"


### PR DESCRIPTION
# What
- Snowflake VQB  :
  - fix columns metadatas problems
  - fix the keeping of granularity on aggregate step
  - writing unittests for keep-granularity option
  - fix collision on snowflake fixtures test when creating table names (allowing multiple tests instances running at the same time)
