### PR TITLE
chore(build): storybook reload css

### DIFF
--- a/.storybook/rollup.config.js
+++ b/.storybook/rollup.config.js
@@ -1,10 +1,31 @@
+import autoprefixer from "autoprefixer";
+import postcss from 'rollup-plugin-postcss'
+import postcssPresetEnv from 'postcss-preset-env';
 import mainConfig from '../rollup.config'
 
+const { plugins, ...partialMainConfig } = mainConfig
+
+const storyBookPlugins = [
+  ...plugins.filter((plugin) => plugin.name !== 'postcss'), // Avoid extra config in mainConfig
+  postcss({
+    plugins: [
+      postcssPresetEnv({
+        stage: 2,
+        features: {
+          'nesting-rules': true,
+        },
+      }),
+      autoprefixer()
+    ],
+  }),
+];
+
 export default {
-  ...mainConfig,
+  ...partialMainConfig,
   input: '.storybook/bundle.ts',
   output: [{
     file: 'dist/storybook/components.js',
     format: 'esm'
   }],
+  plugins: storyBookPlugins
 }


### PR DESCRIPTION
The storybook rollup config is based on the weaverbird config. So the extract option of postCss was kept at the launch of storybook which prevented the reload of the css when there was a change in a component.

So we override the postCss config by removing the extract option when we launch storybook.