### PR TITLE
fix(ui): popover alwaysOpened was not able to take enough place

### DIFF
--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -211,15 +211,8 @@ export default class Popover extends Vue {
 <style lang="scss" scoped>
 .weaverbird-popover {
   font-family: 'Montserrat', sans-serif;
-
-  &:not(.weaverbird-popover--always-opened) {
-    position: absolute;
-    visibility: visible;
-    z-index: 2;
-  }
-
-  &.weaverbird-popover--always-opened {
-    display: block;
-  }
+  position: absolute;
+  visibility: visible;
+  z-index: 2;
 }
 </style>


### PR DESCRIPTION
The size of the parent element was restricting the size of an alwaysOpened popover.

Before:
![Screenshot from 2021-10-28 11-11-29](https://user-images.githubusercontent.com/932583/139225658-64f6118e-f433-4a21-ae01-f04315d7b226.png)


After:
![Screenshot from 2021-10-28 11-10-37](https://user-images.githubusercontent.com/932583/139225676-325b50e1-6ecf-4c78-9ed0-c1106fc8ae98.png)
