### PR TITLE
fix(calendar): use UTC timezone not only time format

### DIFF
--- a/src/components/DatePicker/Calendar.vue
+++ b/src/components/DatePicker/Calendar.vue
@@ -8,6 +8,7 @@
     :is-range="isRange"
     :from-date="defaultDate"
     timeformat="UTC"
+    timezone="UTC"
     @input="onInput"
     @drag="onDrag"
   />


### PR DESCRIPTION
We added a timeformat UTC but not the timezone so the entry dates was calculated as locales dates :wink: 