### PR TITLE
feat(dates-component): add a disabled state to save date button when tab value is incomplete

### DIFF
--- a/src/components/DatePicker/Calendar.vue
+++ b/src/components/DatePicker/Calendar.vue
@@ -8,6 +8,7 @@
     :is-range="isRange"
     timeformat="UTC"
     @input="onInput"
+    @drag="onDrag"
   />
 </template>
 
@@ -69,6 +70,11 @@ export default class Calendar extends Vue {
   /* istanbul ignore next */
   onInput(value: Date | DateRange | undefined): void {
     this.$emit('input', value);
+  }
+
+  // emit partial date range when dragging range to disable validate button
+  onDrag(dragValue: DateRange): void {
+    this.$emit('input', { start: dragValue.start });
   }
 }
 </script>

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -42,7 +42,9 @@
             />
             <div
               class="widget-date-input__editor-button widget-date-input__editor-button--primary"
+              :class="{ 'widget-date-input__editor-button--disabled': hasInvalidTabValue }"
               ref="save"
+              :disabled="hasInvalidTabValue"
               @click="saveCustomVariable"
               v-text="'Set date'"
             />
@@ -119,7 +121,7 @@ export default class DateRangeInput extends Vue {
 
   // keep each tab value in memory to enable to switch between tabs without loosing content
   tabsValues: Record<string, CustomDateRange> = {
-    Fixed: { start: new Date() },
+    Fixed: {},
     Dynamic: { date: '', quantity: -1, duration: 'year' },
   };
 
@@ -172,6 +174,18 @@ export default class DateRangeInput extends Vue {
       );
     } else {
       return 'Select a date';
+    }
+  }
+
+  get hasInvalidTabValue(): boolean {
+    if (this.isFixedTabSelected) {
+      return (
+        !isDateRange(this.currentTabValue) ||
+        !this.currentTabValue.start ||
+        !this.currentTabValue.end
+      );
+    } else {
+      return !isRelativeDateRange(this.currentTabValue) || !this.currentTabValue.date;
     }
   }
 

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -362,4 +362,8 @@ $active-color-dark: #16406a;
     background: $active-color-dark;
   }
 }
+.widget-date-input__editor-button--disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
 </style>

--- a/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -35,7 +35,9 @@
             />
             <div
               class="widget-date-input__editor-button widget-date-input__editor-button--primary"
+              :class="{ 'widget-date-input__editor-button--disabled': hasInvalidTabValue }"
               ref="save"
+              :disabled="hasInvalidTabValue"
               @click="saveCustomVariable"
               v-text="'Set date'"
             />
@@ -99,16 +101,16 @@ export default class NewDateInput extends Vue {
   }
 
   // keep each tab value in memory to enable to switch between tabs without loosing content
-  tabsValues: Record<string, CustomDate> = {
-    Fixed: new Date(),
+  tabsValues: Record<string, CustomDate | undefined> = {
+    Fixed: undefined,
     Dynamic: { quantity: -1, duration: 'year' },
   };
 
-  get currentTabValue(): CustomDate {
+  get currentTabValue(): CustomDate | undefined {
     return this.tabsValues[this.selectedTab];
   }
 
-  set currentTabValue(value: CustomDate) {
+  set currentTabValue(value: CustomDate | undefined) {
     this.tabsValues[this.selectedTab] = value;
   }
 
@@ -150,6 +152,14 @@ export default class NewDateInput extends Vue {
     } else {
       return 'Select a date';
     }
+  }
+
+  get hasInvalidTabValue(): boolean {
+    if (this.isFixedTabSelected) {
+      return !(this.currentTabValue instanceof Date);
+    }
+    // relative tab is always valid because default value is already complete
+    return false;
   }
 
   created() {

--- a/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -327,4 +327,8 @@ $active-color-dark: #16406a;
     background: $active-color-dark;
   }
 }
+.widget-date-input__editor-button--disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
 </style>

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -68,7 +68,7 @@ $active-color-extra-light: #f8f7fa;
 }
 .widget-relative-date-form__quantity {
   flex: 1 25%;
-  margin: 0;
+  margin: 0 !important;
   background: $active-color-extra-light;
 
   ::v-deep .widget-input-number__container {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -81,7 +81,7 @@ export const isRelativeDateRange = (
   return _has(value, 'date') && _has(value, 'duration') && _has(value, 'quantity');
 };
 
-export const isDateRange = (value: string | CustomDateRange): value is DateRange => {
+export const isDateRange = (value: undefined | string | CustomDateRange): value is DateRange => {
   if (!(value instanceof Object)) return false;
   return Object.keys(value).length === 0 || _has(value, 'start') || _has(value, 'end');
 };

--- a/tests/unit/calendar.spec.ts
+++ b/tests/unit/calendar.spec.ts
@@ -64,6 +64,11 @@ describe('Calendar', () => {
       wrapper.find('DatePicker-stub').vm.$emit('input', value);
       expect(wrapper.emitted('input')[0][0]).toStrictEqual(value);
     });
+    it('should emit start date only when datepicker is dragged (range update)', () => {
+      const value = { start: new Date(), end: new Date(2) };
+      (wrapper.vm as any).onDrag(value); // drag event is not found by stub
+      expect(wrapper.emitted('input')[0][0]).toStrictEqual({ start: value.start });
+    });
   });
 
   describe('with highlighted dates', () => {

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -152,12 +152,10 @@ describe('Date range input', () => {
   });
 
   describe('custom editor', () => {
-    const value = { start: new Date(), end: new Date(1) };
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
         variableDelimiters: { start: '{{', end: '}}' },
-        value,
       });
     });
 
@@ -182,10 +180,11 @@ describe('Date range input', () => {
     });
 
     describe('when clicking on save button', () => {
-      const editedValue = { start: new Date(1), end: new Date(11) };
+      const editedValue = { date: '{{today}}', quantity: -1, duration: 'month' };
 
       beforeEach(async () => {
-        wrapper.setData({ currentTabValue: editedValue });
+        wrapper.find('RelativeDateRangeForm-stub').vm.$emit('input', editedValue);
+        await wrapper.vm.$nextTick();
         wrapper.find({ ref: 'save' }).trigger('click');
         await wrapper.vm.$nextTick();
       });
@@ -203,6 +202,9 @@ describe('Date range input', () => {
         expect(wrapper.find('Calendar-stub').exists()).toBe(true);
         expect(wrapper.find('RelativeDateRangeForm-stub').exists()).toBe(false);
       });
+      it('should have a disabled save button', () => {
+        expect(wrapper.find({ ref: 'save' }).attributes('disabled')).toBe('disabled');
+      });
 
       describe('when updating Calendar value', () => {
         const newValue = { start: new Date(8), end: new Date(11) };
@@ -212,6 +214,9 @@ describe('Date range input', () => {
         });
         it('should update tab value', () => {
           expect((wrapper.vm as any).currentTabValue).toStrictEqual(newValue);
+        });
+        it('should have an enabled save button', () => {
+          expect(wrapper.find({ ref: 'save' }).attributes('disabled')).not.toBe('disabled');
         });
       });
     });
@@ -225,6 +230,9 @@ describe('Date range input', () => {
         expect(wrapper.find('RelativeDateRangeForm-stub').exists()).toBe(true);
         expect(wrapper.find('Calendar-stub').exists()).toBe(false);
       });
+      it('should have a disabled save button', () => {
+        expect(wrapper.find({ ref: 'save' }).attributes('disabled')).toBe('disabled');
+      });
 
       describe('when updating RelativeDateRangeForm value', () => {
         const newValue = { date: '{{today}}', quantity: -1, duration: 'month' };
@@ -235,20 +243,25 @@ describe('Date range input', () => {
         it('should update tab value', () => {
           expect((wrapper.vm as any).currentTabValue).toStrictEqual(newValue);
         });
+        it('should have an enabled save button', () => {
+          expect(wrapper.find({ ref: 'save' }).attributes('disabled')).not.toBe('disabled');
+        });
       });
     });
 
     describe('when switching between tabs', () => {
-      const updatedCalendarValue = { start: new Date(1), end: new Date(100000) };
+      const updatedRelativeDateValue = { date: '{{today}}', quantity: -1, duration: 'month' };
       beforeEach(async () => {
-        wrapper.find('Calendar-stub').vm.$emit('input', updatedCalendarValue); // update Calendar value
+        wrapper.find('RelativeDateRangeForm-stub').vm.$emit('input', updatedRelativeDateValue); // update RelativeDateRangeForm value
         await wrapper.vm.$nextTick();
-        wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'Dynamic'); // switching to the other tab
+        wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'Fixed'); // switching to the other tab
         await wrapper.vm.$nextTick();
-        wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'Fixed'); // come back to previous tab
+        wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'Dynamic'); // come back to previous tab
       });
       it('should not remove other tab value', () => {
-        expect(wrapper.find('Calendar-stub').props().value).toBe(updatedCalendarValue);
+        expect(wrapper.find('RelativeDateRangeForm-stub').props().value).toBe(
+          updatedRelativeDateValue,
+        );
       });
     });
   });
@@ -299,6 +312,9 @@ describe('Date range input', () => {
     it('should preselect value in Calendar', () => {
       expect(wrapper.find('Calendar-stub').props().value).toStrictEqual(value);
     });
+    it('should have an enabled save button', () => {
+      expect(wrapper.find({ ref: 'save' }).attributes('disabled')).not.toBe('disabled');
+    });
   });
 
   describe('with selected value as relative date', () => {
@@ -331,6 +347,9 @@ describe('Date range input', () => {
     });
     it('should preselect value in RelativeDateRangeForm', () => {
       expect(wrapper.find('RelativeDateRangeForm-stub').props().value).toStrictEqual(value);
+    });
+    it('should have an enabled save button', () => {
+      expect(wrapper.find({ ref: 'save' }).attributes('disabled')).not.toBe('disabled');
     });
   });
 

--- a/tests/unit/new-date-input.spec.ts
+++ b/tests/unit/new-date-input.spec.ts
@@ -129,12 +129,10 @@ describe('Date input', () => {
   });
 
   describe('custom editor', () => {
-    const value = new Date();
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
         variableDelimiters: { start: '{{', end: '}}' },
-        value,
       });
     });
 
@@ -159,7 +157,7 @@ describe('Date input', () => {
     });
 
     describe('when clicking on save button', () => {
-      const editedValue = new Date(3);
+      const editedValue = { quantity: -1, duration: 'month' };
 
       beforeEach(async () => {
         wrapper.setData({ currentTabValue: editedValue });
@@ -180,6 +178,9 @@ describe('Date input', () => {
         expect(wrapper.find('Calendar-stub').exists()).toBe(true);
         expect(wrapper.find('RelativeDateForm-stub').exists()).toBe(false);
       });
+      it('should have a disabled save button', () => {
+        expect(wrapper.find({ ref: 'save' }).attributes('disabled')).toBe('disabled');
+      });
 
       describe('when updating Calendar value', () => {
         const newValue = new Date(8);
@@ -189,6 +190,9 @@ describe('Date input', () => {
         });
         it('should update tab value', () => {
           expect((wrapper.vm as any).currentTabValue).toStrictEqual(newValue);
+        });
+        it('should have an enabled save button', () => {
+          expect(wrapper.find({ ref: 'save' }).attributes('disabled')).not.toBe('disabled');
         });
       });
     });
@@ -216,16 +220,16 @@ describe('Date input', () => {
     });
 
     describe('when switching between tabs', () => {
-      const updatedCalendarValue = new Date(11);
+      const updatedRelativeDateValue = { quantity: -2, duration: 'month' };
       beforeEach(async () => {
-        wrapper.find('Calendar-stub').vm.$emit('input', updatedCalendarValue); // update Calendar value
+        wrapper.find('RelativeDateForm-stub').vm.$emit('input', updatedRelativeDateValue); // update RelativeDateForm value
         await wrapper.vm.$nextTick();
-        wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'Dynamic'); // switching to the other tab
+        wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'Fixed'); // switching to the other tab
         await wrapper.vm.$nextTick();
-        wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'Fixed'); // come back to previous tab
+        wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'Dynamic'); // come back to previous tab
       });
       it('should not remove other tab value', () => {
-        expect(wrapper.find('Calendar-stub').props().value).toBe(updatedCalendarValue);
+        expect(wrapper.find('RelativeDateForm-stub').props().value).toBe(updatedRelativeDateValue);
       });
     });
   });
@@ -271,6 +275,9 @@ describe('Date input', () => {
 
     it('should preselect value in Calendar', () => {
       expect(wrapper.find('Calendar-stub').props().value).toStrictEqual(value);
+    });
+    it('should have an enabled save button', () => {
+      expect(wrapper.find({ ref: 'save' }).attributes('disabled')).not.toBe('disabled');
     });
   });
 


### PR DESCRIPTION
Add user informations, to notify him if the tab form is well filled or not.

1. Add a disabled state to DateRangeInput and NewDateInput when tab value is incomplete (empty property of DateRange or RelativeDateRange, RelativeDate is always complete as default value need to be passed to add data in form on creation)
2. Add a drag event on calendar to make sure that save button will be disabled during drag
3. Fix some css and apply specific css for disabled buttons

After:
![validation](https://user-images.githubusercontent.com/59559689/136223611-a7cde1a1-1d53-43a0-9950-fdf2710136ea.gif)