### PR TITLE
fix(date-range-input): use correct style for date separator

### DIFF
--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -334,13 +334,6 @@ $active-color-dark: #16406a;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  ::v-deep span {
-    display: inline-block;
-    line-height: 0;
-    font-weight: bold;
-    padding: 0 4px;
-    color: #acacac;
-  }
 }
 .widget-date-input__icon {
   padding: 10px 15px;

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -44,7 +44,7 @@ export const DEFAULT_DURATIONS: DurationOption[] = [
   { label: 'Days ago', value: 'day' },
 ];
 
-export const CUSTOM_DATE_RANGE_LABEL_SEPARATOR = '<span> - </span>'; //use arrow symbol
+export const CUSTOM_DATE_RANGE_LABEL_SEPARATOR = ' - ';
 
 export const dateToString = (date: Date): string => {
   return date.toLocaleDateString(undefined, { timeZone: 'UTC' });

--- a/tests/unit/lib/dates.spec.ts
+++ b/tests/unit/lib/dates.spec.ts
@@ -122,7 +122,7 @@ describe('dateRangeToString', () => {
           end: new Date('2021-10-21T23:59:59.999Z'),
           duration: 'day',
         }),
-      ).toBe('10/20/2021<span> - </span>10/21/2021');
+      ).toBe('10/20/2021 - 10/21/2021');
     });
   });
 });


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/59559689/138278108-7e20463b-c4f5-4fcc-9f54-ef6ff1eb2f40.png)

After:
![after](https://user-images.githubusercontent.com/59559689/138278121-e8b35b16-d632-48d7-a33a-65c9158329e9.png)
