### PR TITLE
feat(relative date range): add before/after field in form

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -44,7 +44,7 @@ export default {
       // Default extensions ['.mjs', '.js', '.json', '.node']
       // We need to add the '.vue' extension because of the import of the component from v-calendar
       // which contains relative paths without extensions.
-      extensions: ['.mjs', '.js', '.json', '.node', '.vue']
+      extensions: ['.mjs', '.js', '.ts', '.json', '.node', '.vue']
     }),
     alias({
       resolve: ['.vue', '.json'],
@@ -63,6 +63,7 @@ export default {
         }),
         autoprefixer()
       ],
+      // extract option break CSS live reload in Storybook, comment it to get it back
       extract: true,
       extract: 'weaverbird.css'
     }),

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -426,7 +426,7 @@ export default class DateRangeInput extends Vue {
   }
   .widget-relative-date-range-form {
     margin: 20px;
-    max-width: 400px;
+    width: 400px;
   }
 }
 .widget-date-input__editor-footer {

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -43,7 +43,10 @@ export default class RelativeDateForm extends Vue {
   }
 
   get durations(): DurationOption[] {
-    return DEFAULT_DURATIONS;
+    return DEFAULT_DURATIONS.map(duration => ({
+      ...duration,
+      label: duration.label + ' ago',
+    }));
   }
 
   get duration(): DurationOption | undefined {

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -1,7 +1,18 @@
 <template>
   <div class="widget-relative-date-range-form">
     <div class="widget-relative-date-range-form__container">
-      <RelativeDateForm class="widget-relative-date-range-form__input" v-model="rangeSize" />
+      <InputNumberWidget
+        class="widget-relative-date-range-form__quantity"
+        v-model="quantity"
+        :min="1"
+      />
+      <AutocompleteWidget
+        class="widget-relative-date-range-form__duration"
+        v-model="duration"
+        :options="durations"
+        trackBy="value"
+        label="label"
+      />
     </div>
     <div class="widget-relative-date-range-form__container">
       <AutocompleteWidget
@@ -23,11 +34,11 @@
 </template>
 
 <script lang="ts">
-import _pick from 'lodash/pick';
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
-import { RelativeDate, RelativeDateRange } from '@/lib/dates';
+import InputNumberWidget from '@/components/stepforms/widgets/InputNumber.vue';
+import { DEFAULT_DURATIONS, DurationOption, RelativeDateRange } from '@/lib/dates';
 import {
   AvailableVariable,
   extractVariableIdentifier,
@@ -35,14 +46,13 @@ import {
   VariablesBucket,
 } from '@/lib/variables';
 
-import RelativeDateForm from './RelativeDateForm.vue';
 /**
  * This component return a relative date range between a date variable and a relative date returned by RelativeDateForm
  */
 @Component({
   name: 'relative-date-range-form',
   components: {
-    RelativeDateForm,
+    InputNumberWidget,
     AutocompleteWidget,
   },
 })
@@ -56,12 +66,27 @@ export default class RelativeDateRangeForm extends Vue {
   @Prop({ default: () => ({ date: '', quantity: -1, duration: 'year' }) })
   value!: RelativeDateRange;
 
-  get rangeSize(): RelativeDate {
-    return _pick(this.value, ['quantity', 'duration']);
+  get quantity(): number {
+    return Math.abs(this.value.quantity);
   }
 
-  set rangeSize(to: RelativeDate) {
-    this.$emit('input', { ...this.value, ...to });
+  set quantity(quantity: number) {
+    this.$emit('input', {
+      ...this.value,
+      quantity: quantity * Math.sign(this.rangeDirection.value),
+    });
+  }
+
+  get durations(): DurationOption[] {
+    return DEFAULT_DURATIONS;
+  }
+
+  get duration(): DurationOption | undefined {
+    return this.durations.find(v => v.value === this.value.duration);
+  }
+
+  set duration(duration: DurationOption | undefined) {
+    this.$emit('input', { ...this.value, duration: duration?.value });
   }
 
   get baseDate(): AvailableVariable | undefined {
@@ -101,6 +126,49 @@ export default class RelativeDateRangeForm extends Vue {
   display: flex;
   justify-content: center;
   margin-bottom: 15px;
+}
+
+.widget-relative-date-range-form__quantity {
+  flex: 1 25%;
+  margin: 0 !important;
+  background: white;
+
+  ::v-deep .widget-input-number__container {
+    margin: 0;
+  }
+
+  ::v-deep .widget-input-number {
+    padding: 8px 12px;
+  }
+}
+.widget-relative-date-range-form__duration {
+  flex: 1 75%;
+  margin: 0 0 0 15px;
+  background: white;
+
+  ::v-deep .multiselect__tags {
+    padding: 8px 12px;
+  }
+
+  ::v-deep .multiselect__option {
+    border: none;
+    margin: 5px;
+    border-radius: 2px;
+    max-height: 30px;
+    padding: 8px 15px;
+    line-height: 25px;
+    box-shadow: none;
+  }
+
+  ::v-deep .multiselect__option--highlight {
+    background: var(--weaverbird-theme-main-color-extra-light, $active-color-faded-3);
+    color: var(--weaverbird-theme-main-color, $active-color);
+  }
+
+  ::v-deep .multiselect__option--selected {
+    background: var(--weaverbird-theme-main-color-light, $active-color-faded-2);
+    color: var(--weaverbird-theme-main-color, $active-color);
+  }
 }
 
 .widget-relative-date-range-form__input {

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -76,13 +76,20 @@ export default class RelativeDateRangeForm extends Vue {
 
   get directions() {
     return [
-      { label: 'before', value: 'before' },
-      { label: 'after', value: 'after' },
+      { label: 'before', value: -1 },
+      { label: 'after', value: +1 },
     ];
   }
 
   get rangeDirection() {
     return this.value.quantity >= 0 ? this.directions[1] : this.directions[0];
+  }
+
+  set rangeDirection(direction: { label: string; value: number }) {
+    this.$emit('input', {
+      ...this.value,
+      quantity: Math.sign(direction.value) * Math.abs(this.value.quantity),
+    });
   }
 }
 </script>

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -108,7 +108,7 @@ export default class RelativeDateRangeForm extends Vue {
 }
 
 .widget-relative-date-range-form__input--direction {
-  flex: 1 25%;
+  flex: 1 0 25%;
   margin-right: 15px;
 }
 

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -100,12 +100,16 @@ export default class RelativeDateRangeForm extends Vue {
 .widget-relative-date-range-form__container {
   display: flex;
   justify-content: center;
-  align-items: center;
   margin-bottom: 15px;
 }
 
 .widget-relative-date-range-form__input {
   flex: 1 100%;
+}
+
+.widget-relative-date-range-form__input--direction {
+  flex: 1 25%;
+  margin-right: 15px;
 }
 
 .widget-relative-date-range-form__input--base-date {

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="widget-relative-date-range-form">
     <div class="widget-relative-date-range-form__container">
-      <p class="widget-relative-date-range-form__label">From</p>
+      <RelativeDateForm class="widget-relative-date-range-form__input" v-model="to" />
+    </div>
+    <div class="widget-relative-date-range-form__container">
       <AutocompleteWidget
         class="widget-relative-date-range-form__input widget-relative-date-range-form__input--from"
         v-model="from"
@@ -10,10 +12,6 @@
         trackBy="identifier"
         label="label"
       />
-    </div>
-    <div class="widget-relative-date-range-form__container">
-      <p class="widget-relative-date-range-form__label">to</p>
-      <RelativeDateForm class="widget-relative-date-range-form__input" v-model="to" />
     </div>
   </div>
 </template>
@@ -80,14 +78,6 @@ export default class RelativeDateRangeForm extends Vue {
   justify-content: center;
   align-items: center;
   margin-bottom: 15px;
-}
-
-.widget-relative-date-range-form__label {
-  flex: 1 0;
-  font-size: 14px;
-  font-family: 'Montserrat', sans-serif;
-  margin-right: 10px;
-  min-width: 40px;
 }
 
 .widget-relative-date-range-form__input {

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -6,8 +6,8 @@
     <div class="widget-relative-date-range-form__container">
       <AutocompleteWidget
         class="widget-relative-date-range-form__input widget-relative-date-range-form__input--direction"
+        v-model="rangeDirection"
         :options="directions"
-        trackBy="identifier"
         label="label"
       />
       <AutocompleteWidget
@@ -79,6 +79,10 @@ export default class RelativeDateRangeForm extends Vue {
       { label: 'before', value: 'before' },
       { label: 'after', value: 'after' },
     ];
+  }
+
+  get rangeDirection() {
+    return this.value.quantity >= 0 ? this.directions[1] : this.directions[0];
   }
 }
 </script>

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -5,6 +5,12 @@
     </div>
     <div class="widget-relative-date-range-form__container">
       <AutocompleteWidget
+        class="widget-relative-date-range-form__input widget-relative-date-range-form__input--direction"
+        :options="directions"
+        trackBy="identifier"
+        label="label"
+      />
+      <AutocompleteWidget
         class="widget-relative-date-range-form__input widget-relative-date-range-form__input--base-date"
         v-model="baseDate"
         :options="availableVariables"
@@ -66,6 +72,13 @@ export default class RelativeDateRangeForm extends Vue {
   set baseDate(variable: AvailableVariable | undefined) {
     const value = `${this.variableDelimiters.start}${variable?.identifier}${this.variableDelimiters.end}`;
     this.$emit('input', { ...this.value, date: value });
+  }
+
+  get directions() {
+    return [
+      { label: 'before', value: 'before' },
+      { label: 'after', value: 'after' },
+    ];
   }
 }
 </script>

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="widget-relative-date-range-form">
     <div class="widget-relative-date-range-form__container">
-      <RelativeDateForm class="widget-relative-date-range-form__input" v-model="to" />
+      <RelativeDateForm class="widget-relative-date-range-form__input" v-model="rangeSize" />
     </div>
     <div class="widget-relative-date-range-form__container">
       <AutocompleteWidget
@@ -50,11 +50,11 @@ export default class RelativeDateRangeForm extends Vue {
   @Prop({ default: () => ({ date: '', quantity: -1, duration: 'year' }) })
   value!: RelativeDateRange;
 
-  get to(): RelativeDate {
+  get rangeSize(): RelativeDate {
     return _pick(this.value, ['quantity', 'duration']);
   }
 
-  set to(to: RelativeDate) {
+  set rangeSize(to: RelativeDate) {
     this.$emit('input', { ...this.value, ...to });
   }
 

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -5,8 +5,8 @@
     </div>
     <div class="widget-relative-date-range-form__container">
       <AutocompleteWidget
-        class="widget-relative-date-range-form__input widget-relative-date-range-form__input--from"
-        v-model="from"
+        class="widget-relative-date-range-form__input widget-relative-date-range-form__input--base-date"
+        v-model="baseDate"
         :options="availableVariables"
         placeholder="Select a date"
         trackBy="identifier"
@@ -58,12 +58,12 @@ export default class RelativeDateRangeForm extends Vue {
     this.$emit('input', { ...this.value, ...to });
   }
 
-  get from(): AvailableVariable | undefined {
+  get baseDate(): AvailableVariable | undefined {
     const identifier = extractVariableIdentifier(this.value.date, this.variableDelimiters);
     return this.availableVariables.find(v => v.identifier === identifier);
   }
 
-  set from(variable: AvailableVariable | undefined) {
+  set baseDate(variable: AvailableVariable | undefined) {
     const value = `${this.variableDelimiters.start}${variable?.identifier}${this.variableDelimiters.end}`;
     this.$emit('input', { ...this.value, date: value });
   }
@@ -84,7 +84,7 @@ export default class RelativeDateRangeForm extends Vue {
   flex: 1 100%;
 }
 
-.widget-relative-date-range-form__input--from {
+.widget-relative-date-range-form__input--base-date {
   background: white;
   margin: 0;
 

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -39,11 +39,11 @@ export type CustomDate = Date | RelativeDate;
 export type CustomDateRange = DateRange | RelativeDateRange;
 
 export const DEFAULT_DURATIONS: DurationOption[] = [
-  { label: 'Years ago', value: 'year' },
-  { label: 'Quarters ago', value: 'quarter' },
-  { label: 'Months ago', value: 'month' },
-  { label: 'Weeks ago', value: 'week' },
-  { label: 'Days ago', value: 'day' },
+  { label: 'Years', value: 'year' },
+  { label: 'Quarters', value: 'quarter' },
+  { label: 'Months', value: 'month' },
+  { label: 'Weeks', value: 'week' },
+  { label: 'Days', value: 'day' },
 ];
 
 export const CUSTOM_DATE_RANGE_LABEL_SEPARATOR = ' - ';
@@ -110,7 +110,8 @@ export const relativeDateToString = (relativeDate: RelativeDate): string => {
   const duration: string | undefined = DEFAULT_DURATIONS.find(
     d => d.value === relativeDate.duration,
   )?.label;
-  return `${Math.abs(relativeDate.quantity)} ${duration?.toLowerCase()}`;
+  const suffix = relativeDate.quantity < 0 ? ' ago' : '';
+  return `${Math.abs(relativeDate.quantity)} ${duration?.toLowerCase()}${suffix}`;
 };
 
 /* istanbul ignore next */

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -106,12 +106,15 @@ export const dateRangeToString = (dateRange: DateRange, locale?: LocaleIdentifie
 };
 
 /* istanbul ignore next */
-export const relativeDateToString = (relativeDate: RelativeDate): string => {
+export const relativeDateToString = (
+  relativeDate: RelativeDate,
+  suffixes = { before: 'ago', after: '' },
+): string => {
   const duration: string | undefined = DEFAULT_DURATIONS.find(
     d => d.value === relativeDate.duration,
   )?.label;
-  const suffix = relativeDate.quantity < 0 ? ' ago' : '';
-  return `${Math.abs(relativeDate.quantity)} ${duration?.toLowerCase()}${suffix}`;
+  const suffix = ' ' + (relativeDate.quantity < 0 ? suffixes.before : suffixes.after);
+  return `${Math.abs(relativeDate.quantity)} ${duration?.toLowerCase()}${suffix.trimEnd()}`;
 };
 
 /* istanbul ignore next */
@@ -121,9 +124,15 @@ export const relativeDateRangeToString = (
   variableDelimiters: VariableDelimiters = { start: '', end: '' },
 ): string => {
   const identifier = extractVariableIdentifier(relativeDateRange.date, variableDelimiters);
-  const from = availableVariables.find(v => v.identifier === identifier)?.label;
-  const to = _pick(relativeDateRange, ['quantity', 'duration']);
-  return `${from}${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}${relativeDateToString(to)}`;
+  const baseDateLabel = availableVariables.find(v => v.identifier === identifier)?.label;
+  const relativeDate = _pick(relativeDateRange, ['quantity', 'duration']);
+  const relativeDateLabel = relativeDateToString(relativeDate, {
+    before: 'before',
+    after: 'after',
+  });
+  return relativeDate.quantity > 0
+    ? `${baseDateLabel}${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}${relativeDateLabel}`
+    : `${relativeDateLabel}${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}${baseDateLabel}`;
 };
 
 export const isRelativeDateRange = (

--- a/tests/unit/lib/dates.spec.ts
+++ b/tests/unit/lib/dates.spec.ts
@@ -145,7 +145,12 @@ describe('relativeDateRangeToString', () => {
   it('should transform a relative date range to a readable label', () => {
     const value: RelativeDateRange = { date: '{{tomorrow}}', quantity: -2, duration: 'month' };
     expect(relativeDateRangeToString(value, SAMPLE_VARIABLES, variableDelimiters)).toStrictEqual(
-      `Tomorrow${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}2 months ago`,
+      `2 months before${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}Tomorrow`,
+    );
+
+    const value2: RelativeDateRange = { date: '{{tomorrow}}', quantity: 2, duration: 'month' };
+    expect(relativeDateRangeToString(value2, SAMPLE_VARIABLES, variableDelimiters)).toStrictEqual(
+      `Tomorrow${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}2 months after`,
     );
   });
 });

--- a/tests/unit/new-date-input.spec.ts
+++ b/tests/unit/new-date-input.spec.ts
@@ -283,7 +283,7 @@ describe('Date input', () => {
   });
 
   describe('with selected value as relative date', () => {
-    const value = { quantity: 1, duration: 'month' };
+    const value = { quantity: -1, duration: 'month' };
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,

--- a/tests/unit/relative-date-form-widget.spec.ts
+++ b/tests/unit/relative-date-form-widget.spec.ts
@@ -33,16 +33,23 @@ describe('Relative date form', () => {
     it('should use an autocomplete input', () => {
       expect(wrapper.find('AutocompleteWidget-stub').exists()).toBe(true);
     });
-    it('should pass durations options to autocomplete', () => {
-      expect(wrapper.find('AutocompleteWidget-stub').props().options).toStrictEqual(
-        DEFAULT_DURATIONS,
-      );
+    it('should pass durations options with suffix to autocomplete', () => {
+      expect(wrapper.find('AutocompleteWidget-stub').props().options).toStrictEqual([
+        { label: 'Years ago', value: 'year' },
+        { label: 'Quarters ago', value: 'quarter' },
+        { label: 'Months ago', value: 'month' },
+        { label: 'Weeks ago', value: 'week' },
+        { label: 'Days ago', value: 'day' },
+      ]);
     });
     it('should pass abs quantity to input number', () => {
       expect(wrapper.find('InputNumberWidget-stub').props().value).toBe(20);
     });
     it('should pass duration to autocomplete', () => {
-      expect(wrapper.find('AutocompleteWidget-stub').props().value).toBe(selectedDuration);
+      expect(wrapper.find('AutocompleteWidget-stub').props().value).toStrictEqual({
+        label: 'Quarters ago',
+        value: 'quarter',
+      });
     });
 
     describe('when quantity is updated', () => {
@@ -88,7 +95,10 @@ describe('Relative date form', () => {
       expect(wrapper.find('InputNumberWidget-stub').props().value).toBe(1);
     });
     it('should set duration to first default duration', () => {
-      expect(wrapper.find('AutocompleteWidget-stub').props().value).toBe(defaultDuration);
+      expect(wrapper.find('AutocompleteWidget-stub').props().value).toStrictEqual({
+        label: 'Years ago',
+        value: 'year',
+      });
     });
   });
 });

--- a/tests/unit/relative-date-range-form-widget.spec.ts
+++ b/tests/unit/relative-date-range-form-widget.spec.ts
@@ -41,11 +41,13 @@ describe('Relative date range form', () => {
         label: 'Today',
       });
     });
-    it('should pass relative date part of value to rangeSize (relative date form) input', () => {
-      expect(wrapper.find('RelativeDateForm-stub').props().value).toStrictEqual({
-        quantity: -1,
-        duration: 'month',
-      });
+    it('should pass relative date part of value to quantity & duration input', () => {
+      expect(
+        wrapper.find('.widget-relative-date-range-form__quantity').props('value'),
+      ).toStrictEqual(1);
+      expect(
+        wrapper.find('.widget-relative-date-range-form__duration').props('value'),
+      ).toStrictEqual({ label: 'Months', value: 'month' });
     });
     it('should pass corresponding direction to rangeDirection input', () => {
       expect(
@@ -71,17 +73,31 @@ describe('Relative date range form', () => {
       });
     });
 
-    describe('when rangeSize is updated', () => {
+    describe('when quantity is updated', () => {
       beforeEach(async () => {
-        wrapper
-          .find('RelativeDateForm-stub')
-          .vm.$emit('input', { date, quantity: -2, duration: 'year' });
+        wrapper.find('.widget-relative-date-range-form__quantity').vm.$emit('input', 2);
         await wrapper.vm.$nextTick();
       });
-      it('should emit value with updated rangeSize', () => {
+      it('should emit value with updated quantity and the right sign', () => {
         expect(wrapper.emitted().input[0][0]).toStrictEqual({
           date,
           quantity: -2,
+          duration: 'month',
+        });
+      });
+    });
+
+    describe('when duration is updated', () => {
+      beforeEach(async () => {
+        wrapper
+          .find('.widget-relative-date-range-form__duration')
+          .vm.$emit('input', { label: 'Years', value: 'year' });
+        await wrapper.vm.$nextTick();
+      });
+      it('should emit value with updated duration', () => {
+        expect(wrapper.emitted().input[0][0]).toStrictEqual({
+          date,
+          quantity: -1,
           duration: 'year',
         });
       });

--- a/tests/unit/relative-date-range-form-widget.spec.ts
+++ b/tests/unit/relative-date-range-form-widget.spec.ts
@@ -33,7 +33,7 @@ describe('Relative date range form', () => {
     it('should instantiate', () => {
       expect(wrapper.exists()).toBe(true);
     });
-    it('should use an autocomplete input for from part', () => {
+    it('should use an autocomplete input for BaseDate part', () => {
       expect(wrapper.find('AutocompleteWidget-stub').exists()).toBe(true);
     });
     it('should use a RelativeDateForm for to part', () => {

--- a/tests/unit/relative-date-range-form-widget.spec.ts
+++ b/tests/unit/relative-date-range-form-widget.spec.ts
@@ -33,7 +33,7 @@ describe('Relative date range form', () => {
     it('should instantiate', () => {
       expect(wrapper.exists()).toBe(true);
     });
-    it('should pass option refering to date value to autocomplete input', () => {
+    it('should pass option referring to date value to baseDate input', () => {
       expect(
         wrapper.find('.widget-relative-date-range-form__input--base-date').props().value,
       ).toStrictEqual({
@@ -41,11 +41,16 @@ describe('Relative date range form', () => {
         label: 'Today',
       });
     });
-    it('should pass relative date part of value to relative date form input', () => {
+    it('should pass relative date part of value to rangeSize (relative date form) input', () => {
       expect(wrapper.find('RelativeDateForm-stub').props().value).toStrictEqual({
         quantity: -1,
         duration: 'month',
       });
+    });
+    it('should pass corresponding direction to rangeDirection input', () => {
+      expect(
+        wrapper.find('.widget-relative-date-range-form__input--direction').props().value,
+      ).toStrictEqual({ label: 'before', value: 'before' });
     });
 
     describe('when baseDate is updated', () => {
@@ -98,8 +103,15 @@ describe('Relative date range form', () => {
     it('should set variable delimiters to empty strings', () => {
       expect((wrapper.vm as any).variableDelimiters).toStrictEqual({ start: '', end: '' });
     });
-    it('should pass empty string as value to autocomplete input', () => {
-      expect(wrapper.find('AutocompleteWidget-stub').props().value).toStrictEqual('');
+    it('should pass empty string as value to baseDate input', () => {
+      expect(
+        wrapper.find('.widget-relative-date-range-form__input--base-date').props().value,
+      ).toStrictEqual('');
+    });
+    it('should pass "before" as default value to rangeDirection input', () => {
+      expect(
+        wrapper.find('.widget-relative-date-range-form__input--direction').props().value,
+      ).toStrictEqual({ label: 'before', value: 'before' });
     });
   });
 });

--- a/tests/unit/relative-date-range-form-widget.spec.ts
+++ b/tests/unit/relative-date-range-form-widget.spec.ts
@@ -40,7 +40,9 @@ describe('Relative date range form', () => {
       expect(wrapper.find('RelativeDateForm-stub').exists()).toBe(true);
     });
     it('should pass option refering to date value to autocomplete input', () => {
-      expect(wrapper.find('AutocompleteWidget-stub').props().value).toStrictEqual({
+      expect(
+        wrapper.find('.widget-relative-date-range-form__input--base-date').props().value,
+      ).toStrictEqual({
         identifier: 'today',
         label: 'Today',
       });
@@ -52,10 +54,12 @@ describe('Relative date range form', () => {
       });
     });
 
-    describe('when from is updated', () => {
+    describe('when baseDate is updated', () => {
       const selectedDateVariable = SAMPLE_VARIABLES[1];
       beforeEach(async () => {
-        wrapper.find('AutocompleteWidget-stub').vm.$emit('input', selectedDateVariable);
+        wrapper
+          .find('.widget-relative-date-range-form__input--base-date')
+          .vm.$emit('input', selectedDateVariable);
         await wrapper.vm.$nextTick();
       });
       it('should emit value with updated date with delimiters', () => {
@@ -68,7 +72,7 @@ describe('Relative date range form', () => {
       });
     });
 
-    describe('when to is updated', () => {
+    describe('when to rangeSize updated', () => {
       beforeEach(async () => {
         wrapper
           .find('RelativeDateForm-stub')
@@ -93,7 +97,9 @@ describe('Relative date range form', () => {
       expect((wrapper.vm as any).value).toStrictEqual({ date: '', quantity: -1, duration: 'year' });
     });
     it('should set available variables to empty array', () => {
-      expect(wrapper.find('AutocompleteWidget-stub').props().options).toStrictEqual([]);
+      expect(
+        wrapper.find('.widget-relative-date-range-form__input--base-date').props().options,
+      ).toStrictEqual([]);
     });
     it('should set variable delimiters to empty strings', () => {
       expect((wrapper.vm as any).variableDelimiters).toStrictEqual({ start: '', end: '' });

--- a/tests/unit/relative-date-range-form-widget.spec.ts
+++ b/tests/unit/relative-date-range-form-widget.spec.ts
@@ -33,12 +33,6 @@ describe('Relative date range form', () => {
     it('should instantiate', () => {
       expect(wrapper.exists()).toBe(true);
     });
-    it('should use an autocomplete input for BaseDate part', () => {
-      expect(wrapper.find('AutocompleteWidget-stub').exists()).toBe(true);
-    });
-    it('should use a RelativeDateForm for RangeSize part', () => {
-      expect(wrapper.find('RelativeDateForm-stub').exists()).toBe(true);
-    });
     it('should pass option refering to date value to autocomplete input', () => {
       expect(
         wrapper.find('.widget-relative-date-range-form__input--base-date').props().value,

--- a/tests/unit/relative-date-range-form-widget.spec.ts
+++ b/tests/unit/relative-date-range-form-widget.spec.ts
@@ -71,14 +71,14 @@ describe('Relative date range form', () => {
       });
     });
 
-    describe('when to rangeSize updated', () => {
+    describe('when rangeSize is updated', () => {
       beforeEach(async () => {
         wrapper
           .find('RelativeDateForm-stub')
           .vm.$emit('input', { date, quantity: -2, duration: 'year' });
         await wrapper.vm.$nextTick();
       });
-      it('should emit value with updated to', () => {
+      it('should emit value with updated rangeSize', () => {
         expect(wrapper.emitted().input[0][0]).toStrictEqual({
           date,
           quantity: -2,

--- a/tests/unit/relative-date-range-form-widget.spec.ts
+++ b/tests/unit/relative-date-range-form-widget.spec.ts
@@ -36,7 +36,7 @@ describe('Relative date range form', () => {
     it('should use an autocomplete input for BaseDate part', () => {
       expect(wrapper.find('AutocompleteWidget-stub').exists()).toBe(true);
     });
-    it('should use a RelativeDateForm for to part', () => {
+    it('should use a RelativeDateForm for RangeSize part', () => {
       expect(wrapper.find('RelativeDateForm-stub').exists()).toBe(true);
     });
     it('should pass option refering to date value to autocomplete input', () => {

--- a/tests/unit/relative-date-range-form-widget.spec.ts
+++ b/tests/unit/relative-date-range-form-widget.spec.ts
@@ -50,7 +50,7 @@ describe('Relative date range form', () => {
     it('should pass corresponding direction to rangeDirection input', () => {
       expect(
         wrapper.find('.widget-relative-date-range-form__input--direction').props().value,
-      ).toStrictEqual({ label: 'before', value: 'before' });
+      ).toStrictEqual({ label: 'before', value: -1 });
     });
 
     describe('when baseDate is updated', () => {
@@ -86,6 +86,22 @@ describe('Relative date range form', () => {
         });
       });
     });
+
+    describe('when rangeDirection is updated', () => {
+      beforeEach(async () => {
+        wrapper
+          .find('.widget-relative-date-range-form__input--direction')
+          .vm.$emit('input', { label: 'after', value: +1 });
+        await wrapper.vm.$nextTick();
+      });
+      it('should emit value with updated rangeDirection', () => {
+        expect(wrapper.emitted().input[0][0]).toStrictEqual({
+          date,
+          quantity: 1,
+          duration: 'month',
+        });
+      });
+    });
   });
 
   describe('empty', () => {
@@ -111,7 +127,7 @@ describe('Relative date range form', () => {
     it('should pass "before" as default value to rangeDirection input', () => {
       expect(
         wrapper.find('.widget-relative-date-range-form__input--direction').props().value,
-      ).toStrictEqual({ label: 'before', value: 'before' });
+      ).toStrictEqual({ label: 'before', value: -1 });
     });
   });
 });


### PR DESCRIPTION
## Form improvements

In the Relative Date Range component, let the user choose is a relative range starts or end with the chosen base date or, in other words, if the specified duration goes "after" or "before".

Before : 

![image](https://user-images.githubusercontent.com/3978482/139905243-79728df3-86e1-43b0-aebf-c0b449e245e5.png)

After : 

![image](https://user-images.githubusercontent.com/3978482/139905293-dd1a0ddd-856b-40c8-b1ed-22b795d933b7.png)

Notice that now we display "years" instead of "years ago" in the duration field, this required changes in DateRangeForm.

## Label improvements

To complete those change, I also tried to improve the selected value label, so instead of :

![image](https://user-images.githubusercontent.com/3978482/139906124-8b585a25-918b-44d5-ba25-f786bbda0494.png)

it will display : 

![image](https://user-images.githubusercontent.com/3978482/139906280-b87f486d-1c25-49db-891f-d07140dfd072.png)

and with the same base date, quantity & duration but using the "after" operator, it will show :

![image](https://user-images.githubusercontent.com/3978482/139906419-d9f52231-2903-403c-9939-35334aa9e1d9.png)

## Others

No changes required on `transformRelativeDateRangeToDateRange` or `transformRelativeDateObjectToDate` that seems to already handle both positive and negative range quantities.