### PR TITLE
feat(date-range-input): replace range-calendar with unique calendar using a range

### DIFF
--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -25,7 +25,7 @@
             @tabSelected="selectTab"
           />
           <div class="widget-date-input__editor-body">
-            <RangeCalendar v-if="isFixedTabSelected" v-model="currentTabValue" />
+            <Calendar v-if="isFixedTabSelected" v-model="currentTabValue" isRange />
             <RelativeDateRangeForm
               v-else
               v-model="currentTabValue"
@@ -57,7 +57,7 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import { POPOVER_ALIGN } from '@/components/constants';
-import RangeCalendar from '@/components/DatePicker/RangeCalendar.vue';
+import Calendar from '@/components/DatePicker/Calendar.vue';
 import FAIcon from '@/components/FAIcon.vue';
 import Popover from '@/components/Popover.vue';
 import Tabs from '@/components/Tabs.vue';
@@ -78,7 +78,7 @@ import {
 import CustomVariableList from './CustomVariableList.vue';
 import RelativeDateRangeForm from './RelativeDateRangeForm.vue';
 /**
- * This component allow to select a variable or to switch between tabs and select a date range on a Fixed (RangeCalendar) or Dynamic way (RelativeDateRangeForm),
+ * This component allow to select a variable or to switch between tabs and select a date range on a Fixed (Calendar) or Dynamic way (RelativeDateRangeForm),
  * each tab value is keeped in memory to avoid user to loose data when switching between tabs
  */
 @Component({
@@ -87,7 +87,7 @@ import RelativeDateRangeForm from './RelativeDateRangeForm.vue';
     CustomVariableList,
     Popover,
     Tabs,
-    RangeCalendar,
+    Calendar,
     RelativeDateRangeForm,
     FAIcon,
   },
@@ -311,7 +311,6 @@ $active-color-dark: #16406a;
   flex: 1;
   height: 276px;
   min-height: 276px;
-  width: 542px;
   .range-calendar {
     margin: -1px;
     width: 100%;

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -200,14 +200,14 @@ describe('Date range input', () => {
         await wrapper.vm.$nextTick();
       });
       it('should display correct body component', () => {
-        expect(wrapper.find('RangeCalendar-stub').exists()).toBe(true);
+        expect(wrapper.find('Calendar-stub').exists()).toBe(true);
         expect(wrapper.find('RelativeDateRangeForm-stub').exists()).toBe(false);
       });
 
-      describe('when updating RangeCalendar value', () => {
+      describe('when updating Calendar value', () => {
         const newValue = { start: new Date(8), end: new Date(11) };
         beforeEach(async () => {
-          wrapper.find('RangeCalendar-stub').vm.$emit('input', newValue);
+          wrapper.find('Calendar-stub').vm.$emit('input', newValue);
           await wrapper.vm.$nextTick();
         });
         it('should update tab value', () => {
@@ -223,7 +223,7 @@ describe('Date range input', () => {
       });
       it('should display correct body component', () => {
         expect(wrapper.find('RelativeDateRangeForm-stub').exists()).toBe(true);
-        expect(wrapper.find('RangeCalendar-stub').exists()).toBe(false);
+        expect(wrapper.find('Calendar-stub').exists()).toBe(false);
       });
 
       describe('when updating RelativeDateRangeForm value', () => {
@@ -239,16 +239,16 @@ describe('Date range input', () => {
     });
 
     describe('when switching between tabs', () => {
-      const updatedRangeCalendarValue = { start: new Date(1), end: new Date(100000) };
+      const updatedCalendarValue = { start: new Date(1), end: new Date(100000) };
       beforeEach(async () => {
-        wrapper.find('RangeCalendar-stub').vm.$emit('input', updatedRangeCalendarValue); // update RangeCalendar value
+        wrapper.find('Calendar-stub').vm.$emit('input', updatedCalendarValue); // update Calendar value
         await wrapper.vm.$nextTick();
         wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'Dynamic'); // switching to the other tab
         await wrapper.vm.$nextTick();
         wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'Fixed'); // come back to previous tab
       });
       it('should not remove other tab value', () => {
-        expect(wrapper.find('RangeCalendar-stub').props().value).toBe(updatedRangeCalendarValue);
+        expect(wrapper.find('Calendar-stub').props().value).toBe(updatedCalendarValue);
       });
     });
   });
@@ -296,8 +296,8 @@ describe('Date range input', () => {
       expect(wrapper.find('Tabs-stub').props().selectedTab).toBe('Fixed');
     });
 
-    it('should preselect value in RangeCalendar', () => {
-      expect(wrapper.find('RangeCalendar-stub').props().value).toStrictEqual(value);
+    it('should preselect value in Calendar', () => {
+      expect(wrapper.find('Calendar-stub').props().value).toStrictEqual(value);
     });
   });
 
@@ -346,7 +346,7 @@ describe('Date range input', () => {
       expect(wrapper.find('Tabs-stub').exists()).toBe(false);
     });
     it('should always use "Fixed" as selected tab', () => {
-      expect(wrapper.find('RangeCalendar-stub').exists()).toBe(true);
+      expect(wrapper.find('Calendar-stub').exists()).toBe(true);
     });
     it('should pass down disabled relative date props to custom variable list', () => {
       expect(wrapper.find('CustomVariableList-stub').props().enableRelativeDate).toBe(false);


### PR DESCRIPTION
Before: we used range calendar component (two calendar next to each other)
![before](https://user-images.githubusercontent.com/59559689/136203347-0a4698a9-85c6-4353-a2cc-47edaf4caccd.gif)

After: we use a single calendar with isRange prop to true
![one-calendar-only](https://user-images.githubusercontent.com/59559689/136203394-b107e5d1-9c5c-4714-a483-11d56c33f110.gif)

