### PR TITLE
fix(range calendar): clamp selection to bounds when switching granularity TCTC-1031

### DIFF
--- a/src/components/DatePicker/CustomGranularityCalendar.vue
+++ b/src/components/DatePicker/CustomGranularityCalendar.vue
@@ -51,7 +51,7 @@ import { DateTime } from 'luxon';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
 import FAIcon from '@/components/FAIcon.vue';
-import { DateRange } from '@/lib/dates';
+import { clampRange, DateRange } from '@/lib/dates';
 import { LocaleIdentifier } from '@/lib/internationalization';
 
 import { AvailableDuration, GranularityConfig, RANGE_PICKERS } from './GranularityConfigs';
@@ -97,9 +97,14 @@ export default class CustomGranularityCalendar extends Vue {
     return this.pickerConfig.selectableRanges.currentOptions(this.currentNavRangeStart);
   }
 
-  get selectedRangeStart(): DateTime | undefined {
+  get boundedValue(): DateRange | undefined {
     if (!this.value || !this.value.start) return undefined;
-    return this.pickerConfig.selectableRanges.rangeToOption(this.value.start);
+    return clampRange(this.value, this.bounds);
+  }
+
+  get selectedRangeStart(): DateTime | undefined {
+    if (!this.boundedValue?.start) return undefined;
+    return this.pickerConfig.selectableRanges.rangeToOption(this.boundedValue.start);
   }
 
   // A period is disabled if it has no overlap with the bounds
@@ -141,6 +146,7 @@ export default class CustomGranularityCalendar extends Vue {
 
   created() {
     if (this.selectedRangeStart) this.currentNavRangeStart = this.selectedRangeStart;
+    this.updateSelectedRange();
   }
 
   selectPreviousNavRange() {
@@ -155,7 +161,7 @@ export default class CustomGranularityCalendar extends Vue {
     return this.pickerConfig.selectableRanges.optionToRange(date);
   }
 
-  selectRange(range: Required<DateRange>) {
+  selectRange(range: DateRange) {
     this.$emit('input', range);
   }
 

--- a/src/components/stepforms/widgets/DateComponents/TabbedRangeCalendars.vue
+++ b/src/components/stepforms/widgets/DateComponents/TabbedRangeCalendars.vue
@@ -58,6 +58,10 @@ export default class TabbedRangeCalendars extends Vue {
 
   selectedTab = this.enabledCalendars[0];
 
+  created() {
+    this.updateTabForCurrentValue();
+  }
+
   @Watch('enabledCalendars')
   onEnabledCalendarsChange() {
     if (!this.value.duration || !this.enabledCalendars.includes(this.value.duration)) {
@@ -67,9 +71,7 @@ export default class TabbedRangeCalendars extends Vue {
 
   @Watch('value')
   onValueChange() {
-    if (this.value.duration && this.enabledCalendars.includes(this.value.duration)) {
-      this.selectTab(this.value.duration);
-    }
+    this.updateTabForCurrentValue();
   }
 
   get currentValue(): CustomDateRange {
@@ -82,6 +84,12 @@ export default class TabbedRangeCalendars extends Vue {
 
   get calendarGranularity(): string | undefined {
     return this.selectedTab !== 'day' ? this.selectedTab : undefined;
+  }
+
+  updateTabForCurrentValue() {
+    if (this.value.duration && this.enabledCalendars.includes(this.value.duration)) {
+      this.selectTab(this.value.duration);
+    }
   }
 
   selectTab(tab: string) {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -136,3 +136,24 @@ export const isDateRange = (value: undefined | string | CustomDateRange): value 
   if (!(value instanceof Object)) return false;
   return Object.keys(value).length === 0 || _has(value, 'start') || _has(value, 'end');
 };
+
+export const clampRange = (range: DateRange, bounds: DateRange): DateRange => {
+  if (range.start == null || range.end == null || bounds.start == null || bounds.end == null) {
+    return range;
+  }
+
+  const rangeStartIsOutOfBound = range.start < bounds.start || bounds.end < range.start;
+  const rangeEndIsOutOfBound = range.end < bounds.start || bounds.end < range.end;
+  const rangeContainBounds = range.start < bounds.start && bounds.end < range.end;
+
+  if (rangeStartIsOutOfBound && rangeEndIsOutOfBound && !rangeContainBounds) {
+    throw new Error('Cannot clamp range that does not overlap with bounds');
+  }
+
+  const clampedRange = {
+    ...range,
+    start: rangeStartIsOutOfBound ? bounds.start : range.start,
+    end: rangeEndIsOutOfBound ? bounds.end : range.end,
+  };
+  return clampedRange;
+};

--- a/stories/dates/date-range-input.js
+++ b/stories/dates/date-range-input.js
@@ -262,8 +262,8 @@ stories.add('custom (with bounds)', () => ({
       availableVariables: SAMPLE_VARIABLES,
       variableDelimiters: { start: '{{', end: '}}' },
       relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
-      value: { start: new Date('2021/1/1'), end: new Date('2021/1/5') },
-      bounds: { start: new Date('2021/1/2'), end: new Date('2021/10/4') },
+      value: { start: new Date('2021/2/1'), end: new Date('2021/2/5') },
+      bounds: { start: new Date('2021/2/2'), end: new Date('2021/10/4') },
       actualRangeValue: undefined,
     };
   },

--- a/tests/unit/calendar.spec.ts
+++ b/tests/unit/calendar.spec.ts
@@ -72,6 +72,34 @@ describe('Calendar', () => {
       (wrapper.vm as any).onDrag(value); // drag event is not found by stub
       expect(wrapper.emitted('input')[0][0]).toStrictEqual({ start: value.start, duration: 'day' });
     });
+
+    describe('range out of bounds', () => {
+      const bounds = {
+        start: new Date('2021-11-15T00:00:00'),
+        end: new Date('2021-12-15T00:00:00'),
+        duration: 'day',
+      };
+
+      beforeEach(() => {
+        createWrapper({
+          value: {
+            start: new Date('2021-11-01T00:00:00'),
+            end: new Date('2022-12-18T00:00:00'),
+            duration: 'day',
+          },
+          availableDates: bounds,
+          isRange: true,
+        });
+      });
+
+      it('should use clamped range instead of raw value', () => {
+        expect(wrapper.find(DatePicker).props('value')).toStrictEqual(bounds);
+      });
+
+      it('should emit clamped range', () => {
+        expect(wrapper.emitted('input')[0][0]).toStrictEqual(bounds);
+      });
+    });
   });
 
   describe('with highlighted dates', () => {

--- a/tests/unit/custom-granularity-calendar.spec.ts
+++ b/tests/unit/custom-granularity-calendar.spec.ts
@@ -116,6 +116,41 @@ describe('CustomGranularityCalendar', () => {
     });
   });
 
+  describe('range out of bounds', () => {
+    const bounds = {
+      start: new Date('11/15/2021'),
+      end: new Date('12/15/2021'),
+      duration: 'day',
+    };
+
+    beforeEach(() => {
+      createWrapper({
+        granularity: 'month',
+        value: {
+          start: new Date('10/15/2021'),
+          end: new Date('12/15/2021'),
+          duration: 'month',
+        },
+        bounds,
+      });
+    });
+
+    it('should use clamped range instead of raw value', () => {
+      expect(wrapper.find('.custom-granularity-calendar__option--selected').text()).toBe(
+        'November',
+      );
+    });
+
+    it('should emit corresponding clamped range', () => {
+      expect(wrapper.emitted('input')).toHaveLength(1);
+      expect(wrapper.emitted('input')[0][0]).toStrictEqual({
+        start: new Date('2021-11-01T00:00:00.000Z'),
+        end: new Date('2021-11-30T23:59:59.999Z'),
+        duration: 'month',
+      });
+    });
+  });
+
   describe('When switching granularity with a selected date range', () => {
     beforeEach(async () => {
       createWrapper({
@@ -128,8 +163,8 @@ describe('CustomGranularityCalendar', () => {
     });
 
     it('should emit an updated selected date range', () => {
-      expect(wrapper.emitted('input')).toHaveLength(1);
-      const emittedDate: DateRange = wrapper.emitted('input')[0][0];
+      expect(wrapper.emitted('input')).toHaveLength(2);
+      const emittedDate: DateRange = wrapper.emitted('input')[1][0];
       expect(emittedDate.start?.toISOString()).toStrictEqual(`2021-01-01T00:00:00.000Z`);
       expect(emittedDate.end?.toISOString()).toStrictEqual(`2021-03-31T23:59:59.999Z`);
       expect(emittedDate.duration).toBe('quarter');

--- a/tests/unit/lib/dates.spec.ts
+++ b/tests/unit/lib/dates.spec.ts
@@ -1,5 +1,7 @@
 import {
+  clampRange,
   CUSTOM_DATE_RANGE_LABEL_SEPARATOR,
+  DateRange,
   dateRangeToString,
   dateToString,
   isDateRange,
@@ -177,5 +179,60 @@ describe('isDateRange', () => {
   });
   it('should return true if value is a full date range', () => {
     expect(isDateRange({ start: new Date(), end: new Date(1) })).toBe(true);
+  });
+});
+
+describe('clampRange', () => {
+  const bounds: DateRange = {
+    start: new Date('2021-11-15T00:00:00'),
+    end: new Date('2021-12-15T00:00:00'),
+    duration: 'day',
+  };
+
+  it('should left untouched range completely contain in bound', () => {
+    const rangeInBounds: DateRange = {
+      start: new Date('2021-11-16T00:00:00'),
+      end: new Date('2021-11-18T00:00:00'),
+      duration: 'day',
+    };
+    expect(clampRange(rangeInBounds, bounds)).toStrictEqual(rangeInBounds);
+  });
+  it('should clamp range overlapping with left bound', () => {
+    const rangeOutOfLeftBound: DateRange = {
+      start: new Date('2021-11-01T00:00:00'),
+      end: new Date('2021-11-18T00:00:00'),
+      duration: 'day',
+    };
+    expect(clampRange(rangeOutOfLeftBound, bounds)).toStrictEqual({
+      ...rangeOutOfLeftBound,
+      start: bounds.start,
+    });
+  });
+  it('should clamp range overlapping with right bound', () => {
+    const rangeOutOfRightBound: DateRange = {
+      start: new Date('2021-11-15T00:00:00'),
+      end: new Date('2022-01-18T00:00:00'),
+      duration: 'day',
+    };
+    expect(clampRange(rangeOutOfRightBound, bounds)).toStrictEqual({
+      ...rangeOutOfRightBound,
+      end: bounds.end,
+    });
+  });
+  it('should clamp range overlapping both bounds', () => {
+    const rangeOutOfBounds: DateRange = {
+      start: new Date('2021-11-01T00:00:00'),
+      end: new Date('2022-12-18T00:00:00'),
+      duration: 'day',
+    };
+    expect(clampRange(rangeOutOfBounds, bounds)).toStrictEqual(bounds);
+  });
+  it('should throw an error when range it completely out of bounds without any overlap', () => {
+    const rangeOutOfBounds: DateRange = {
+      start: new Date('2022-11-16T00:00:00'),
+      end: new Date('2022-11-18T00:00:00'),
+      duration: 'day',
+    };
+    expect(() => clampRange(rangeOutOfBounds, bounds)).toThrow();
   });
 });

--- a/tests/unit/tabbed-range-calendars.spec.ts
+++ b/tests/unit/tabbed-range-calendars.spec.ts
@@ -79,37 +79,56 @@ describe('TabbedRangeCalendars', () => {
   });
 
   describe('with selected value', () => {
-    describe('with known granularity', () => {
-      beforeEach(async () => {
-        createWrapper();
-        await wrapper.setProps({
-          value: {
-            start: new Date(Date.UTC(2012, 0, 1)),
-            end: new Date(Date.UTC(2012, 11, 31, 23, 59, 59, 999)),
-            duration: 'year',
-          },
+    describe('on create', () => {
+      describe('with a day range', () => {
+        beforeEach(async () => {
+          await createWrapper({
+            value: {
+              start: new Date('2021-11-01T00:00:00'),
+              end: new Date('2022-12-18T00:00:00'),
+              duration: 'day',
+            }
+          });
         });
-      });
 
-      it('should select the appropriate tab', () => {
-        expect(wrapper.find('Tabs-stub').props('selectedTab')).toBe('year');
+        it('should select the day Calendar', () => {
+          expect(wrapper.find('Calendar-stub').isVisible()).toBe(true);
+        });
       });
     });
+    describe('on update', () => {
+      describe('with known granularity', () => {
+        beforeEach(async () => {
+          createWrapper();
+          await wrapper.setProps({
+            value: {
+              start: new Date(Date.UTC(2012, 0, 1)),
+              end: new Date(Date.UTC(2012, 11, 31, 23, 59, 59, 999)),
+              duration: 'year',
+            },
+          });
+        });
 
-    describe('with unknown granularity', () => {
-      beforeEach(async () => {
-        createWrapper();
-        await wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'day');
-        await wrapper.setProps({
-          value: {
-            start: new Date(Date.UTC(2012, 0, 1)),
-            end: new Date(Date.UTC(2012, 11, 31, 23, 59, 59, 999)),
-          },
+        it('should select the appropriate tab', () => {
+          expect(wrapper.find('Tabs-stub').props('selectedTab')).toBe('year');
         });
       });
 
-      it('should stay on the already selected tab', () => {
-        expect(wrapper.find('Tabs-stub').props('selectedTab')).toBe('day');
+      describe('with unknown granularity', () => {
+        beforeEach(async () => {
+          createWrapper();
+          await wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'day');
+          await wrapper.setProps({
+            value: {
+              start: new Date(Date.UTC(2012, 0, 1)),
+              end: new Date(Date.UTC(2012, 11, 31, 23, 59, 59, 999)),
+            },
+          });
+        });
+
+        it('should stay on the already selected tab', () => {
+          expect(wrapper.find('Tabs-stub').props('selectedTab')).toBe('day');
+        });
       });
     });
   });

--- a/tests/unit/tabbed-range-calendars.spec.ts
+++ b/tests/unit/tabbed-range-calendars.spec.ts
@@ -77,6 +77,7 @@ describe('TabbedRangeCalendars', () => {
       expect(wrapper.find('CustomGranularityCalendar-stub').props('granularity')).toBe('year');
     });
   });
+
   describe('with selected value', () => {
     describe('with known granularity', () => {
       beforeEach(async () => {
@@ -112,6 +113,7 @@ describe('TabbedRangeCalendars', () => {
       });
     });
   });
+
   describe('with updated enabled calendars', () => {
     beforeEach(async () => {
       await wrapper.setProps({

--- a/tests/unit/tabbed-range-calendars.spec.ts
+++ b/tests/unit/tabbed-range-calendars.spec.ts
@@ -87,7 +87,7 @@ describe('TabbedRangeCalendars', () => {
               start: new Date('2021-11-01T00:00:00'),
               end: new Date('2022-12-18T00:00:00'),
               duration: 'day',
-            }
+            },
           });
         });
 


### PR DESCRIPTION
In the "Fixed" tab of the Date Range Calendar, when switching between tabs, with bounds configured, the selected range could end up out of bounds because : 

- on "larger than day" granularity we allow selection of any period that completely OR partially without configured bounds
- bounds where not taken into account when retrieving the appropriate value when arriving on a new calendar

This led to : 

- a wrong range being displayed as selected
- and no range appearing as selected at all in the case of the "day" calendar

This PR fix that.

## How

Make end calendars clamp the selected range to bounds before determining their corresponding value
and emit the end result back which is guaranteed to not be completely out of bound.

First tried to do this on their common parent `TabbedRangeCalendar` but wasn't appropriate. 
It was fine for clamping the selected range to current bound but not for determining the right value for the
current selected tab.

## Screenshots

Before, with bound set from February 2nd to October 3rd, when selecting Q4 and switching to the day calendar : 
 
![image](https://user-images.githubusercontent.com/3978482/140091338-753a3795-b67d-49d6-ba41-0249a867746d.png)

After:

![image](https://user-images.githubusercontent.com/3978482/140091807-6c080153-f54a-4f0c-bd0b-9bc3c52ce09c.png)

---

Before, with bound set from February 2nd to October 3rd, when selecting Q1 and switching to the month calendar : 

![image](https://user-images.githubusercontent.com/3978482/140091519-c2b28084-1323-466f-bde4-256ff44a4803.png)

After:

![image](https://user-images.githubusercontent.com/3978482/140092013-d25ef96c-2d37-4b73-aeaa-cd92396505c0.png)

