### PR TITLE
feat(front): make date-range input fixed/relative tabs hideable

### DIFF
--- a/src/components/stepforms/widgets/DateComponents/CustomVariableList.vue
+++ b/src/components/stepforms/widgets/DateComponents/CustomVariableList.vue
@@ -7,7 +7,7 @@
     />
     <VariableListOption
       class="widget-custom-variable-list__custom-option"
-      label="Custom"
+      :label="customLabel"
       identifier="custom"
       :selectedVariables="selectedVariables"
       @input="selectCustomVariable"
@@ -34,6 +34,14 @@ export default class CustomVariableList extends Vue {
 
   @Prop({ default: () => [] })
   availableVariables!: VariablesBucket;
+
+  @Prop({ default: () => true })
+  enableRelativeDate!: boolean;
+
+  get customLabel(): string {
+    // use specific "Fixed" label when relative date is not enabled
+    return this.enableRelativeDate ? 'Custom' : 'Calendar';
+  }
 
   chooseVariable(variableIdentifier: string) {
     this.$emit('input', variableIdentifier);

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -12,11 +12,13 @@
           class="widget-date-input__editor-side"
           :availableVariables="availableVariables"
           :selectedVariables="selectedVariables"
+          :enableRelativeDate="enableRelativeDate"
           @selectCustomVariable="editCustomVariable"
           @input="selectVariable"
         />
         <div class="widget-date-input__editor-content" v-show="isCustom" ref="custom-editor">
           <Tabs
+            v-if="enableRelativeDate"
             class="widget-date-input__editor-header"
             :tabs="tabs"
             :selectedTab="selectedTab"
@@ -103,6 +105,9 @@ export default class DateRangeInput extends Vue {
   @Prop({ default: () => ({ start: '', end: '' }) })
   variableDelimiters!: VariableDelimiters;
 
+  @Prop({ default: () => true })
+  enableRelativeDate!: boolean;
+
   isEditorOpened = false;
   isEditingCustomVariable = false; // force to expand custom part of editor
   alignLeft: string = POPOVER_ALIGN.LEFT;
@@ -182,6 +187,10 @@ export default class DateRangeInput extends Vue {
     } else if (isRelativeDateRange(this.value)) {
       this.tabsValues.Dynamic = this.value;
       this.selectTab('Dynamic');
+    }
+    // force fixed tab by default if relative date is not enabled
+    if (!this.enableRelativeDate) {
+      this.selectTab('Fixed');
     }
   }
 

--- a/stories/dates/date-range-input.js
+++ b/stories/dates/date-range-input.js
@@ -160,3 +160,31 @@ stories.add('custom (relative date range)', () => ({
     };
   },
 }));
+
+stories.add('without relative date enabled', () => ({
+  template: `
+    <div>
+      <DateRangeInput 
+        :available-variables="availableVariables" 
+        :relative-available-variables="relativeAvailableVariables" 
+        :variable-delimiters="variableDelimiters" 
+        enableRelativeDate="false"
+        v-model="value" 
+      />
+      <pre>{{ value }}</pre>
+    </div>
+  `,
+
+  components: {
+    DateRangeInput,
+  },
+
+  data() {
+    return {
+      availableVariables: SAMPLE_VARIABLES,
+      variableDelimiters: { start: '{{', end: '}}'},
+      relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
+      value: undefined,
+    };
+  },
+}));

--- a/tests/unit/custom-variable-list.spec.ts
+++ b/tests/unit/custom-variable-list.spec.ts
@@ -2,6 +2,45 @@ import { shallowMount, Wrapper } from '@vue/test-utils';
 
 import CustomVariableList from '@/components/stepforms/widgets/DateComponents/CustomVariableList.vue';
 
+const AVAILABLE_VARIABLES = [
+  {
+    category: 'App variables',
+    label: 'view',
+    identifier: 'appRequesters.view',
+    value: 'Product 123',
+  },
+  {
+    category: 'App variables',
+    label: 'date.month',
+    identifier: 'appRequesters.date.month',
+    value: 'Apr',
+  },
+  {
+    category: 'App variables',
+    label: 'date.year',
+    identifier: 'appRequesters.date.year',
+    value: '2020',
+  },
+  {
+    category: 'App variables',
+    label: 'date.today',
+    identifier: 'appRequesters.date.today',
+    value: new Date(1623398957013),
+  },
+  {
+    category: 'Story variables',
+    label: 'country',
+    identifier: 'requestersManager.country',
+    value: '2020',
+  },
+  {
+    category: 'Story variables',
+    label: 'city',
+    identifier: 'appRequesters.city',
+    value: 'New York',
+  },
+];
+
 describe('Custom variable list', () => {
   let wrapper: Wrapper<CustomVariableList>;
 
@@ -9,44 +48,7 @@ describe('Custom variable list', () => {
     wrapper = shallowMount(CustomVariableList, {
       sync: false,
       propsData: {
-        availableVariables: [
-          {
-            category: 'App variables',
-            label: 'view',
-            identifier: 'appRequesters.view',
-            value: 'Product 123',
-          },
-          {
-            category: 'App variables',
-            label: 'date.month',
-            identifier: 'appRequesters.date.month',
-            value: 'Apr',
-          },
-          {
-            category: 'App variables',
-            label: 'date.year',
-            identifier: 'appRequesters.date.year',
-            value: '2020',
-          },
-          {
-            category: 'App variables',
-            label: 'date.today',
-            identifier: 'appRequesters.date.today',
-            value: new Date(1623398957013),
-          },
-          {
-            category: 'Story variables',
-            label: 'country',
-            identifier: 'requestersManager.country',
-            value: '2020',
-          },
-          {
-            category: 'Story variables',
-            label: 'city',
-            identifier: 'appRequesters.city',
-            value: 'New York',
-          },
-        ],
+        availableVariables: AVAILABLE_VARIABLES,
       },
     });
   });
@@ -60,6 +62,9 @@ describe('Custom variable list', () => {
   });
 
   it('should display an "Custom" option ...', () => {
+    expect(wrapper.find('.widget-custom-variable-list__custom-option').props().label).toBe(
+      'Custom',
+    );
     expect(wrapper.find('.widget-custom-variable-list__custom-option').exists()).toBe(true);
   });
 
@@ -87,6 +92,27 @@ describe('Custom variable list', () => {
   });
 });
 
+describe('Custom variable list - with disabled relative date', () => {
+  let wrapper: Wrapper<CustomVariableList>;
+  beforeEach(() => {
+    wrapper = shallowMount(CustomVariableList, {
+      sync: false,
+      propsData: {
+        availableVariables: AVAILABLE_VARIABLES,
+        enableRelativeDate: false,
+      },
+    });
+  });
+  afterEach(() => {
+    wrapper.destroy();
+  });
+  it('should display an "Calendar" option ...', () => {
+    expect(wrapper.find('.widget-custom-variable-list__custom-option').props().label).toBe(
+      'Calendar',
+    );
+  });
+});
+
 describe('Custom variable list - empty', () => {
   let wrapper: Wrapper<CustomVariableList>;
   beforeEach(() => {
@@ -100,5 +126,8 @@ describe('Custom variable list - empty', () => {
   });
   it('should set availableVariables to empty array', () => {
     expect((wrapper.vm as any).availableVariables).toStrictEqual([]);
+  });
+  it('should set enableRelativeDate to true', () => {
+    expect((wrapper.vm as any).enableRelativeDate).toBe(true);
   });
 });

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -346,7 +346,7 @@ describe('Date range input', () => {
       expect(wrapper.find('Tabs-stub').exists()).toBe(false);
     });
     it('should always use "Fixed" as selected tab', () => {
-      expect(wrapper.find('Tabs-stub').props().selectedTab).toBe('Fixed');
+      expect((wrapper.vm as any).selectedTab).toBe('Fixed');
     });
     it('should pass disabled relative date disabled to custom variable list', () => {
       expect(wrapper.find('CustomVariableList-stub').props().enableRelativeDate).toBe(false);

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -346,9 +346,9 @@ describe('Date range input', () => {
       expect(wrapper.find('Tabs-stub').exists()).toBe(false);
     });
     it('should always use "Fixed" as selected tab', () => {
-      expect((wrapper.vm as any).selectedTab).toBe('Fixed');
+      expect(wrapper.find('RangeCalendar-stub').exists()).toBe(true);
     });
-    it('should pass disabled relative date disabled to custom variable list', () => {
+    it('should pass down disabled relative date props to custom variable list', () => {
       expect(wrapper.find('CustomVariableList-stub').props().enableRelativeDate).toBe(false);
     });
   });

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -334,6 +334,25 @@ describe('Date range input', () => {
     });
   });
 
+  describe('with relative date disabled', () => {
+    beforeEach(() => {
+      createWrapper({
+        availableVariables: SAMPLE_VARIABLES,
+        variableDelimiters: { start: '{{', end: '}}' },
+        enableRelativeDate: false,
+      });
+    });
+    it('should have no tabs', () => {
+      expect(wrapper.find('Tabs-stub').exists()).toBe(false);
+    });
+    it('should always use "Fixed" as selected tab', () => {
+      expect(wrapper.find('Tabs-stub').props().selectedTab).toBe('Fixed');
+    });
+    it('should pass disabled relative date disabled to custom variable list', () => {
+      expect(wrapper.find('CustomVariableList-stub').props().enableRelativeDate).toBe(false);
+    });
+  });
+
   describe('empty', () => {
     beforeEach(() => {
       createWrapper();


### PR DESCRIPTION
Add a new prop enableRelativeDate to date range input
I false, it will hide the tabs 'Fixed'/'Dynamic' and use Fixed tab as default tab
Add specific label to custom variable list custom button if enableRelativeDate is false