### PR TITLE
feat(sql evolution): add evolution step & unit tests

### DIFF
--- a/server/tests/backends/fixtures/evolution/abs_nogroups.json
+++ b/server/tests/backends/fixtures/evolution/abs_nogroups.json
@@ -1,0 +1,163 @@
+{
+  "exclude": [
+    "sql"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name":"evolution",
+        "date_col":"DATE",
+        "value_col":"VALUE",
+        "evolution_type":"vsLastYear",
+        "evolution_format":"abs",
+        "new_column": "pouet"
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "date",
+          "type": "datetime"
+        },
+        {
+          "name": "value",
+          "type": "integer"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "date": "2019-06-01",
+        "value": 6
+      },
+      {
+        "date": "2019-01-01",
+        "value": 2
+      },
+      {
+        "date": "2019-02-01",
+        "value": 5
+      },
+      {
+        "date": "2019-03-01",
+        "value": 3
+      },
+      {
+        "date": "2019-04-01",
+        "value": 8
+      },
+      {
+        "date": "2019-05-01",
+        "value": 9
+      },
+      {
+        "date": "2020-06-01",
+        "value": 6
+      },
+      {
+        "date": "2020-01-01",
+        "value": 3
+      },
+      {
+        "date": "2020-02-01",
+        "value": 5
+      },
+      {
+        "date": "2020-03-01",
+        "value": 3
+      },
+      {
+        "date": "2020-04-01",
+        "value": 8
+      },
+      {
+        "date": "2020-05-01",
+        "value": 9
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "DATE",
+          "type": "datetime"
+        },
+        {
+          "name": "VALUE",
+          "type": "integer"
+        },
+        {
+          "name": "POUET",
+          "type": "number"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "DATE": "2019-01-01",
+        "VALUE": 2,
+        "POUET": null
+      },
+      {
+        "DATE": "2019-02-01",
+        "VALUE": 5,
+        "POUET": null
+      },
+      {
+        "DATE": "2019-03-01",
+        "VALUE": 3,
+        "POUET": null
+      },
+      {
+        "DATE": "2019-04-01",
+        "VALUE": 8,
+        "POUET": null
+      },
+      {
+        "DATE": "2019-05-01",
+        "VALUE": 9,
+        "POUET": null
+      },
+      {
+        "DATE": "2019-06-01",
+        "VALUE": 6,
+        "POUET": null
+      },
+      {
+        "DATE": "2020-01-01",
+        "VALUE": 3,
+        "POUET": 1
+      },
+      {
+        "DATE": "2020-02-01",
+        "VALUE": 5,
+        "POUET": 0
+      },
+      {
+        "DATE": "2020-03-01",
+        "VALUE": 3,
+        "POUET": 0
+      },
+      {
+        "DATE": "2020-04-01",
+        "VALUE": 8,
+        "POUET": 0
+      },
+      {
+        "DATE": "2020-05-01",
+        "VALUE": 9,
+        "POUET": 0
+      },
+      {
+        "DATE": "2020-06-01",
+        "VALUE": 6,
+        "POUET": 0
+      }
+    ]
+  }
+}

--- a/server/tests/backends/fixtures/evolution/abs_nogroups.json
+++ b/server/tests/backends/fixtures/evolution/abs_nogroups.json
@@ -10,7 +10,7 @@
         "value_col":"VALUE",
         "evolution_type":"vsLastYear",
         "evolution_format":"abs",
-        "new_column": "pouet"
+        "new_column": "POUET"
       }
     ]
   },
@@ -18,11 +18,11 @@
     "schema": {
       "fields": [
         {
-          "name": "date",
+          "name": "DATE",
           "type": "datetime"
         },
         {
-          "name": "value",
+          "name": "VALUE",
           "type": "integer"
         }
       ],
@@ -30,52 +30,52 @@
     },
     "data": [
       {
-        "date": "2019-06-01",
-        "value": 6
+        "DATE": "2019-01-01",
+        "VALUE": 2
       },
       {
-        "date": "2019-01-01",
-        "value": 2
+        "DATE": "2019-02-01",
+        "VALUE": 5
       },
       {
-        "date": "2019-02-01",
-        "value": 5
+        "DATE": "2019-03-01",
+        "VALUE": 3
       },
       {
-        "date": "2019-03-01",
-        "value": 3
+        "DATE": "2019-04-01",
+        "VALUE": 8
       },
       {
-        "date": "2019-04-01",
-        "value": 8
+        "DATE": "2019-05-01",
+        "VALUE": 9
       },
       {
-        "date": "2019-05-01",
-        "value": 9
+        "DATE": "2019-06-01",
+        "VALUE": 6
       },
       {
-        "date": "2020-06-01",
-        "value": 6
+        "DATE": "2020-01-01",
+        "VALUE": 3
       },
       {
-        "date": "2020-01-01",
-        "value": 3
+        "DATE": "2020-02-01",
+        "VALUE": 5
       },
       {
-        "date": "2020-02-01",
-        "value": 5
+        "DATE": "2020-03-01",
+        "VALUE": 3
       },
       {
-        "date": "2020-03-01",
-        "value": 3
+        "DATE": "2020-04-01",
+        "VALUE": 8
       },
       {
-        "date": "2020-04-01",
-        "value": 8
+        "DATE": "2020-05-01",
+        "VALUE": 9
       },
       {
-        "date": "2020-05-01",
-        "value": 9
+        "DATE": "2020-06-01",
+        "VALUE": 6
       }
     ]
   },

--- a/server/tests/backends/fixtures/evolution/perc_groups.json
+++ b/server/tests/backends/fixtures/evolution/perc_groups.json
@@ -1,0 +1,108 @@
+{
+  "exclude": [
+    "sql"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name":"evolution",
+        "date_col":"DATE",
+        "value_col":"VALUE",
+        "evolution_type":"vsLastYear",
+        "evolution_format":"pct",
+        "index_columns": ["COUNTRY"],
+        "new_column": "pouet"
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "date",
+          "type": "datetime"
+        },
+        {
+          "name": "value",
+          "type": "number"
+        },
+        {
+          "name": "country",
+          "type": "string"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "date": "2019-01-01",
+        "value": 2,
+        "country": "France"
+      },
+      {
+        "date": "2019-01-01",
+        "value": 1,
+        "country": "Italy"
+      },
+      {
+        "date": "2020-01-01",
+        "value": 4,
+        "country": "France"
+      },
+      {
+        "date": "2020-01-01",
+        "value": 0.5,
+        "country": "Italy"
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "DATE",
+          "type": "datetime"
+        },
+        {
+          "name": "VALUE",
+          "type": "number"
+        },
+        {
+          "name": "COUNTRY",
+          "type": "string"
+        },
+        {
+          "name": "POUET",
+          "type": "number"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "DATE": "2019-01-01",
+        "VALUE": 1.0,
+        "COUNTRY": "Italy",
+        "POUET": null
+      },
+      {
+        "DATE": "2019-01-01",
+        "VALUE": 2.0,
+        "COUNTRY": "France",
+        "POUET": null
+      },
+      {
+        "DATE": "2020-01-01",
+        "VALUE": 4.0,
+        "COUNTRY": "France",
+        "POUET": 1.0
+      },
+      {
+        "DATE": "2020-01-01",
+        "VALUE": 0.5,
+        "COUNTRY": "Italy",
+        "POUET": -0.5
+      }
+    ]
+  }
+}

--- a/server/tests/backends/fixtures/evolution/perc_groups.json
+++ b/server/tests/backends/fixtures/evolution/perc_groups.json
@@ -11,7 +11,7 @@
         "evolution_type":"vsLastYear",
         "evolution_format":"pct",
         "index_columns": ["COUNTRY"],
-        "new_column": "pouet"
+        "new_column": "POUET"
       }
     ]
   },
@@ -19,15 +19,15 @@
     "schema": {
       "fields": [
         {
-          "name": "date",
+          "name": "DATE",
           "type": "datetime"
         },
         {
-          "name": "value",
+          "name": "VALUE",
           "type": "number"
         },
         {
-          "name": "country",
+          "name": "COUNTRY",
           "type": "string"
         }
       ],
@@ -35,24 +35,24 @@
     },
     "data": [
       {
-        "date": "2019-01-01",
-        "value": 2,
-        "country": "France"
+        "DATE": "2019-01-01 00:00:01",
+        "VALUE": 2,
+        "COUNTRY": "France"
       },
       {
-        "date": "2019-01-01",
-        "value": 1,
-        "country": "Italy"
+        "DATE": "2019-01-01 00:00:02",
+        "VALUE": 1,
+        "COUNTRY": "Italy"
       },
       {
-        "date": "2020-01-01",
-        "value": 4,
-        "country": "France"
+        "DATE": "2020-01-01 00:00:01",
+        "VALUE": 4,
+        "COUNTRY": "France"
       },
       {
-        "date": "2020-01-01",
-        "value": 0.5,
-        "country": "Italy"
+        "DATE": "2020-01-01 00:00:02",
+        "VALUE": 0.5,
+        "COUNTRY": "Italy"
       }
     ]
   },
@@ -80,25 +80,25 @@
     },
     "data": [
       {
-        "DATE": "2019-01-01",
-        "VALUE": 1.0,
-        "COUNTRY": "Italy",
-        "POUET": null
-      },
-      {
-        "DATE": "2019-01-01",
+        "DATE": "2019-01-01 00:00:01",
         "VALUE": 2.0,
         "COUNTRY": "France",
         "POUET": null
       },
       {
-        "DATE": "2020-01-01",
+        "DATE": "2019-01-01 00:00:02",
+        "VALUE": 1.0,
+        "COUNTRY": "Italy",
+        "POUET": null
+      },
+      {
+        "DATE": "2020-01-01 00:00:01",
         "VALUE": 4.0,
         "COUNTRY": "France",
         "POUET": 1.0
       },
       {
-        "DATE": "2020-01-01",
+        "DATE": "2020-01-01 00:00:02",
         "VALUE": 0.5,
         "COUNTRY": "Italy",
         "POUET": -0.5

--- a/server/tests/backends/fixtures/evolution/perc_nogroups.json
+++ b/server/tests/backends/fixtures/evolution/perc_nogroups.json
@@ -10,7 +10,7 @@
         "value_col":"VALUE",
         "evolution_type":"vsLastYear",
         "evolution_format":"pct",
-        "new_column": "pouet"
+        "new_column": "POUET"
       }
     ]
   },
@@ -18,11 +18,11 @@
     "schema": {
       "fields": [
         {
-          "name": "date",
+          "name": "DATE",
           "type": "datetime"
         },
         {
-          "name": "value",
+          "name": "VALUE",
           "type": "integer"
         }
       ],
@@ -30,52 +30,52 @@
     },
     "data": [
       {
-        "date": "2019-01-01",
-        "value": 2
+        "DATE": "2019-01-01",
+        "VALUE": 2
       },
       {
-        "date": "2019-02-01",
-        "value": 5
+        "DATE": "2019-02-01",
+        "VALUE": 5
       },
       {
-        "date": "2019-03-01",
-        "value": 3
+        "DATE": "2019-03-01",
+        "VALUE": 3
       },
       {
-        "date": "2019-04-01",
-        "value": 8
+        "DATE": "2019-04-01",
+        "VALUE": 8
       },
       {
-        "date": "2019-05-01",
-        "value": 9
+        "DATE": "2019-05-01",
+        "VALUE": 9
       },
       {
-        "date": "2019-06-01",
-        "value": 6
+        "DATE": "2019-06-01",
+        "VALUE": 6
       },
       {
-        "date": "2020-01-01",
-        "value": 2
+        "DATE": "2020-01-01",
+        "VALUE": 2
       },
       {
-        "date": "2020-02-01",
-        "value": 5
+        "DATE": "2020-02-01",
+        "VALUE": 5
       },
       {
-        "date": "2020-03-01",
-        "value": 3
+        "DATE": "2020-03-01",
+        "VALUE": 3
       },
       {
-        "date": "2020-04-01",
-        "value": 8
+        "DATE": "2020-04-01",
+        "VALUE": 8
       },
       {
-        "date": "2020-05-01",
-        "value": 9
+        "DATE": "2020-05-01",
+        "VALUE": 9
       },
       {
-        "date": "2020-06-01",
-        "value": 3
+        "DATE": "2020-06-01",
+        "VALUE": 3
       }
     ]
   },

--- a/server/tests/backends/fixtures/evolution/perc_nogroups.json
+++ b/server/tests/backends/fixtures/evolution/perc_nogroups.json
@@ -1,0 +1,163 @@
+{
+  "exclude": [
+    "sql"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name":"evolution",
+        "date_col":"DATE",
+        "value_col":"VALUE",
+        "evolution_type":"vsLastYear",
+        "evolution_format":"pct",
+        "new_column": "pouet"
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "date",
+          "type": "datetime"
+        },
+        {
+          "name": "value",
+          "type": "integer"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "date": "2019-01-01",
+        "value": 2
+      },
+      {
+        "date": "2019-02-01",
+        "value": 5
+      },
+      {
+        "date": "2019-03-01",
+        "value": 3
+      },
+      {
+        "date": "2019-04-01",
+        "value": 8
+      },
+      {
+        "date": "2019-05-01",
+        "value": 9
+      },
+      {
+        "date": "2019-06-01",
+        "value": 6
+      },
+      {
+        "date": "2020-01-01",
+        "value": 2
+      },
+      {
+        "date": "2020-02-01",
+        "value": 5
+      },
+      {
+        "date": "2020-03-01",
+        "value": 3
+      },
+      {
+        "date": "2020-04-01",
+        "value": 8
+      },
+      {
+        "date": "2020-05-01",
+        "value": 9
+      },
+      {
+        "date": "2020-06-01",
+        "value": 3
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "DATE",
+          "type": "datetime"
+        },
+        {
+          "name": "VALUE",
+          "type": "integer"
+        },
+        {
+          "name": "POUET",
+          "type": "number"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "DATE": "2019-01-01",
+        "VALUE": 2,
+        "POUET": null
+      },
+      {
+        "DATE": "2019-02-01",
+        "VALUE": 5,
+        "POUET": null
+      },
+      {
+        "DATE": "2019-03-01",
+        "VALUE": 3,
+        "POUET": null
+      },
+      {
+        "DATE": "2019-04-01",
+        "VALUE": 8,
+        "POUET": null
+      },
+      {
+        "DATE": "2019-05-01",
+        "VALUE": 9,
+        "POUET": null
+      },
+      {
+        "DATE": "2019-06-01",
+        "VALUE": 6,
+        "POUET": null
+      },
+      {
+        "DATE": "2020-01-01",
+        "VALUE": 2,
+        "POUET": 0
+      },
+      {
+        "DATE": "2020-02-01",
+        "VALUE": 5,
+        "POUET": 0
+      },
+      {
+        "DATE": "2020-03-01",
+        "VALUE": 3,
+        "POUET": 0
+      },
+      {
+        "DATE": "2020-04-01",
+        "VALUE": 8,
+        "POUET": 0
+      },
+      {
+        "DATE": "2020-05-01",
+        "VALUE": 9,
+        "POUET": 0
+      },
+      {
+        "DATE": "2020-06-01",
+        "VALUE": 3,
+        "POUET": -0.5
+      }
+    ]
+  }
+}

--- a/server/tests/steps/sql_translator/test_evolution.py
+++ b/server/tests/steps/sql_translator/test_evolution.py
@@ -37,7 +37,7 @@ def test_translate_evolution(mocker, query):
     expected_transformed_query = (
         "WITH SELECT_STEP_0 AS (SELECT * FROM products), EVOLUTION_STEP_1 AS "
         "(SELECT A.TOTO AS TOTO, A.RAICHU AS RAICHU, A.FLORIZARRE AS FLORIZARRE, A.DATE AS DATE, "
-        "A.RAICHU - B.RAICHU AS RAICHU_EVOL_ABS FROM SELECT_STEP_0 A LEFT JOIN SELECT_STEP_0 B "
+        "(A.RAICHU - B.RAICHU) AS RAICHU_EVOL_ABS FROM SELECT_STEP_0 A LEFT JOIN SELECT_STEP_0 B "
         "ON A.DATE = DATEADD('month', 1, B.DATE) ORDER BY A.DATE)"
     )
     assert query.transformed_query == expected_transformed_query

--- a/server/tests/steps/sql_translator/test_evolution.py
+++ b/server/tests/steps/sql_translator/test_evolution.py
@@ -1,0 +1,110 @@
+import pytest
+
+from weaverbird.backends.sql_translator.metadata import ColumnMetadata, SqlQueryMetadataManager
+from weaverbird.backends.sql_translator.steps import translate_evolution
+from weaverbird.backends.sql_translator.types import SQLQuery
+from weaverbird.pipeline.steps import EvolutionStep
+
+
+@pytest.fixture
+def query():
+    return SQLQuery(
+        query_name='SELECT_STEP_0',
+        transformed_query='WITH SELECT_STEP_0 AS (SELECT * FROM products)',
+        selection_query='SELECT TOTO, RAICHU, FLORIZARRE FROM SELECT_STEP_0',
+        metadata_manager=SqlQueryMetadataManager(
+            tables_metadata={
+                'TABLE1': {'TOTO': 'str', 'RAICHU': 'int', 'FLORIZARRE': 'str', 'DATE': 'TIMESTAMP'}
+            },
+        ),
+    )
+
+
+def test_translate_evolution(mocker, query):
+    step = EvolutionStep(
+        name='evolution',
+        dateCol='DATE',
+        valueCol='RAICHU',
+        evolutionType='vsLastMonth',
+        evolutionFormat='abs',
+    )
+    query = translate_evolution(
+        step,
+        query,
+        index=1,
+    )
+
+    expected_transformed_query = (
+        "WITH SELECT_STEP_0 AS (SELECT * FROM products), EVOLUTION_STEP_1 AS "
+        "(SELECT A.TOTO AS TOTO, A.RAICHU AS RAICHU, A.FLORIZARRE AS FLORIZARRE, A.DATE AS DATE, "
+        "B.RAICHU - A.RAICHU AS RAICHU_EVOL_ABS FROM SELECT_STEP_0 A LEFT JOIN SELECT_STEP_0 B "
+        "ON A.DATE = DATEADD('month', 1, DATE) ORDER BY A.DATE"
+    )
+    assert query.transformed_query == expected_transformed_query
+    assert (
+        query.selection_query
+        == 'SELECT TOTO, RAICHU, FLORIZARRE, DATE, RAICHU_EVOL_ABS FROM EVOLUTION_STEP_1'
+    )
+    assert query.query_name == 'EVOLUTION_STEP_1'
+    assert query.metadata_manager.retrieve_query_metadata_columns() == {
+        'DATE': ColumnMetadata(
+            name='DATE',
+            original_name='DATE',
+            type='TIMESTAMP',
+            original_type='TIMESTAMP',
+            alias=None,
+            delete=False,
+        ),
+        'FLORIZARRE': ColumnMetadata(
+            name='FLORIZARRE',
+            original_name='FLORIZARRE',
+            type='STR',
+            original_type='str',
+            alias=None,
+            delete=False,
+        ),
+        'RAICHU': ColumnMetadata(
+            name='RAICHU',
+            original_name='RAICHU',
+            type='INT',
+            original_type='int',
+            alias=None,
+            delete=False,
+        ),
+        'TOTO': ColumnMetadata(
+            name='TOTO',
+            original_name='TOTO',
+            type='STR',
+            original_type='str',
+            alias=None,
+            delete=False,
+        ),
+        'RAICHU_EVOL_ABS': ColumnMetadata(
+            name='RAICHU_EVOL_ABS',
+            original_name='RAICHU_EVOL_ABS',
+            type='FLOAT',
+            original_type='float',
+            alias=None,
+            delete=False,
+        ),
+    }
+
+
+def test_translate_evolution_error(mocker, query):
+    step = EvolutionStep(
+        name='evolution',
+        dateCol='DATE',
+        valueCol='VALUE',
+        evolutionType='vsLastMonth',
+        evolutionFormat='abs',
+    )
+    mocker.patch(
+        'weaverbird.backends.sql_translator.steps.evolution.build_selection_query',
+        side_effect=Exception,
+    )
+    with pytest.raises(Exception):
+        translate_evolution(
+            step,
+            query,
+            index=1,
+        )

--- a/server/tests/steps/sql_translator/test_evolution.py
+++ b/server/tests/steps/sql_translator/test_evolution.py
@@ -37,8 +37,8 @@ def test_translate_evolution(mocker, query):
     expected_transformed_query = (
         "WITH SELECT_STEP_0 AS (SELECT * FROM products), EVOLUTION_STEP_1 AS "
         "(SELECT A.TOTO AS TOTO, A.RAICHU AS RAICHU, A.FLORIZARRE AS FLORIZARRE, A.DATE AS DATE, "
-        "B.RAICHU - A.RAICHU AS RAICHU_EVOL_ABS FROM SELECT_STEP_0 A LEFT JOIN SELECT_STEP_0 B "
-        "ON A.DATE = DATEADD('month', 1, A.DATE) ORDER BY A.DATE)"
+        "A.RAICHU - B.RAICHU AS RAICHU_EVOL_ABS FROM SELECT_STEP_0 A LEFT JOIN SELECT_STEP_0 B "
+        "ON A.DATE = DATEADD('month', 1, B.DATE) ORDER BY A.DATE)"
     )
     assert query.transformed_query == expected_transformed_query
     assert (

--- a/server/tests/steps/sql_translator/test_evolution.py
+++ b/server/tests/steps/sql_translator/test_evolution.py
@@ -38,7 +38,7 @@ def test_translate_evolution(mocker, query):
         "WITH SELECT_STEP_0 AS (SELECT * FROM products), EVOLUTION_STEP_1 AS "
         "(SELECT A.TOTO AS TOTO, A.RAICHU AS RAICHU, A.FLORIZARRE AS FLORIZARRE, A.DATE AS DATE, "
         "B.RAICHU - A.RAICHU AS RAICHU_EVOL_ABS FROM SELECT_STEP_0 A LEFT JOIN SELECT_STEP_0 B "
-        "ON A.DATE = DATEADD('month', 1, DATE) ORDER BY A.DATE"
+        "ON A.DATE = DATEADD('month', 1, A.DATE) ORDER BY A.DATE)"
     )
     assert query.transformed_query == expected_transformed_query
     assert (

--- a/server/weaverbird/backends/sql_translator/steps/__init__.py
+++ b/server/weaverbird/backends/sql_translator/steps/__init__.py
@@ -9,6 +9,7 @@ from .customsql import translate_customsql
 from .dateextract import translate_dateextract
 from .delete import translate_delete
 from .duplicate import translate_duplicate
+from .evolution import translate_evolution
 from .fillna import translate_fillna
 from .filter import translate_filter
 from .formula import translate_formula
@@ -65,4 +66,5 @@ sql_steps_translators: Dict[str, SQLStepTranslator] = {
     'fillna': translate_fillna,
     'customsql': translate_customsql,
     'duplicate': translate_duplicate,
+    'evolution': translate_evolution,
 }

--- a/server/weaverbird/backends/sql_translator/steps/__init__.py
+++ b/server/weaverbird/backends/sql_translator/steps/__init__.py
@@ -11,8 +11,8 @@ from .customsql import translate_customsql
 from .dateextract import translate_dateextract
 from .delete import translate_delete
 from .duplicate import translate_duplicate
-from .evolution import translate_evolution
 from .duration import translate_duration
+from .evolution import translate_evolution
 from .fillna import translate_fillna
 from .filter import translate_filter
 from .formula import translate_formula

--- a/server/weaverbird/backends/sql_translator/steps/evolution.py
+++ b/server/weaverbird/backends/sql_translator/steps/evolution.py
@@ -46,20 +46,20 @@ def translate_evolution(
     )
 
     if step.evolution_format == 'abs':
-        new_column = f'''B.{step.value_col} - A.{step.value_col} AS {new_column_name}'''
+        new_column = f'''A.{step.value_col} - B.{step.value_col} AS {new_column_name}'''
     else:
-        new_column = f'''B.{step.value_col} / A.{step.value_col} - 1 AS {new_column_name}'''
+        new_column = f'''A.{step.value_col} / B.{step.value_col} - 1 AS {new_column_name}'''
 
     date_join = (
-        f"A.{step.date_col} = DATEADD('{DATE_UNIT[step.evolution_type]}', 1, {step.date_col})"
+        f"A.{step.date_col} = DATEADD('{DATE_UNIT[step.evolution_type]}', 1, B.{step.date_col})"
     )
     selected_columns = [
         f'A.{c} AS {c}' for c in query.metadata_manager.retrieve_query_metadata_columns()
     ] + [new_column]
 
     transformed_query = f"""{query.transformed_query}, {query_name} AS (SELECT {', '.join(selected_columns)}\
- FROM {query.query_name} A LEFT JOIN {query.query_name} B ON {" AND ".join([date_join]+[f"A.{c} ="
-    f"B.{c}" for c in step.index_columns])} ORDER BY A.{step.date_col}"""
+ FROM {query.query_name} A LEFT JOIN {query.query_name} B ON {" AND ".join([date_join]+[f"A.{c} = "
+    f"B.{c}" for c in step.index_columns])} ORDER BY A.{step.date_col})"""
 
     query.metadata_manager.add_query_metadata_column(new_column_name, 'float')
 

--- a/server/weaverbird/backends/sql_translator/steps/evolution.py
+++ b/server/weaverbird/backends/sql_translator/steps/evolution.py
@@ -1,0 +1,73 @@
+from weaverbird.backends.sql_translator.steps.utils.query_transformation import (
+    build_selection_query,
+)
+from weaverbird.backends.sql_translator.types import (
+    SQLPipelineTranslator,
+    SQLQuery,
+    SQLQueryDescriber,
+    SQLQueryExecutor,
+    SQLQueryRetriever,
+)
+from weaverbird.pipeline.steps import EvolutionStep
+
+
+def translate_evolution(
+    step: EvolutionStep,
+    query: SQLQuery,
+    index: int,
+    sql_query_retriever: SQLQueryRetriever = None,
+    sql_query_describer: SQLQueryDescriber = None,
+    sql_query_executor: SQLQueryExecutor = None,
+    sql_translate_pipeline: SQLPipelineTranslator = None,
+    subcall_from_other_pipeline_count: int = None,
+) -> SQLQuery:
+    """
+    Example of generated query (evolution on date column + 1 year, groupby orderstatus):
+    SELECT A.O_TOTALPRICE AS P1, B.O_TOTALPRICE AS P2, A.O_ORDERDATE AS DATE, A.O_ORDERSTATUS as STAT,
+    B.O_ORDERSTATUS AS STATB
+    FROM ORDERS_TRUNC A
+    LEFT JOIN ORDERS_TRUNC B
+    ON A.O_ORDERDATE = DATEADD('year', 1, B.O_ORDERDATE) AND A.O_ORDERSTATUS = B.O_ORDERSTATUS
+    WHERE DATEADD('year', 1, B.O_ORDERDATE) IS NULL OR B.O_ORDERSTATUS IS NULL
+    """
+
+    DATE_UNIT = {
+        'vsLastYear': 'year',
+        'vsLastMonth': 'month',
+        'vsLastWeek': 'week',
+        'vsLastDay': 'day',
+    }
+
+    query_name = f'EVOLUTION_STEP_{index}'
+    new_column_name = (
+        step.new_column.upper()
+        if step.new_column
+        else f'{step.value_col}_EVOL_{step.evolution_format.upper()}'
+    )
+
+    if step.evolution_format == 'abs':
+        new_column = f'''B.{step.value_col} - A.{step.value_col} AS {new_column_name}'''
+    else:
+        new_column = f'''B.{step.value_col} / A.{step.value_col} - 1 AS {new_column_name}'''
+
+    date_join = (
+        f"A.{step.date_col} = DATEADD('{DATE_UNIT[step.evolution_type]}', 1, {step.date_col})"
+    )
+    selected_columns = [
+        f'A.{c} AS {c}' for c in query.metadata_manager.retrieve_query_metadata_columns()
+    ] + [new_column]
+
+    transformed_query = f"""{query.transformed_query}, {query_name} AS (SELECT {', '.join(selected_columns)}\
+ FROM {query.query_name} A LEFT JOIN {query.query_name} B ON {" AND ".join([date_join]+[f"A.{c} ="
+    f"B.{c}" for c in step.index_columns])} ORDER BY A.{step.date_col}"""
+
+    query.metadata_manager.add_query_metadata_column(new_column_name, 'float')
+
+    return SQLQuery(
+        query_name=query_name,
+        transformed_query=transformed_query,
+        selection_query=build_selection_query(
+            query.metadata_manager.retrieve_query_metadata_columns(), query_name
+        ),
+        metadata_manager=query.metadata_manager,
+    )

--- a/src/lib/translators/snowflake.ts
+++ b/src/lib/translators/snowflake.ts
@@ -48,6 +48,10 @@ export class SnowflakeTranslator extends BaseTranslator {
     return step;
   }
 
+  evolution(step: Readonly<S.EvolutionStep>) {
+    return step;
+  }
+
   fillna(step: Readonly<S.FillnaStep>) {
     return step;
   }

--- a/src/lib/translators/snowflake.ts
+++ b/src/lib/translators/snowflake.ts
@@ -59,7 +59,7 @@ export class SnowflakeTranslator extends BaseTranslator {
   duration(step: Readonly<S.ComputeDurationStep>) {
     return step;
   }
-  
+
   evolution(step: Readonly<S.EvolutionStep>) {
     return step;
   }


### PR DESCRIPTION
* Add SQL Evolution Step

Implementation pattern: 
- Join the input query to itself on left Date = right Date + 1 Year/Month/Week
- Compute Evol in Abs or %  
- Use `DATEADD` to compute evolution from a provided timestamp column

https://user-images.githubusercontent.com/71276735/134045097-05b18fb9-fce4-49e7-8371-d3e94566e246.mp4