### PR TITLE
fix(front): activate periods that overlap with the bounds

### DIFF
--- a/src/components/DatePicker/CustomGranularityCalendar.vue
+++ b/src/components/DatePicker/CustomGranularityCalendar.vue
@@ -98,11 +98,12 @@ export default class CustomGranularityCalendar extends Vue {
     return this.pickerConfig.selectableRanges.rangeToOption(this.value.start);
   }
 
+  // A period is disabled if it has no overlap with the bounds
   isOptionDisabled(date: DateTime): boolean {
     const { start, end } = this.pickerConfig.selectableRanges.optionToRange(date);
-    const isBeforeStartBound = this.bounds.start ? start < this.bounds.start : false;
-    const isAfterEndBound = this.bounds.end ? end >= this.bounds.end : false;
-    return isBeforeStartBound || isAfterEndBound;
+    const endBeforeStartBound = this.bounds.start ? end < this.bounds.start : false;
+    const startAfterEndBound = this.bounds.end ? start >= this.bounds.end : false;
+    return endBeforeStartBound || startAfterEndBound;
   }
 
   get selectableOptions(): SelectableOption[] {

--- a/tests/unit/custom-granularity-calendar.spec.ts
+++ b/tests/unit/custom-granularity-calendar.spec.ts
@@ -293,11 +293,11 @@ describe('CustomGranularityCalendar', () => {
       });
     });
 
-    it('should deactivate choices that are not contained in the bounds range', async () => {
+    it('should deactivate choices that have no overlap with the bounds range', async () => {
       await wrapper.setProps({
         bounds: {
-          start: new Date('2021-05-01'), // start of may 2021
-          end: new Date('2021-12-01'), // start of december 2021
+          start: new Date('2021-05-15'), // middle of may 2021
+          end: new Date('2021-11-31'), // end of november 2021
         },
       });
 


### PR DESCRIPTION
Before, we required that the whole period was contained in the bounds
for it to selectable