### PR TITLE
feat(front): Table numbers improvements

### DIFF
--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -74,9 +74,10 @@
           <tbody class="data-viewer__body">
             <tr class="data-viewer__row" v-for="(row, index) in dataset.data" :key="index">
               <DataViewerCell
+                class="data-viewer__cell"
+                :class="{ 'data-viewer-cell--active': isSelected(columnHeaders[cellidx].name) }"
                 v-for="(cell, cellidx) in row"
                 :key="cellidx"
-                :isSelected="isSelected(columnHeaders[cellidx].name)"
                 :value="cell"
               />
             </tr>
@@ -329,7 +330,7 @@ export default class DataViewer extends Vue {
 }
 
 .data-viewer__header-cell,
-.data-viewer-cell {
+.data-viewer__cell {
   position: relative;
   padding: 8px;
   background-color: white;
@@ -343,14 +344,14 @@ export default class DataViewer extends Vue {
   min-width: 140px;
 }
 
-.data-viewer-cell {
+.data-viewer__cell {
   background-color: #fafafa;
   white-space: normal;
   overflow: hidden;
 }
 
 .data-viewer__header-cell--active,
-.data-viewer-cell--active {
+.data-viewer__cell--active {
   // It's trick to have its left side colored cause of border-collapse
   border-left: 1px double;
   background-color: $active-color-faded-3;
@@ -359,7 +360,7 @@ export default class DataViewer extends Vue {
 }
 
 .data-viewer__row:last-child {
-  .data-viewer-cell--active {
+  .data-viewer__cell--active {
     border-bottom-color: $active-color;
   }
 }

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -75,7 +75,7 @@
             <tr class="data-viewer__row" v-for="(row, index) in dataset.data" :key="index">
               <DataViewerCell
                 class="data-viewer__cell"
-                :class="{ 'data-viewer-cell--active': isSelected(columnHeaders[cellidx].name) }"
+                :class="{ 'data-viewer__cell--active': isSelected(columnHeaders[cellidx].name) }"
                 v-for="(cell, cellidx) in row"
                 :key="cellidx"
                 :value="cell"

--- a/src/components/DataViewerCell.vue
+++ b/src/components/DataViewerCell.vue
@@ -1,6 +1,10 @@
 <template functional>
   <td
-    :class="{ 'data-viewer-cell': true, 'data-viewer-cell--active': props.isSelected }"
+    class="data-viewer-cell"
+    :class="{
+      'data-viewer-cell--active': props.isSelected,
+      'data-viewer-cell--numeric': $options.methods.isNumeric(props.value)
+    }"
     data-cy="weaverbird-data-viewer-cell"
   >
     {{ $options.methods.getValue(props.value) }}
@@ -11,7 +15,7 @@
  * @name DataViewerCell
  * @description A table cell displayed in a DataViewer
  *
- * @param {boolean} isSelected - Wether the cell is selected or is in a selected column
+ * @param {boolean} isSelected - Weather the cell is selected or is in a selected column
  * @param {string} value - The cell's value
  */
 export default {
@@ -31,11 +35,17 @@ export default {
         ? JSON.stringify(value)
         : value.toString();
     },
+
+    isNumeric(value: any): boolean {
+      return typeof value === 'number';
+    }
   },
 };
 </script>
-<style lang="scss" scoped>
-.data-viewer-cell {
+<style lang="scss">
+.data-viewer-cell--numeric {
+  text-align: right;
+
   // Ensure that digits all take the same width, so they stay aligned vertically
   font-variant-numeric: tabular-nums;
 }

--- a/src/components/DataViewerCell.vue
+++ b/src/components/DataViewerCell.vue
@@ -1,48 +1,53 @@
-<template functional>
+<template>
   <td
     class="data-viewer-cell"
     :class="{
-      'data-viewer-cell--active': props.isSelected,
-      'data-viewer-cell--numeric': $options.methods.isNumeric(props.value)
+      'data-viewer-cell--numeric': isNumeric,
     }"
     data-cy="weaverbird-data-viewer-cell"
   >
-    {{ $options.methods.getValue(props.value) }}
+    {{ stringifiedValue }}
   </td>
 </template>
+
 <script lang="ts">
+import Vue from 'vue';
+
 /**
  * @name DataViewerCell
  * @description A table cell displayed in a DataViewer
  *
- * @param {boolean} isSelected - Weather the cell is selected or is in a selected column
  * @param {string} value - The cell's value
  */
-export default {
+export default Vue.extend({
   name: 'data-viewer-cell',
+
   props: {
     value: {
       default: () => '-',
     },
-    isSelected: {
-      type: Boolean,
-      default: () => false,
+  },
+
+  computed: {
+    stringifiedValue(): string {
+      return this.getValue(this.value);
+    },
+    isNumeric(): boolean {
+      return typeof this.value === 'number';
     },
   },
+
   methods: {
-    getValue(value: any) {
+    getValue(value: any): string {
       return typeof value === 'object' && !(value instanceof Date)
         ? JSON.stringify(value)
         : value.toString();
     },
-
-    isNumeric(value: any): boolean {
-      return typeof value === 'number';
-    }
   },
-};
+});
 </script>
-<style lang="scss">
+
+<style lang="scss" scoped>
 .data-viewer-cell--numeric {
   text-align: right;
 

--- a/src/components/DataViewerCell.vue
+++ b/src/components/DataViewerCell.vue
@@ -34,4 +34,9 @@ export default {
   },
 };
 </script>
-<style lang="scss"></style>
+<style lang="scss" scoped>
+.data-viewer-cell {
+  // Ensure that digits all take the same width, so they stay aligned vertically
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/tests/unit/data-viewer-cell.spec.ts
+++ b/tests/unit/data-viewer-cell.spec.ts
@@ -1,4 +1,5 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
 
 import DataViewerCell from '@/components/DataViewerCell.vue';
 
@@ -10,10 +11,8 @@ describe('Data Viewer Cell', () => {
   });
   it('should instantiate with value undefined', () => {
     const wrapper = shallowMount(DataViewerCell, {
-      context: {
-        props: {
-          value: undefined,
-        },
+      propsData: {
+        value: undefined,
       },
     });
     expect(wrapper.exists()).toBeTruthy();
@@ -22,34 +21,37 @@ describe('Data Viewer Cell', () => {
   describe('value is a string', () => {
     it('should display the value', () => {
       const wrapper = shallowMount(DataViewerCell, {
-        context: {
-          props: {
-            value: 'my_value',
-          },
+        propsData: {
+          value: 'my_value',
         },
       });
       expect(wrapper.text()).toEqual('my_value');
     });
   });
   describe('value is a number', () => {
-    it('should display the value', () => {
-      const wrapper = shallowMount(DataViewerCell, {
-        context: {
-          props: {
-            value: 12,
-          },
+    let wrapper: Wrapper<Vue>;
+
+    beforeEach(() => {
+      wrapper = shallowMount(DataViewerCell, {
+        propsData: {
+          value: 12,
         },
       });
+    });
+
+    it('should display the value', () => {
       expect(wrapper.text()).toEqual('12');
+    });
+
+    it('should has a specific style to align the numbers to the right', () => {
+      expect(wrapper.classes()).toContain('data-viewer-cell--numeric');
     });
   });
   describe('value is an object', () => {
     it('should display the value', () => {
       const wrapper = shallowMount(DataViewerCell, {
-        context: {
-          props: {
-            value: { my_column: 'my_value' },
-          },
+        propsData: {
+          value: { my_column: 'my_value' },
         },
       });
       expect(wrapper.text()).toEqual('{"my_column":"my_value"}');
@@ -59,24 +61,11 @@ describe('Data Viewer Cell', () => {
     it('should display the value', () => {
       const date = new Date();
       const wrapper = shallowMount(DataViewerCell, {
-        context: {
-          props: {
-            value: date,
-          },
+        propsData: {
+          value: date,
         },
       });
       expect(wrapper.text()).toEqual(date.toString());
     });
-  });
-  it('should have specific class when selected', () => {
-    const wrapper = shallowMount(DataViewerCell, {
-      context: {
-        props: {
-          value: 'my_value',
-          isSelected: true,
-        },
-      },
-    });
-    expect(wrapper.classes()).toContain('data-viewer-cell--active');
   });
 });

--- a/tests/unit/data-viewer.spec.ts
+++ b/tests/unit/data-viewer.spec.ts
@@ -532,8 +532,8 @@ describe('Data Viewer', () => {
           rowsWrapper
             .at(i)
             .find('dataviewercell-stub')
-            .attributes('isselected'),
-        ).toEqual('true');
+            .classes(),
+        ).toContain('data-viewer__cell--active');
       });
     });
   });


### PR DESCRIPTION
To ease comparison between numbers in the date table: 
- use a fixed width for digits
- align numbers to the right