### PR TITLE
style(date range input): range separator

### DIFF
--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -342,8 +342,9 @@ $active-color-dark: #16406a;
   ::v-deep span {
     display: inline-block;
     line-height: 0;
-    font-size: 30px;
-    color: #c8c8c8;
+    font-weight: bold;
+    padding: 0 4px;
+    color: #acacac;
   }
 }
 .widget-date-input__button {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -43,7 +43,7 @@ export const DEFAULT_DURATIONS: DurationOption[] = [
   { label: 'Days ago', value: 'day' },
 ];
 
-export const CUSTOM_DATE_RANGE_LABEL_SEPARATOR = '<span>&#8594;</span>'; //use arrow symbol
+export const CUSTOM_DATE_RANGE_LABEL_SEPARATOR = '<span> - </span>'; //use arrow symbol
 
 export const dateToString = (date: Date): string => {
   return date.toLocaleDateString(undefined, { timeZone: 'UTC' });


### PR DESCRIPTION
That look good on every browser, not as "font dependant" like the unicode arrow is

Before (Chrome) : 

![image](https://user-images.githubusercontent.com/3978482/137742266-7b9224d5-405d-4367-a7f8-274cfa1aa57d.png)

Before (Firefox) : 

![image](https://user-images.githubusercontent.com/3978482/137742154-c57d78f0-c714-411b-83b4-65ad93dc28e2.png)

After (Chrome & Firefox) : 

![image](https://user-images.githubusercontent.com/3978482/137742591-3ac52756-5cf9-4bde-b69e-ab3700ab98c1.png)

![image](https://user-images.githubusercontent.com/3978482/137741956-934f84a8-f0b6-4a04-8d0f-677a1e1cca28.png)
