### PR TITLE
feat(date-range-input): add props to define bounds for calendar as date range

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -6,6 +6,7 @@
     :select-attribute="selectedDatesStyle"
     :drag-attribute="rangeSelectedDatesStyle"
     :is-range="isRange"
+    :from-date="defaultDate"
     timeformat="UTC"
     @input="onInput"
   />
@@ -35,6 +36,9 @@ export default class Calendar extends Vue {
 
   @Prop({ default: false })
   isRange!: boolean;
+
+  @Prop({ default: undefined })
+  defaultDate!: Date | undefined; // used only to move calendar cursor to specified date
 
   get selectedDatesStyle(): DatePickerHighlight {
     return {

--- a/src/components/RangeCalendar.vue
+++ b/src/components/RangeCalendar.vue
@@ -5,6 +5,7 @@
       :value="value.start"
       :availableDates="getAvailableDates('start')"
       :highlightedDates="highlightedDates"
+      :defaultDate="valueWithBounds.start"
       @input="onInput($event, 'start')"
     />
     <Calendar
@@ -12,6 +13,7 @@
       :value="value.end"
       :availableDates="getAvailableDates('end')"
       :highlightedDates="highlightedDates"
+      :defaultDate="valueWithBounds.end"
       @input="onInput($event, 'end')"
     />
   </div>

--- a/src/components/RangeCalendar.vue
+++ b/src/components/RangeCalendar.vue
@@ -34,18 +34,28 @@ export default class RangeCalendar extends Vue {
   @Prop({ default: () => ({}) })
   value!: DateRange;
 
+  @Prop({ default: () => ({}) })
+  bounds!: DateRange;
+
   // dates to highlight in calendar to fake a range mode
   get highlightedDates(): DateRange | undefined {
     return this.value.start && this.value.end ? this.value : undefined;
   }
 
+  get valueWithBounds(): DateRange {
+    return {
+      start: this.value.start ?? this.bounds.start,
+      end: this.value.end ?? this.bounds.end,
+    };
+  }
+
   getAvailableDates(prop: DateRangeSide): DateRange {
     if (prop === 'start') {
-      // start value can be anything before end value
-      return { start: undefined, end: this.value.end };
+      // start value can be anything between bounds start and valueWithBounds end (bound or value)
+      return { start: this.bounds.start, end: this.valueWithBounds.end };
     } else {
-      // end value can be anything after start value
-      return { start: this.value.start, end: undefined };
+      // end value can be anything between valueWithBounds start (bound or value) and bounds end
+      return { start: this.valueWithBounds.start, end: this.bounds.end };
     }
   }
 

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -25,7 +25,7 @@
             @tabSelected="selectTab"
           />
           <div class="widget-date-input__editor-body">
-            <RangeCalendar v-if="isFixedTabSelected" v-model="currentTabValue" />
+            <RangeCalendar v-if="isFixedTabSelected" v-model="currentTabValue" :bounds="bounds" />
             <RelativeDateRangeForm
               v-else
               v-model="currentTabValue"
@@ -63,6 +63,7 @@ import RangeCalendar from '@/components/RangeCalendar.vue';
 import Tabs from '@/components/Tabs.vue';
 import {
   CustomDateRange,
+  DateRange,
   dateRangeToString,
   isDateRange,
   isRelativeDateRange,
@@ -107,6 +108,9 @@ export default class DateRangeInput extends Vue {
 
   @Prop({ default: () => true })
   enableRelativeDate!: boolean;
+
+  @Prop({ default: () => ({}) })
+  bounds!: DateRange;
 
   isEditorOpened = false;
   isEditingCustomVariable = false; // force to expand custom part of editor

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -123,7 +123,7 @@ export default class DateRangeInput extends Vue {
 
   // keep each tab value in memory to enable to switch between tabs without loosing content
   tabsValues: Record<string, CustomDateRange> = {
-    Fixed: { start: new Date() },
+    Fixed: {},
     Dynamic: { date: '', quantity: -1, duration: 'year' },
   };
 

--- a/stories/calendar.js
+++ b/stories/calendar.js
@@ -67,9 +67,9 @@ stories.add('range', () => ({
 stories.add('with highlighted dates', () => ({
   components: { Calendar },
   data() {
-    return { 
+    return {
       value: new Date('01/01/2021'),
-      highlightedDates: { start: new Date('02/01/2021'), end: new Date('01/01/2021') } 
+      highlightedDates: { start: new Date('02/01/2021'), end: new Date('01/01/2021') },
     };
   },
   computed: {
@@ -87,6 +87,40 @@ stories.add('with highlighted dates', () => ({
       <Calendar 
         :value="value"
         :highlightedDates="highlightedDates"
+        @input="input"
+      />
+      <pre>{{ formattedValue }}</pre>
+    </div>
+  `,
+}));
+
+stories.add('with available dates and default date', () => ({
+  components: { Calendar },
+  data() {
+    return { value: undefined };
+  },
+  computed: {
+    formattedValue() {
+      return formatValue(this.value);
+    },
+    availableDates() {
+      return { start: new Date(2020, 11), end: new Date(2021, 1) };
+    },
+    defaultDate() {
+      return new Date(2020, 12); // calendar should open on december month until a value is selected
+    },
+  },
+  methods: {
+    input(value) {
+      this.value = value;
+    },
+  },
+  template: `
+    <div>
+      <Calendar 
+        :value="value"
+        :availableDates="availableDates"
+        :defaultDate="defaultDate"
         @input="input"
       />
       <pre>{{ formattedValue }}</pre>

--- a/stories/dates/date-range-input.js
+++ b/stories/dates/date-range-input.js
@@ -161,14 +161,15 @@ stories.add('custom (relative date range)', () => ({
   },
 }));
 
-stories.add('without relative date enabled', () => ({
+stories.add('without relative date enabled and bounds', () => ({
   template: `
     <div>
       <DateRangeInput 
         :available-variables="availableVariables" 
         :relative-available-variables="relativeAvailableVariables" 
         :variable-delimiters="variableDelimiters" 
-        enableRelativeDate="false"
+        :enableRelativeDate="false"
+        :bounds="bounds"
         v-model="value" 
       />
       <pre>{{ value }}</pre>
@@ -185,6 +186,7 @@ stories.add('without relative date enabled', () => ({
       variableDelimiters: { start: '{{', end: '}}'},
       relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
       value: undefined,
+      bounds: { start: new Date(2021, 7), end: new Date(2021, 8) },
     };
   },
 }));

--- a/stories/range-calendar.js
+++ b/stories/range-calendar.js
@@ -37,3 +37,36 @@ stories.add('simple', () => ({
     </div>
   `,
 }));
+
+stories.add('with bounds', () => ({
+  components: { RangeCalendar },
+  data() {
+    return { value: { start: undefined, end: undefined } };
+  },
+  computed: {
+    formattedValue() {
+      return {
+        start: formatValue(this.value.start),
+        end: formatValue(this.value.end),
+      };
+    },
+    bounds() {
+      return { start: new Date(2020, 11), end: new Date(2021, 1) }
+    }
+  },
+  methods: {
+    input(value) {
+      this.value = value;
+    },
+  },
+  template: `
+    <div>
+      <RangeCalendar 
+        :value="value"
+        :bounds="bounds"
+        @input="input"
+      />
+      <pre>{{ formattedValue }}</pre>
+    </div>
+  `,
+}));

--- a/tests/unit/calendar.spec.ts
+++ b/tests/unit/calendar.spec.ts
@@ -81,4 +81,16 @@ describe('Calendar', () => {
       expect(attributes[0].dates).toStrictEqual(highlightedDates);
     });
   });
+
+  describe('with defaultDate', () => {
+    const defaultDate = new Date(1000);
+    beforeEach(() => {
+      createWrapper({ defaultDate });
+    });
+    it('should move calendar cursor to defaultDate', () => {
+      expect(wrapper.find('DatePicker-stub').attributes('from-date')).toStrictEqual(
+        defaultDate.toString(),
+      );
+    });
+  });
 });

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -374,6 +374,9 @@ describe('Date range input', () => {
     it('should set selected variable to undefined', () => {
       expect((wrapper.vm as any).variable).toBeUndefined();
     });
+    it('should set bounds to empty date range', () => {
+      expect((wrapper.vm as any).bounds).toStrictEqual({});
+    });
     it('should pass empty string as selected variable to CustomVariableList', () => {
       expect(wrapper.find('CustomVariableList-stub').props().selectedVariables).toStrictEqual('');
     });

--- a/tests/unit/range-calendar.spec.ts
+++ b/tests/unit/range-calendar.spec.ts
@@ -4,7 +4,8 @@ import RangeCalendar from '@/components/RangeCalendar.vue';
 
 describe('RangeCalendar', () => {
   let wrapper: Wrapper<RangeCalendar>;
-  const value = { start: new Date(), end: new Date(1) };
+  const value = { start: new Date(2021, 10, 25), end: new Date(2021, 10, 28) };
+  const bounds = { start: new Date(2021, 9), end: new Date(2021, 12) };
   const createWrapper = (props: any = {}): void => {
     wrapper = shallowMount(RangeCalendar, {
       sync: false,
@@ -40,13 +41,13 @@ describe('RangeCalendar', () => {
       expect(calendars.at(1).props().availableDates).toStrictEqual({ ...value, end: undefined }); // value can't be lower than start
     });
     it('should emit modified start range when first Calendar is updated', () => {
-      const date = new Date(1);
+      const date = new Date(2021, 10, 15);
       const calendars = wrapper.findAll('Calendar-stub');
       calendars.at(0).vm.$emit('input', date);
       expect(wrapper.emitted('input')[0][0]).toStrictEqual({ ...value, start: date });
     });
     it('should emit modified end range when last Calendar is updated', () => {
-      const date = new Date(2);
+      const date = new Date(2021, 10, 26);
       const calendars = wrapper.findAll('Calendar-stub');
       calendars.at(1).vm.$emit('input', date);
       expect(wrapper.emitted('input')[0][0]).toStrictEqual({ ...value, end: date });
@@ -61,15 +62,44 @@ describe('RangeCalendar', () => {
       const calendar = wrapper.find('Calendar-stub');
       expect(calendar.props().highlightedDates).toStrictEqual(value);
     });
+    describe('with bounds', () => {
+      beforeEach(() => {
+        wrapper.setProps({ bounds });
+      });
+      it('should pass available dates updated with bounds', () => {
+        const calendars = wrapper.findAll('Calendar-stub');
+        expect(calendars.at(0).props().availableDates).toStrictEqual({
+          start: bounds.start,
+          end: value.end,
+        });
+        expect(calendars.at(1).props().availableDates).toStrictEqual({
+          start: value.start,
+          end: bounds.end,
+        });
+      });
+    });
   });
 
   describe('when range is not complete', () => {
     beforeEach(() => {
-      createWrapper({ value: { start: new Date() } });
+      createWrapper({ value: { start: new Date(2021, 10, 25) } });
     });
     it('should not pass range included dates to highlight in Calendar', () => {
       const calendar = wrapper.find('Calendar-stub');
       expect(calendar.props().highlightedDates).toStrictEqual(undefined);
+    });
+    describe('with bounds', () => {
+      beforeEach(() => {
+        wrapper.setProps({ bounds });
+      });
+      it('should pass available dates updated with bounds', () => {
+        const calendars = wrapper.findAll('Calendar-stub');
+        expect(calendars.at(0).props().availableDates).toStrictEqual(bounds);
+        expect(calendars.at(1).props().availableDates).toStrictEqual({
+          start: value.start,
+          end: bounds.end,
+        });
+      });
     });
   });
 
@@ -79,6 +109,16 @@ describe('RangeCalendar', () => {
     });
     it('should set value to {} by default', () => {
       expect((wrapper.vm as any).value).toStrictEqual({});
+    });
+    describe('with bounds', () => {
+      beforeEach(() => {
+        wrapper.setProps({ bounds });
+      });
+      it('should pass bounds as available dates', () => {
+        const calendars = wrapper.findAll('Calendar-stub');
+        expect(calendars.at(0).props().availableDates).toStrictEqual(bounds);
+        expect(calendars.at(1).props().availableDates).toStrictEqual(bounds);
+      });
     });
   });
 });

--- a/tests/unit/range-calendar.spec.ts
+++ b/tests/unit/range-calendar.spec.ts
@@ -40,6 +40,11 @@ describe('RangeCalendar', () => {
       expect(calendars.at(0).props().availableDates).toStrictEqual({ ...value, start: undefined }); // value can't be greater than end
       expect(calendars.at(1).props().availableDates).toStrictEqual({ ...value, end: undefined }); // value can't be lower than start
     });
+    it('should pass correct default dates to Calendar components', () => {
+      const calendars = wrapper.findAll('Calendar-stub');
+      expect(calendars.at(0).props().defaultDate).toStrictEqual(value.start);
+      expect(calendars.at(1).props().defaultDate).toStrictEqual(value.end);
+    });
     it('should emit modified start range when first Calendar is updated', () => {
       const date = new Date(2021, 10, 15);
       const calendars = wrapper.findAll('Calendar-stub');
@@ -77,6 +82,11 @@ describe('RangeCalendar', () => {
           end: bounds.end,
         });
       });
+      it('should pass correct default dates to Calendar components', () => {
+        const calendars = wrapper.findAll('Calendar-stub');
+        expect(calendars.at(0).props().defaultDate).toStrictEqual(value.start);
+        expect(calendars.at(1).props().defaultDate).toStrictEqual(value.end);
+      });
     });
   });
 
@@ -87,6 +97,11 @@ describe('RangeCalendar', () => {
     it('should not pass range included dates to highlight in Calendar', () => {
       const calendar = wrapper.find('Calendar-stub');
       expect(calendar.props().highlightedDates).toStrictEqual(undefined);
+    });
+    it('should pass correct default dates to Calendar components', () => {
+      const calendars = wrapper.findAll('Calendar-stub');
+      expect(calendars.at(0).props().defaultDate).toStrictEqual(value.start);
+      expect(calendars.at(1).props().defaultDate).toStrictEqual(undefined);
     });
     describe('with bounds', () => {
       beforeEach(() => {
@@ -100,6 +115,11 @@ describe('RangeCalendar', () => {
           end: bounds.end,
         });
       });
+      it('should pass correct default dates to Calendar components', () => {
+        const calendars = wrapper.findAll('Calendar-stub');
+        expect(calendars.at(0).props().defaultDate).toStrictEqual(value.start);
+        expect(calendars.at(1).props().defaultDate).toStrictEqual(bounds.end);
+      });
     });
   });
 
@@ -110,6 +130,11 @@ describe('RangeCalendar', () => {
     it('should set value to {} by default', () => {
       expect((wrapper.vm as any).value).toStrictEqual({});
     });
+    it('should pass correct default dates to Calendar components', () => {
+      const calendars = wrapper.findAll('Calendar-stub');
+      expect(calendars.at(0).props().defaultDate).toStrictEqual(undefined);
+      expect(calendars.at(1).props().defaultDate).toStrictEqual(undefined);
+    });
     describe('with bounds', () => {
       beforeEach(() => {
         wrapper.setProps({ bounds });
@@ -118,6 +143,11 @@ describe('RangeCalendar', () => {
         const calendars = wrapper.findAll('Calendar-stub');
         expect(calendars.at(0).props().availableDates).toStrictEqual(bounds);
         expect(calendars.at(1).props().availableDates).toStrictEqual(bounds);
+      });
+      it('should pass correct default dates to Calendar components', () => {
+        const calendars = wrapper.findAll('Calendar-stub');
+        expect(calendars.at(0).props().defaultDate).toStrictEqual(bounds.start);
+        expect(calendars.at(1).props().defaultDate).toStrictEqual(bounds.end);
       });
     });
   });


### PR DESCRIPTION
1. Add props to date-range input to declare bounds as a date range
2. Remove default start date for fixed tab (new Date()), because it can be outside of the bounds so we prefer not to select anything on default
3. Update available dates in range calendar to make it work with bounds (rule is: use value to define bunds first, if inexstant, use bounds, used bound depends on date range side (start/end) )
4. Add a new default date props to put cursor of calendar (open calendar on specific month)
5. Put cursor of calendar on bounds if no value is provided in range calendar

Example with bounds only and no value (will put defaultDate to bounds automatically): 
![bouns](https://user-images.githubusercontent.com/59559689/136021398-13bd741b-f68d-433e-b61a-b1ab8cef4ee6.gif)
