### PR TITLE
fix(relative date range form): use the right operator names TCTC-1182

### DIFF
--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -101,8 +101,8 @@ export default class RelativeDateRangeForm extends Vue {
 
   get directions() {
     return [
-      { label: 'before', value: -1 },
-      { label: 'after', value: +1 },
+      { label: 'until', value: -1 },
+      { label: 'from', value: +1 },
     ];
   }
 

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -127,12 +127,10 @@ export const relativeDateRangeToString = (
   const baseDateLabel = availableVariables.find(v => v.identifier === identifier)?.label;
   const relativeDate = _pick(relativeDateRange, ['quantity', 'duration']);
   const relativeDateLabel = relativeDateToString(relativeDate, {
-    before: 'before',
-    after: 'after',
+    before: 'until',
+    after: 'from',
   });
-  return relativeDate.quantity > 0
-    ? `${baseDateLabel}${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}${relativeDateLabel}`
-    : `${relativeDateLabel}${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}${baseDateLabel}`;
+  return `${relativeDateLabel}${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}${baseDateLabel}`;
 };
 
 export const isRelativeDateRange = (

--- a/tests/unit/lib/dates.spec.ts
+++ b/tests/unit/lib/dates.spec.ts
@@ -147,12 +147,12 @@ describe('relativeDateRangeToString', () => {
   it('should transform a relative date range to a readable label', () => {
     const value: RelativeDateRange = { date: '{{tomorrow}}', quantity: -2, duration: 'month' };
     expect(relativeDateRangeToString(value, SAMPLE_VARIABLES, variableDelimiters)).toStrictEqual(
-      `2 months before${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}Tomorrow`,
+      `2 months until${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}Tomorrow`,
     );
 
     const value2: RelativeDateRange = { date: '{{tomorrow}}', quantity: 2, duration: 'month' };
     expect(relativeDateRangeToString(value2, SAMPLE_VARIABLES, variableDelimiters)).toStrictEqual(
-      `Tomorrow${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}2 months after`,
+      `2 months from${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}Tomorrow`,
     );
   });
 });

--- a/tests/unit/relative-date-range-form-widget.spec.ts
+++ b/tests/unit/relative-date-range-form-widget.spec.ts
@@ -52,7 +52,7 @@ describe('Relative date range form', () => {
     it('should pass corresponding direction to rangeDirection input', () => {
       expect(
         wrapper.find('.widget-relative-date-range-form__input--direction').props().value,
-      ).toStrictEqual({ label: 'before', value: -1 });
+      ).toStrictEqual({ label: 'until', value: -1 });
     });
 
     describe('when baseDate is updated', () => {
@@ -107,7 +107,7 @@ describe('Relative date range form', () => {
       beforeEach(async () => {
         wrapper
           .find('.widget-relative-date-range-form__input--direction')
-          .vm.$emit('input', { label: 'after', value: +1 });
+          .vm.$emit('input', { label: 'from', value: +1 });
         await wrapper.vm.$nextTick();
       });
       it('should emit value with updated rangeDirection', () => {
@@ -143,7 +143,7 @@ describe('Relative date range form', () => {
     it('should pass "before" as default value to rangeDirection input', () => {
       expect(
         wrapper.find('.widget-relative-date-range-form__input--direction').props().value,
-      ).toStrictEqual({ label: 'before', value: -1 });
+      ).toStrictEqual({ label: 'until', value: -1 });
     });
   });
 });


### PR DESCRIPTION
While doing UAT, we noticed that the "before" & "after" operator suggested that the base date was **excluded** from the resulting range while it was indeed **included**.

In further discussion, we discovered that there is indeed 4 possible operators for defining relative date range with our simplified form : 

![image](https://user-images.githubusercontent.com/3978482/140528002-b6183835-13c4-4f5e-84f7-27cad9da7e6f.png)

Two of them being "inclusive" (until & from) and the two other being "exclusive" (before & after) : 

![image](https://user-images.githubusercontent.com/3978482/140527774-4555eeeb-45d1-476d-b9c8-ec0c84053914.png)

So operator names where not in tune with the underlying behavior. This PR fix that.
We'll see later if we implement the two other operators or choose those two instead of current ones.