### PR TITLE
fix(sql pivot): clean selected cols

### DIFF
--- a/server/tests/steps/sql_translator/test_pivot.py
+++ b/server/tests/steps/sql_translator/test_pivot.py
@@ -41,11 +41,11 @@ def test_translate_pivot(sql_query_executor):
         agg_function='sum',
     )
     res = translate_pivot(step, query, index=1, sql_query_executor=sql_query_executor)
-    assert (
-        res.transformed_query
-        == """WITH SELECT_STEP_0 AS (SELECT COMPANY, COUNTRY, CURRENCY, PROVIDER FROM PRODUCTS),\
- PIVOT_STEP_1 AS (SELECT COMPANY, COUNTRY, "'SPAIN'" AS SPAIN, "'FRANCE'" AS FRANCE\
- FROM SELECT_STEP_0 PIVOT(sum(PROVIDER) FOR CURRENCY IN ('SPAIN', 'FRANCE')))"""
+    assert res.transformed_query == (
+        """WITH SELECT_STEP_0 AS (SELECT COMPANY, COUNTRY, CURRENCY, PROVIDER FROM PRODUCTS), """
+        """PRE_PIVOT_STEP_1 AS (SELECT COMPANY, COUNTRY, CURRENCY, PROVIDER FROM SELECT_STEP_0), """
+        """PIVOT_STEP_1 AS (SELECT COMPANY, COUNTRY, "'SPAIN'" AS SPAIN, "'FRANCE'" AS FRANCE """
+        """FROM PRE_PIVOT_STEP_1 PIVOT(sum(PROVIDER) FOR CURRENCY IN ('SPAIN', 'FRANCE')))"""
     )
     assert res.selection_query == 'SELECT COMPANY, COUNTRY, SPAIN, FRANCE FROM PIVOT_STEP_1'
     assert res.metadata_manager.retrieve_query_metadata_columns() == {

--- a/server/weaverbird/backends/sql_translator/steps/pivot.py
+++ b/server/weaverbird/backends/sql_translator/steps/pivot.py
@@ -43,9 +43,9 @@ def translate_pivot(
         .values.tolist()
     )
 
-    pivoted_values_column_type = query.metadata_manager.retrieve_query_metadata_column_by_name(
+    pivoted_values_column_type = query.metadata_manager.retrieve_query_metadata_column_type_by_name(
         step.value_column
-    ).type
+    )
     query.metadata_manager.remove_query_metadata_columns(
         query.metadata_manager.retrieve_query_metadata_columns_as_list(columns_filter=step.index)
     )
@@ -56,10 +56,18 @@ def translate_pivot(
         query.metadata_manager.update_query_metadata_column_alias(f'''"'{name}'"''', name)
         for name in pivot_values
     ]
-    pivot_query = f"""SELECT {query.metadata_manager.retrieve_query_metadata_columns_as_str()} \
-FROM {query.query_name} PIVOT({aggregate_part} FOR {step.column_to_pivot} IN ({', '.join([f"'{val}'" for val in pivot_values])})\
-"""
-    transformed_query = f"""{query.transformed_query}, {query_name} AS ({pivot_query}))"""
+    prepivot_query = (
+        f'''PRE_{query_name} AS (SELECT {', '.join(step.index + [step.column_to_pivot, step.value_column])} FROM'''
+        f''' {query.query_name})'''
+    )
+    pivot_query = (
+        f"""SELECT {query.metadata_manager.retrieve_query_metadata_columns_as_str()}"""
+        f""" FROM PRE_{query_name} PIVOT({aggregate_part} FOR {step.column_to_pivot} IN"""
+        f"""({', '.join([f"'{val}'" for val in pivot_values])})"""
+    )
+    transformed_query = (
+        f"""{query.transformed_query}, {prepivot_query}, {query_name} AS ({pivot_query}))"""
+    )
 
     new_query = SQLQuery(
         query_name=query_name,

--- a/server/weaverbird/backends/sql_translator/steps/pivot.py
+++ b/server/weaverbird/backends/sql_translator/steps/pivot.py
@@ -62,7 +62,7 @@ def translate_pivot(
     )
     pivot_query = (
         f"""SELECT {query.metadata_manager.retrieve_query_metadata_columns_as_str()}"""
-        f""" FROM PRE_{query_name} PIVOT({aggregate_part} FOR {step.column_to_pivot} IN"""
+        f""" FROM PRE_{query_name} PIVOT({aggregate_part} FOR {step.column_to_pivot} IN """
         f"""({', '.join([f"'{val}'" for val in pivot_values])})"""
     )
     transformed_query = (


### PR DESCRIPTION
When using SQL's `Pivot` step, we need to preselect columns from columns to keep, value column & pivot column to avoid keeping them in the transformation. 
