### PR TITLE
feat(vqb): kill residuals tables + job to kill all old tables

### DIFF
--- a/server/tests/backends/sql_translator/test_snowflake_translator_steps.py
+++ b/server/tests/backends/sql_translator/test_snowflake_translator_steps.py
@@ -1,4 +1,5 @@
 import json
+import time
 from os import environ
 from random import randint
 from typing import Dict, NamedTuple, Optional, Union
@@ -22,6 +23,8 @@ WAREHOUSE = 'toucan_test'
 DATABASE = 'toucan_test'
 ROLE = 'toucan_test'
 SCHEMA = 'toucan_test'
+
+SNOWFLAKE_TABLES_TESTS = []
 
 
 # Update this method to use snowflake connection
@@ -91,62 +94,131 @@ def snowflake_query_executor(domain: str, query_string: str = None) -> Union[Tes
         return TestDataSlice(df=pd.DataFrame(res))
 
 
+def _drop_table(table_array: list):
+    global SNOWFLAKE_TABLES_TESTS
+
+    """
+    This method will drop tables
+    As given parameter, we have list of tables we want to drop
+
+    """
+    print("[x] Cleaning tables in progress, please wait...")
+    # Drop created table
+    for case_id in table_array:
+        # The try catch just if we're droping an already drope table in the process
+        try:
+            print(f"[-] Droping {case_id}")
+            execute(get_connection(), f'DROP TABLE {case_id};')
+            # we remove from SNOWFLAKE_TABLES_TESTS the case test
+            SNOWFLAKE_TABLES_TESTS.remove(case_id) if case_id in SNOWFLAKE_TABLES_TESTS else print(
+                f"{case_id} not in the list anymore !"
+            )
+        except Exception as es:
+            print(es)
+            print(f"[-] {case_id} was probably already dropped or not available !")
+
+
+def clean_too_old_residuals_tables():
+    """
+    This function  will get the list of all available tables
+    and then clean the too much old one by calculate the time of the creation of those tables
+
+    """
+    try:
+        # we get table list from snowflake
+        tables_list: pd.DataFrame = execute(get_connection(), "SHOW TABLES;")
+        too_old_tables_to_delete: list = []
+
+        # we loop on table's name of the database
+        for table_name in tables_list["name"].to_list():
+            if "_TOUCAN_TEST_" in table_name:
+                created_table_time = int(table_name.split("___")[1])
+                # if the table is too old (Was created 24 hour earlier)
+                if time.time() - created_table_time > 86400:
+                    too_old_tables_to_delete.append(table_name)
+
+        # then we delete the list of residual tables:
+        _drop_table(too_old_tables_to_delete)
+    except Exception as es:
+        # in some case we can have an exception here for an empty result for table
+        # no worries, not a big deal, that's why there is this error skip here
+        print(es)
+
+
 # Translation from Pipeline json to SQL query
 @pytest.mark.parametrize('case_id, case_spec_file_path', test_cases)
 def test_sql_translator_pipeline(case_id, case_spec_file_path, get_engine):
-    # TO prevent conflict on snowflake tables when testing on multiple terminals
-    case_id = case_id.replace("/", "") + str(randint(1, 100000))
+    global SNOWFLAKE_TABLES_TESTS
+
+    # Let's clean some old residuals tables
+    clean_too_old_residuals_tables()
+
+    # To prevent conflicts on snowflake tables when testing on multiple terminals
+    # we're going to create specific tables for tests with this structure
+    # tableName_creationTime_caseid (Ex: SUBSTRING_toucan_test_@169494938@_3342)
+    # The _toucan_test_ is to prevent drop e2e tables because those tables will not have tha keyword
+    case_id = (
+        f"{case_id.replace('/', '')}_toucan_test___{str(int(time.time()))}___{str(randint(1, 100))}"
+    )
 
     spec_file = open(case_spec_file_path, 'r')
     spec = json.loads(spec_file.read())
     spec_file.close()
 
-    # Drop created table
-    execute(get_connection(), f'DROP TABLE IF EXISTS {case_id}', False)
+    try:
+        # Drop created table
+        execute(get_connection(), f'DROP TABLE IF EXISTS {case_id}', False)
 
-    # inserting the data in Snowflake
-    # Take data in fixture file, set in pandas, create table and insert
-    data_to_insert = pd.read_json(json.dumps(spec['input']), orient='table')
-    data_to_insert.to_sql(
-        name=case_id.replace('/', ''), con=get_engine, index=False, if_exists='replace', chunksize=1
-    )
+        # We append tables we just created that will be cleaned at the end of tests
+        SNOWFLAKE_TABLES_TESTS.append(case_id)
 
-    if 'other_inputs' in spec:
-        for input in spec['other_inputs']:
-            pd.read_json(json.dumps(spec['other_inputs'][input]), orient='table').to_sql(
-                name=input,
-                con=get_engine,
-                index=False,
-                if_exists='replace',
+        # inserting the data in Snowflake
+        # Take data in fixture file, set in pandas, create table and insert
+        data_to_insert = pd.read_json(json.dumps(spec['input']), orient='table')
+        data_to_insert.to_sql(
+            name=case_id, con=get_engine, index=False, if_exists='replace', chunksize=1
+        )
+
+        if 'other_inputs' in spec:
+            for input in spec['other_inputs']:
+                pd.read_json(json.dumps(spec['other_inputs'][input]), orient='table').to_sql(
+                    name=input,
+                    con=get_engine,
+                    index=False,
+                    if_exists='replace',
+                )
+
+        steps = spec['step']['pipeline']
+        steps.insert(0, {'name': 'domain', 'domain': case_id})
+        pipeline = Pipeline(steps=steps)
+
+        # Convert Pipeline object to Snowflake Query
+        query, report = translate_pipeline(
+            pipeline,
+            sql_query_retriever=sql_retrieve_city,
+            sql_query_describer=snowflake_query_describer,
+            sql_query_executor=snowflake_query_executor,
+        )
+
+        # Execute request generated from Pipeline in Snowflake and get the result
+        result: pd.DataFrame = execute(get_connection(), query)
+
+        _drop_table([case_id])
+        if 'other_inputs' in spec:
+            _drop_table(spec['other_inputs'])
+
+        # Compare result and expected (from fixture file)
+        if 'expected_sql' in spec:
+            result_expected: pd.DataFrame = pd.read_json(
+                json.dumps(spec['expected_sql']), orient='table'
+            )
+        else:
+            result_expected: pd.DataFrame = pd.read_json(
+                json.dumps(spec['expected']), orient='table'
             )
 
-    steps = spec['step']['pipeline']
-    steps.insert(0, {'name': 'domain', 'domain': case_id})
-    pipeline = Pipeline(steps=steps)
-
-    # Convert Pipeline object to Snowflake Query
-    query, report = translate_pipeline(
-        pipeline,
-        sql_query_retriever=sql_retrieve_city,
-        sql_query_describer=snowflake_query_describer,
-        sql_query_executor=snowflake_query_executor,
-    )
-
-    # Execute request generated from Pipeline in Snowflake and get the result
-    result: pd.DataFrame = execute(get_connection(), query)
-
-    # Drop created table
-    execute(get_connection(), f'DROP TABLE {case_id};')
-    if 'other_inputs' in spec:
-        for input in spec['other_inputs']:
-            execute(get_connection(), f'DROP TABLE {input}')
-
-    # Compare result and expected (from fixture file)
-    if 'expected_sql' in spec:
-        result_expected: pd.DataFrame = pd.read_json(
-            json.dumps(spec['expected_sql']), orient='table'
-        )
-    else:
-        result_expected: pd.DataFrame = pd.read_json(json.dumps(spec['expected']), orient='table')
-
-    assert_dataframes_equals(result_expected, result)
+        assert_dataframes_equals(result_expected, result)
+    except KeyboardInterrupt as es:
+        print(es)
+        # We try to kill residuals tables
+        _drop_table(SNOWFLAKE_TABLES_TESTS)

--- a/server/tests/backends/sql_translator/test_snowflake_translator_steps.py
+++ b/server/tests/backends/sql_translator/test_snowflake_translator_steps.py
@@ -98,14 +98,14 @@ def snowflake_query_executor(domain: str, query_string: str = None) -> Union[Tes
         return TestDataSlice(df=pd.DataFrame(res))
 
 
-def _drop_table(table_array: list):
-    global SNOWFLAKE_TABLES_TESTS
-
+def _drop_tables(table_array: list):
     """
     This method will drop tables
     As given parameter, we have list of tables we want to drop
 
     """
+    global SNOWFLAKE_TABLES_TESTS
+
     logger.info("[x] Cleaning tables in progress, please wait...")
     # Drop created table
     for case_id in table_array:
@@ -144,7 +144,7 @@ def clean_too_old_residuals_tables():
                     too_old_tables_to_delete.append(table_name)
 
         # then we delete the list of residual tables:
-        _drop_table(too_old_tables_to_delete)
+        _drop_tables(too_old_tables_to_delete)
     except Exception as es:
         # in some case we can have an exception here for an empty result for table
         # no worries, not a big deal, that's why there is this error skip here
@@ -212,9 +212,9 @@ def test_sql_translator_pipeline(case_id, case_spec_file_path, get_engine):
         # Execute request generated from Pipeline in Snowflake and get the result
         result: pd.DataFrame = execute(get_connection(), query)
 
-        _drop_table([case_id])
+        _drop_tables([case_id])
         if 'other_inputs' in spec:
-            _drop_table(spec['other_inputs'])
+            _drop_tables(spec['other_inputs'])
 
         # Compare result and expected (from fixture file)
         if 'expected_sql' in spec:
@@ -230,4 +230,4 @@ def test_sql_translator_pipeline(case_id, case_spec_file_path, get_engine):
     except KeyboardInterrupt as es:
         logger.info(es)
         # We try to kill residuals tables
-        _drop_table(SNOWFLAKE_TABLES_TESTS)
+        _drop_tables(SNOWFLAKE_TABLES_TESTS)

--- a/server/tests/backends/sql_translator/test_snowflake_translator_steps.py
+++ b/server/tests/backends/sql_translator/test_snowflake_translator_steps.py
@@ -12,7 +12,6 @@ from snowflake.sqlalchemy import URL
 from sqlalchemy import create_engine
 
 from server.tests.utils import assert_dataframes_equals, retrieve_case, type_code_mapping
-
 from weaverbird.backends.pandas_executor.pipeline_executor import logger
 from weaverbird.backends.sql_translator import translate_pipeline
 from weaverbird.pipeline import Pipeline
@@ -116,7 +115,9 @@ def _drop_table(table_array: list):
 
             execute(get_connection(), f'DROP TABLE {case_id};')
             # we remove from SNOWFLAKE_TABLES_TESTS the case test
-            SNOWFLAKE_TABLES_TESTS.remove(case_id) if case_id in SNOWFLAKE_TABLES_TESTS else logger.info(
+            SNOWFLAKE_TABLES_TESTS.remove(
+                case_id
+            ) if case_id in SNOWFLAKE_TABLES_TESTS else logger.info(
                 f"{case_id} not in the list anymore !"
             )
         except Exception as es:


### PR DESCRIPTION
# Why
- Because we were having too much tables when somebody was skipping/interrupting tests
- Too much residuals tables with unused datasets

# How
- Added a kind of job to delete all old tables with more than 24h of creation
- Automatically catch the keyboard interrupt and try to kill all tables created