### PR TITLE
fix(sql pivot): handle pivot with illegal characters in value

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weaverbird"
-version = "0.8.4"
+version = "0.8.5"
 description = "Pandas engine for weaverbird data pipelines"
 authors = ["Toucan Toco <dev+weaverbird@toucantoco.com>"]
 license = "MIT"

--- a/server/tests/backends/fixtures/pivot/columns_cleaning.json
+++ b/server/tests/backends/fixtures/pivot/columns_cleaning.json
@@ -1,0 +1,108 @@
+{
+  "exclude": [
+    "sql"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name":"pivot",
+        "index":["EMPID"],
+        "column_to_pivot":"MONTH",
+        "value_column":"AMOUNT",
+        "agg_function":"sum"
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "EMPID",
+          "type": "string"
+        },
+        {
+          "name": "AMOUNT",
+          "type": "integer"
+        },
+        {
+          "name": "MONTH",
+          "type": "string"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "EMPID": "1-A X",
+        "AMOUNT": 10000,
+        "MONTH": "JAN"
+      },
+      {
+        "EMPID": "1-A X",
+        "AMOUNT": 400,
+        "MONTH": "JAN"
+      },
+      {
+        "EMPID": "2-A X",
+        "AMOUNT": 4500,
+        "MONTH": "JAN"
+      },
+      {
+        "EMPID": "2-A X",
+        "AMOUNT": 35000,
+        "MONTH": "JAN"
+      },
+      {
+        "EMPID": "1-A X",
+        "AMOUNT": 5000,
+        "MONTH": "FEB"
+      },
+      {
+        "EMPID": "1-A X",
+        "AMOUNT": 3000,
+        "MONTH": "FEB"
+      },
+      {
+        "EMPID": "2-A X",
+        "AMOUNT": 200,
+        "MONTH": "FEB"
+      },
+      {
+        "EMPID": "2-A X",
+        "AMOUNT": 90500,
+        "MONTH": "FEB"
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "EMPID",
+          "type": "string"
+        },
+        {
+          "name": "JAN",
+          "type": "string"
+        },
+        {
+          "name": "FEB",
+          "type": "integer"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "EMPID": "1-A X",
+        "JAN": 10400,
+        "FEB": 8000
+      },
+      {
+        "EMPID": "2-A X",
+        "JAN": 39500,
+        "FEB": 90700
+      }
+    ]
+  }
+}

--- a/server/tests/steps/sql_translator/test_pivot.py
+++ b/server/tests/steps/sql_translator/test_pivot.py
@@ -44,8 +44,9 @@ def test_translate_pivot(sql_query_executor):
     assert res.transformed_query == (
         """WITH SELECT_STEP_0 AS (SELECT COMPANY, COUNTRY, CURRENCY, PROVIDER FROM PRODUCTS), """
         """PRE_PIVOT_STEP_1 AS (SELECT COMPANY, COUNTRY, CURRENCY, PROVIDER FROM SELECT_STEP_0), """
-        """PIVOT_STEP_1 AS (SELECT COMPANY, COUNTRY, "'SPAIN'" AS SPAIN, "'FRANCE'" AS FRANCE """
-        """FROM PRE_PIVOT_STEP_1 PIVOT(sum(PROVIDER) FOR CURRENCY IN ('SPAIN', 'FRANCE')))"""
+        """PIVOT_STEP_1 AS (SELECT COMPANY, COUNTRY, SPAIN, FRANCE """
+        """FROM PRE_PIVOT_STEP_1 PIVOT(sum(PROVIDER) FOR CURRENCY IN ('SPAIN', 'FRANCE')) """
+        """AS p (COMPANY, COUNTRY, SPAIN, FRANCE))"""
     )
     assert res.selection_query == 'SELECT COMPANY, COUNTRY, SPAIN, FRANCE FROM PIVOT_STEP_1'
     assert res.metadata_manager.retrieve_query_metadata_columns() == {

--- a/server/tests/steps/sql_translator/utils/test_query_transformation.py
+++ b/server/tests/steps/sql_translator/utils/test_query_transformation.py
@@ -11,6 +11,7 @@ from weaverbird.backends.sql_translator.steps.utils.query_transformation import 
     generate_query_by_keeping_granularity,
     handle_zero_division,
     remove_metadatas_columns_from_query,
+    sanitize_column_name,
     sanitize_input,
     snowflake_date_format,
 )
@@ -355,6 +356,15 @@ def test_sanitize_input():
     assert sanitize_input('bla') == 'bla'
     assert sanitize_input("bla'") == "bla\\'"
     assert sanitize_input('bla"') == 'bla\\"'
+
+
+def test_sanitize_column_name():
+    assert sanitize_column_name('bla') == 'bla'
+    assert sanitize_column_name("bla'") == 'bla_'
+    assert sanitize_column_name('bla"') == 'bla_'
+    assert sanitize_column_name('1bla') == '_1bla'
+    assert sanitize_column_name('€bla') == '_bla'
+    assert sanitize_column_name('./§PL%L121R0°I"""$$"' '""€€') == '___PL_L121R0_I___$$_____'
 
 
 def test_remove_metadatas_columns_from_query(query):

--- a/server/weaverbird/backends/sql_translator/steps/pivot.py
+++ b/server/weaverbird/backends/sql_translator/steps/pivot.py
@@ -62,7 +62,7 @@ def translate_pivot(
     pivot_query = (
         f"""SELECT {query.metadata_manager.retrieve_query_metadata_columns_as_str()}"""
         f""" FROM PRE_{query_name} PIVOT({aggregate_part} FOR {step.column_to_pivot} IN """
-        f"""({', '.join([f"'{val}'" for val in pivot_values])})) as p ({', '.join(step.index + sanitized_columns)})"""
+        f"""({', '.join([f"'{val}'" for val in pivot_values])})) AS p ({', '.join(step.index + sanitized_columns)})"""
     )
     transformed_query = (
         f"""{query.transformed_query}, {prepivot_query}, {query_name} AS ({pivot_query})"""

--- a/server/weaverbird/backends/sql_translator/steps/pivot.py
+++ b/server/weaverbird/backends/sql_translator/steps/pivot.py
@@ -2,7 +2,7 @@ from distutils import log
 
 from weaverbird.backends.sql_translator.steps.utils.query_transformation import (
     build_selection_query,
-    sanitize_input,
+    sanitize_column_name,
 )
 from weaverbird.backends.sql_translator.types import (
     SQLPipelineTranslator,
@@ -43,7 +43,7 @@ def translate_pivot(
         .df[f'{step.column_to_pivot}']
         .values.tolist()
     )
-    sanitized_columns = [sanitize_input(p) for p in pivot_values]
+    sanitized_columns = [sanitize_column_name(p) for p in pivot_values]
 
     pivoted_values_column_type = query.metadata_manager.retrieve_query_metadata_column_type_by_name(
         step.value_column

--- a/server/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
+++ b/server/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
@@ -383,7 +383,9 @@ def get_query_for_date_extract(
 
 
 def sanitize_input(value: str) -> str:
-    return value.replace('"', '\\"').replace("'", "\\'")
+    if value[0].isdigit():
+        value = f'_{value}'
+    return value.replace('"', '\\"').replace("'", "\\'").replace('-', '_').replace(' ', '_')
 
 
 def build_aggregated_columns(aggregations):

--- a/server/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
+++ b/server/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
@@ -383,9 +383,13 @@ def get_query_for_date_extract(
 
 
 def sanitize_input(value: str) -> str:
-    if value[0].isdigit():
-        value = f'_{value}'
-    return value.replace('"', '\\"').replace("'", "\\'").replace('-', '_').replace(' ', '_')
+    return value.replace('"', '\\"').replace("'", "\\'")
+
+
+def sanitize_column_name(col: str) -> str:
+    if col[0].isdigit():
+        col = f'_{col}'
+    return col.replace('-', '_').replace(' ', '_')
 
 
 def build_aggregated_columns(aggregations):

--- a/server/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
+++ b/server/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
@@ -387,9 +387,11 @@ def sanitize_input(value: str) -> str:
 
 
 def sanitize_column_name(col: str) -> str:
+    # see   https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html
     if col[0].isdigit():
-        col = f'_{col}'
-    return col.replace('-', '_').replace(' ', '_')
+        return f"_{col[0]}{re.sub(r'[^0-9a-zA-Z_$]', '_', col[1:])}"
+    else:
+        return re.sub(r'[^0-9a-zA-Z_$]', '_', col)
 
 
 def build_aggregated_columns(aggregations):


### PR DESCRIPTION
In SQL `Pivot` step we might have values with `-`, ` `, or starting with a number in value column to pass as column names.
This PR cleans such illegal characters.