### PR TITLE
fix: typo in UI column instead of colum

### DIFF
--- a/src/components/stepforms/AddTextColumnStepForm.vue
+++ b/src/components/stepforms/AddTextColumnStepForm.vue
@@ -9,7 +9,7 @@
     <InputTextWidget
       class="newColumnInput"
       v-model="editedStep.new_column"
-      name="New colum:"
+      name="New column:"
       placeholder="Enter a new column name"
       data-path=".new_column"
       :errors="errors"

--- a/src/components/stepforms/FormulaStepForm.vue
+++ b/src/components/stepforms/FormulaStepForm.vue
@@ -9,7 +9,7 @@
     <InputTextWidget
       class="newColumnInput"
       v-model="editedStep.new_column"
-      name="New colum:"
+      name="New column:"
       placeholder="Enter a new column name"
       data-path=".new_column"
       :errors="errors"

--- a/src/components/stepforms/IfThenElseStepForm.vue
+++ b/src/components/stepforms/IfThenElseStepForm.vue
@@ -9,7 +9,7 @@
     <InputTextWidget
       class="newColumnInput"
       v-model="editedStep.newColumn"
-      name="New colum:"
+      name="New column:"
       placeholder="Enter a name"
       data-path=".newColumn"
       :errors="errors"


### PR DESCRIPTION
There was a typo in the components where a new column name should be specified : colum without a n

This PR fixes that