### PR TITLE
feat(date-range-input): enable user to select relative date as bounds

### DIFF
--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -36,7 +36,7 @@
               <TabbedRangeCalendars
                 v-model="currentTabValue"
                 :enabledCalendars="enabledCalendars"
-                :bounds="bounds"
+                :bounds="boundsAsDateRange"
               />
             </div>
             <RelativeDateRangeForm
@@ -141,12 +141,22 @@ export default class DateRangeInput extends Vue {
   enabledCalendars!: string[] | undefined;
 
   @Prop({ default: () => ({ start: undefined, end: undefined }) })
-  bounds!: DateRange;
+  bounds!: CustomDateRange;
 
   isEditorOpened = false;
   isEditingCustomVariable = false; // force to expand custom part of editor
   alignLeft: string = POPOVER_ALIGN.LEFT;
   selectedTab = 'Dynamic';
+
+  get boundsAsDateRange(): DateRange | undefined {
+    const dateRange = transformValueToDateRange(
+      this.bounds,
+      this.availableVariables,
+      this.relativeAvailableVariables,
+      this.variableDelimiters,
+    );
+    return dateRange;
+  }
 
   get tabs(): string[] {
     return ['Dynamic', 'Fixed'];

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -440,17 +440,20 @@ describe('Date range input', () => {
   });
 
   describe('with bounds', () => {
-    const bounds = { start: new Date('2020/1/1'), end: new Date('2020/6/1') };
+    const bounds: RelativeDateRange = { date: '{{today}}', quantity: 1, duration: 'month' };
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
+        relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '{{', end: '}}' },
         value: { start: new Date('2020/2/1'), end: new Date('2020/3/1') },
         bounds,
       });
     });
-    it('should pass bounds to TabbedRangeCalendars', () => {
-      expect(wrapper.find('TabbedRangeCalendars-stub').props().bounds).toStrictEqual(bounds);
+    it('should pass bounds as date range to TabbedRangeCalendars', () => {
+      const bounds = wrapper.find('TabbedRangeCalendars-stub').props().bounds;
+      expect(bounds).not.toBeUndefined();
+      expect(isDateRange(bounds)).toBe(true);
     });
   });
 


### PR DESCRIPTION
Use new transformValueToDateRange method to enable user to select bounds as relative date