### PR TITLE
fix(new date inputs): close popover when clicking outside

### DIFF
--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -2,11 +2,17 @@
   <div class="widget-date-input">
     <div class="widget-date-input__container">
       <span class="widget-date-input__label" v-html="label" />
-      <div class="widget-date-input__button" @click="openEditor">
+      <div class="widget-date-input__button" @click.stop="openEditor">
         <FAIcon icon="far calendar" />
       </div>
     </div>
-    <popover class="widget-date-input__editor" :visible="isEditorOpened" :align="alignLeft" bottom>
+    <popover
+      class="widget-date-input__editor"
+      :visible="isEditorOpened"
+      :align="alignLeft"
+      bottom
+      @closed="closeEditor"
+    >
       <div class="widget-date-input__editor-container">
         <CustomVariableList
           v-if="hasVariables"

--- a/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -2,11 +2,17 @@
   <div class="widget-date-input">
     <div class="widget-date-input__container">
       <span class="widget-date-input__label">{{ label }}</span>
-      <div class="widget-date-input__button" @click="openEditor">
+      <div class="widget-date-input__button" @click.stop="openEditor">
         <FAIcon icon="far calendar" />
       </div>
     </div>
-    <popover class="widget-date-input__editor" :visible="isEditorOpened" :align="alignLeft" bottom>
+    <popover
+      class="widget-date-input__editor"
+      :visible="isEditorOpened"
+      :align="alignLeft"
+      @closed="closeEditor"
+      bottom
+    >
       <div class="widget-date-input__editor-container">
         <CustomVariableList
           v-if="hasVariables"


### PR DESCRIPTION
Had to stop event propagation on the button opening the popover because it was closing immediatly