### PR TITLE
fix(custom calendars): update selected range when swtiching granularity 

### DIFF
--- a/src/components/DatePicker/CustomGranularityCalendar.vue
+++ b/src/components/DatePicker/CustomGranularityCalendar.vue
@@ -40,7 +40,7 @@
 
 <script lang="ts">
 import { DateTime } from 'luxon';
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
 import FAIcon from '@/components/FAIcon.vue';
 import { DateRange } from '@/lib/dates';
@@ -101,6 +101,11 @@ export default class CustomGranularityCalendar extends Vue {
 
   selectRange(date: DateTime) {
     this.$emit('input', this.pickerConfig.selectableRanges.optionToRange(date));
+  }
+
+  @Watch('granularity')
+  updateSelectedRange() {
+    if (this.selectedRangeStart) this.selectRange(this.selectedRangeStart);
   }
 }
 </script>

--- a/tests/unit/custom-granularity-calendar.spec.ts
+++ b/tests/unit/custom-granularity-calendar.spec.ts
@@ -106,6 +106,26 @@ describe('CustomGranularityCalendar', () => {
     });
   });
 
+  describe('When switching granularity with a selected date range', () => {
+    beforeEach(async () => {
+      createWrapper({
+        granularity: 'month',
+        value: {
+          start: new Date('02/01/2021'),
+        },
+      });
+      await wrapper.setProps({ granularity: 'quarter' });
+    });
+
+    it('should emit an updated selected date range', () => {
+      expect(wrapper.emitted('input')).toHaveLength(1);
+      const emittedDate: DateRange = wrapper.emitted('input')[0][0];
+      expect(emittedDate.start?.toISOString()).toStrictEqual(`2021-01-01T00:00:00.000Z`);
+      expect(emittedDate.end?.toISOString()).toStrictEqual(`2021-03-31T23:59:59.999Z`);
+      expect(emittedDate.duration).toBe('quarter');
+    });
+  });
+
   // For everything else, only test date related fonction aka the "Granularity Config"
   describe('Decade navigation', () => {
     it('should provide the right label', () => {


### PR DESCRIPTION
## Before

![toucan_weaverbird_calendar_select-before](https://user-images.githubusercontent.com/3978482/137145665-0a2dcc1e-1414-477c-9cf2-4c2816e6f2d8.gif)

## After

![toucan_weaverbird_calendar_select-after](https://user-images.githubusercontent.com/3978482/137145372-5eae1f6c-eef0-46ee-b55c-ffce246d2af5.gif)
