### PR TITLE
build(storybook): avoid babeling storybok bundle

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,0 +1,5 @@
+{
+  "ignore": [
+    "../dist/storybook/components.js"
+  ]
+}


### PR DESCRIPTION
This repairs the storybook build command, that were failing upon reading and trying to transpile the bundle of components produced by rollup.
With this, we should be able to deploy the storybook again.