### PR TITLE
fix(custom-granularity-calendar): update navigation based on selected option when switching between tabs TCTC-1031

### DIFF
--- a/src/components/DatePicker/CustomGranularityCalendar.vue
+++ b/src/components/DatePicker/CustomGranularityCalendar.vue
@@ -170,6 +170,9 @@ export default class CustomGranularityCalendar extends Vue {
     if (this.selectedRangeStart) {
       const range = this.retrieveRangeFromOption(this.selectedRangeStart);
       this.selectRange(range);
+      // update navigation start to retrieve options of same page that selected date range in new granularity
+      // ex: we select 2028 in year tab then switch to month tab, we expect to retrieve 2028's months as options
+      this.currentNavRangeStart = this.selectedRangeStart;
     }
   }
 }

--- a/tests/unit/custom-granularity-calendar.spec.ts
+++ b/tests/unit/custom-granularity-calendar.spec.ts
@@ -169,6 +169,10 @@ describe('CustomGranularityCalendar', () => {
       expect(emittedDate.end?.toISOString()).toStrictEqual(`2021-03-31T23:59:59.999Z`);
       expect(emittedDate.duration).toBe('quarter');
     });
+
+    it('should update navigation start to retrieve options of same page that selected date range in new granularity', () => {
+      expect(wrapper.find('.custom-granularity-calendar__header').text()).toBe('2021');
+    });
   });
 
   // For everything else, only test date related fonction aka the "Granularity Config"


### PR DESCRIPTION
When we switch between granulrity tabs of calendars we want to retrieve options that fit the current selected option.
Day calendar is already ok because it has a from property, just needed to update navStart in customgranulrity calendar on granulrity watcher

Before:
![before](https://user-images.githubusercontent.com/59559689/140123257-cbbb98cc-554b-4195-ac2e-986de8ae30d0.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/140112195-787581f0-00a7-4d38-ae74-cb8874ca98e0.gif)
