### PR TITLE
fix(date-range-input): force popover to update position when opening the custom editor

### DIFF
--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -62,10 +62,10 @@ export default class Popover extends Vue {
   bottom!: boolean;
 
   @Prop({
-    type: Boolean,
-    default: false,
+    type: Number,
+    default: 0, // we increment the number each time we need the position to be updated
   })
-  forcePositionUpdate!: boolean;
+  forcePositionUpdate!: number;
 
   // Inject any element as `weaverbirdPopoverContainer` in any parent component
   @Inject({ default: document.body }) weaverbirdPopoverContainer!: Element;
@@ -87,10 +87,8 @@ export default class Popover extends Vue {
   }
 
   @Watch('forcePositionUpdate')
-  forceUpdatePosition(forcePositionUpdate: boolean) {
-    if (forcePositionUpdate) {
-      this.updatePosition();
-    }
+  forceUpdatePosition() {
+    this.updatePosition();
   }
 
   async mounted() {

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -157,7 +157,7 @@ export default class DateRangeInput extends Vue {
   isEditingCustomVariable = false; // force to expand custom part of editor
   alignLeft: string = POPOVER_ALIGN.LEFT;
   selectedTab = 'Relative';
-  forcePopoverToUpdatePosition = false;
+  forcePopoverToUpdatePosition = 0;
 
   get accessibleVariables(): VariablesBucket {
     // some variables are required for date computations but should not be part of the variable list displayed to users
@@ -280,7 +280,6 @@ export default class DateRangeInput extends Vue {
     if (this.alwaysOpen) return;
     this.isEditorOpened = false;
     this.isEditingCustomVariable = false;
-    this.forcePopoverToUpdatePosition = false;
   }
 
   selectVariable(value: string): void {
@@ -293,7 +292,7 @@ export default class DateRangeInput extends Vue {
     this.isEditingCustomVariable = true;
     // force popover to update position to always display custom editor in visible part of screen
     await this.$nextTick();
-    this.forcePopoverToUpdatePosition = true;
+    this.forcePopoverToUpdatePosition = this.forcePopoverToUpdatePosition + 1;
   }
 
   saveCustomVariable(): void {

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -159,7 +159,7 @@ describe('Date range input', () => {
         expect(wrapper.find({ ref: 'custom-editor' }).isVisible()).toBe(true);
       });
       it('should force popover to update position to always display custom editor in visible part of screen', () => {
-        expect(wrapper.find('.widget-date-input__editor').props().forcePositionUpdate).toBe(true);
+        expect(wrapper.find('.widget-date-input__editor').props().forcePositionUpdate).toBe(1);
       });
     });
   });
@@ -190,9 +190,6 @@ describe('Date range input', () => {
 
       it('should close the editor', () => {
         expect(wrapper.find('popover-stub').props().visible).toBe(false);
-      });
-      it('should restore popover to update position to false', () => {
-        expect(wrapper.find('.widget-date-input__editor').props().forcePositionUpdate).toBe(false);
       });
     });
 

--- a/tests/unit/popover.spec.ts
+++ b/tests/unit/popover.spec.ts
@@ -360,7 +360,7 @@ describe('Popover', function() {
         popoverWrapper.vm as any,
         'updatePosition',
       );
-      await popoverWrapper.setProps({ forcePositionUpdate: true });
+      await popoverWrapper.setProps({ forcePositionUpdate: 1 });
 
       expect(updatePositionSpy).toHaveBeenCalled();
     });


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/59559689/137779405-d4938b54-3ec3-49f0-aeb2-553d7180ff0a.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/137779420-3e648146-266f-4b44-888c-eeb1ce1d2fab.gif)

It shake a little but didn't found a better way to do it changing alignment don't change anything