### PR TITLE
fix(selected-tab): right tab should be opend for the selected date-range on open calendar

### DIFF
--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -270,6 +270,7 @@ export default class DateRangeInput extends Vue {
   }
 
   openEditor(): void {
+    this.initTabs();
     this.isEditorOpened = true;
   }
 

--- a/src/components/stepforms/widgets/DateComponents/TabbedRangeCalendars.vue
+++ b/src/components/stepforms/widgets/DateComponents/TabbedRangeCalendars.vue
@@ -55,6 +55,15 @@ export default class TabbedRangeCalendars extends Vue {
     this.selectedTab = this.enabledCalendars[0];
   }
 
+  @Watch('value')
+  onValueChange() {
+    this.selectTab(
+      this.value.duration && this.enabledCalendars.includes(this.value.duration)
+        ? this.value.duration
+        : this.enabledCalendars[0],
+    );
+  }
+
   get currentValue(): CustomDateRange {
     return this.value;
   }

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -255,6 +255,26 @@ describe('Date range input', () => {
       });
     });
 
+    describe('choose right selected tab when opening calendar', () => {
+      const initialValue: RelativeDateRange = { date: '{{today}}', quantity: 1, duration: 'month' };
+      const updatedValue = { start: new Date(), end: new Date(1) };
+      beforeEach(async () => {
+        createWrapper({
+          availableVariables: SAMPLE_VARIABLES,
+          relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
+          variableDelimiters: { start: '{{', end: '}}' },
+          value: initialValue,
+        });
+        await wrapper.setProps({
+          value: updatedValue,
+        });
+        await wrapper.find('.widget-date-input__button').trigger('click');
+      });
+      it('should select "Fixed" tab by default', () => {
+        expect(wrapper.find('Tabs-stub').props().selectedTab).toBe('Fixed');
+      });
+    });
+
     describe('when selecting "Dynamic" tab', () => {
       beforeEach(async () => {
         wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'Dynamic');

--- a/tests/unit/tabbed-range-calendars.spec.ts
+++ b/tests/unit/tabbed-range-calendars.spec.ts
@@ -67,4 +67,20 @@ describe('TabbedRangeCalendars', () => {
       expect(wrapper.find('CustomGranularityCalendar-stub').props('granularity')).toBe('year');
     });
   });
+  describe('with selected value', () => {
+    beforeEach(async () => {
+      createWrapper();
+      await wrapper.setProps({
+        value: {
+          start: new Date(Date.UTC(2012, 0, 1)),
+          end: new Date(Date.UTC(2012, 11, 31, 23, 59, 59, 999)),
+          duration: 'year',
+        },
+      });
+    });
+
+    it('should select the appropriate tab', () => {
+      expect(wrapper.find('Tabs-stub').props('selectedTab')).toBe('year');
+    });
+  });
 });


### PR DESCRIPTION
# What
There was a small bug on the CustomDateRange when choosing a specific date-range and then closing the calendar, reopening it and changing the granularity without setting the new date, if we open the calendar again, it shoul open on the appropriate tab corresponding to our precedent selected granularity

## Before
![prev](https://user-images.githubusercontent.com/22576758/137336642-99d2667e-1fe6-46cc-b95a-b3f87dfac28f.gif)

## After
![Peek 2021-10-14 16-17](https://user-images.githubusercontent.com/22576758/137336661-421b815a-0d0b-48e3-9296-1ed9ea7b08bb.gif)

