### PR TITLE
refactor(relative date range): use a proper "operator" property TCTC-1183

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- RelativeDateRange: use a proper "operator" property in data model
+
 ## [0.75.0] - 2021-11-09
 
 ### Changed

--- a/src/components/DatePicker/transform-value-to-date-or-range.ts
+++ b/src/components/DatePicker/transform-value-to-date-or-range.ts
@@ -1,6 +1,12 @@
 import { DateTime } from 'luxon';
 
-import { DateRange, isDateRange, RelativeDate, RelativeDateRange } from '@/lib/dates';
+import {
+  DateRange,
+  isDateRange,
+  RELATIVE_DATE_RANGE_OPERATORS,
+  RelativeDate,
+  RelativeDateRange,
+} from '@/lib/dates';
 import { retrieveVariable, VariableDelimiters, VariablesBucket } from '@/lib/variables';
 
 /*
@@ -82,7 +88,8 @@ export const transformRelativeDateRangeToDateRange = (
   const target = DateTime.fromJSDate(targetDateTime, { zone: 'UTC' }).toJSDate();
 
   // if quantity is negative, target will arrive before base
-  const [start, end] = relativeDateRange.operator === 'from' ? [base, target] : [target, base];
+  const quantityIsPositive = RELATIVE_DATE_RANGE_OPERATORS[relativeDateRange.operator].sign > 0;
+  const [start, end] = quantityIsPositive ? [base, target] : [target, base];
   return { start, end };
 };
 

--- a/src/components/DatePicker/transform-value-to-date-or-range.ts
+++ b/src/components/DatePicker/transform-value-to-date-or-range.ts
@@ -67,7 +67,9 @@ export const transformRelativeDateRangeToDateRange = (
       // Base day should be included in full
       // so if the range starts with the base day, its time should be 00:00
       // but if the range ends with the base day, its time should be 23:59
-      relativeDateRange.quantity > 0 ? {} : { hour: 23, minute: 59, second: 59, millisecond: 999 },
+      relativeDateRange.operator === 'from'
+        ? {}
+        : { hour: 23, minute: 59, second: 59, millisecond: 999 },
     )
     .toJSDate();
 
@@ -80,7 +82,7 @@ export const transformRelativeDateRangeToDateRange = (
   const target = DateTime.fromJSDate(targetDateTime, { zone: 'UTC' }).toJSDate();
 
   // if quantity is negative, target will arrive before base
-  const [start, end] = relativeDateRange.quantity >= 0 ? [base, target] : [target, base];
+  const [start, end] = relativeDateRange.operator === 'from' ? [base, target] : [target, base];
   return { start, end };
 };
 

--- a/src/components/DatePicker/transform-value-to-date-or-range.ts
+++ b/src/components/DatePicker/transform-value-to-date-or-range.ts
@@ -67,6 +67,8 @@ export const transformRelativeDateRangeToDateRange = (
   )?.value;
   if (!(value instanceof Date)) return;
 
+  const operator = RELATIVE_DATE_RANGE_OPERATORS[relativeDateRange.operator];
+
   // pass base date to UTC
   const base = DateTime.fromJSDate(value, { zone: 'UTC' })
     .set(
@@ -81,14 +83,18 @@ export const transformRelativeDateRangeToDateRange = (
 
   // retrieve end date from luxon
   const targetDateTime = transformRelativeDateObjectToDate(
-    { ...relativeDateRange, date: base },
+    {
+      ...relativeDateRange,
+      quantity: Math.sign(operator.sign) * Math.abs(relativeDateRange.quantity),
+      date: base,
+    },
     true, // ensure we add or remove 1ms so that the target day is not included
   );
 
   const target = DateTime.fromJSDate(targetDateTime, { zone: 'UTC' }).toJSDate();
 
   // if quantity is negative, target will arrive before base
-  const quantityIsPositive = RELATIVE_DATE_RANGE_OPERATORS[relativeDateRange.operator].sign > 0;
+  const quantityIsPositive = operator.sign > 0;
   const [start, end] = quantityIsPositive ? [base, target] : [target, base];
   return { start, end };
 };
@@ -173,8 +179,8 @@ undefined -> undefined
 { start: new Date(), end: new Date() } -> { start: new Date(), end: new Date() }
 
 // Relative Date range
-{ date: 'variable_name', quantity: 2, duration: 'month' } ->  { start: new Date(variable_name.value), end: new Date(variable_name.value).plus(2 month) }
-{ date: 'variable_name', quantity: -2, duration: 'month' } ->  { start: new Date(variable_name.value).minus(2 month), end: new Date(variable_name.value) }
+{ date: 'variable_name', quantity: 2, duration: 'month', operator: 'from' } ->  { start: new Date(variable_name.value), end: new Date(variable_name.value).plus(2 month) }
+{ date: 'variable_name', quantity: 2, duration: 'month', operator: 'until' } ->  { start: new Date(variable_name.value).minus(2 month), end: new Date(variable_name.value) }
 */
 export const transformValueToDateRange = (
   value: undefined | string | RelativeDateRange | DateRange,

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -205,7 +205,7 @@ export default class DateRangeInput extends Vue {
   // keep each tab value in memory to enable to switch between tabs without loosing content
   tabsValues: Record<string, CustomDateRange> = {
     Fixed: {}, // DateRange should be empty on init because we can have bounds so defined dates could be out of bounds
-    Relative: { date: '', quantity: -1, duration: 'year', operator: 'until' },
+    Relative: { date: '', quantity: 1, duration: 'year', operator: 'until' },
   };
 
   get currentTabValue(): CustomDateRange {

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -205,7 +205,7 @@ export default class DateRangeInput extends Vue {
   // keep each tab value in memory to enable to switch between tabs without loosing content
   tabsValues: Record<string, CustomDateRange> = {
     Fixed: {}, // DateRange should be empty on init because we can have bounds so defined dates could be out of bounds
-    Relative: { date: '', quantity: -1, duration: 'year' },
+    Relative: { date: '', quantity: -1, duration: 'year', operator: 'until' },
   };
 
   get currentTabValue(): CustomDateRange {

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -68,7 +68,7 @@ export default class RelativeDateRangeForm extends Vue {
   @Prop({ default: () => ({ start: '', end: '' }) })
   variableDelimiters!: VariableDelimiters;
 
-  @Prop({ default: () => ({ date: '', quantity: -1, duration: 'year', operator: 'until' }) })
+  @Prop({ default: () => ({ date: '', quantity: 1, duration: 'year', operator: 'until' }) })
   value!: RelativeDateRange;
 
   get quantity(): number {
@@ -78,7 +78,7 @@ export default class RelativeDateRangeForm extends Vue {
   set quantity(quantity: number) {
     this.$emit('input', {
       ...this.value,
-      quantity: quantity * Math.sign(this.operator.sign),
+      quantity: quantity,
     });
   }
 
@@ -124,7 +124,7 @@ export default class RelativeDateRangeForm extends Vue {
     this.$emit('input', {
       ...this.value,
       operator: operator.label,
-      quantity: Math.sign(operator.sign) * Math.abs(this.value.quantity),
+      quantity: this.quantity,
     });
   }
 }

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -68,7 +68,7 @@ export default class RelativeDateRangeForm extends Vue {
   @Prop({ default: () => ({ start: '', end: '' }) })
   variableDelimiters!: VariableDelimiters;
 
-  @Prop({ default: () => ({ date: '', quantity: -1, duration: 'year' }) })
+  @Prop({ default: () => ({ date: '', quantity: -1, duration: 'year', operator: 'until' }) })
   value!: RelativeDateRange;
 
   get quantity(): number {

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -16,9 +16,9 @@
     </div>
     <div class="widget-relative-date-range-form__container">
       <AutocompleteWidget
-        class="widget-relative-date-range-form__input widget-relative-date-range-form__input--direction"
-        v-model="rangeDirection"
-        :options="directions"
+        class="widget-relative-date-range-form__input widget-relative-date-range-form__input--operator"
+        v-model="operator"
+        :options="operators"
         label="label"
       />
       <AutocompleteWidget
@@ -38,7 +38,12 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputNumberWidget from '@/components/stepforms/widgets/InputNumber.vue';
-import { DEFAULT_DURATIONS, DurationOption, RelativeDateRange } from '@/lib/dates';
+import {
+  DEFAULT_DURATIONS,
+  DurationOption,
+  RELATIVE_DATE_RANGE_OPERATORS,
+  RelativeDateRange,
+} from '@/lib/dates';
 import {
   AvailableVariable,
   extractVariableIdentifier,
@@ -73,7 +78,7 @@ export default class RelativeDateRangeForm extends Vue {
   set quantity(quantity: number) {
     this.$emit('input', {
       ...this.value,
-      quantity: quantity * Math.sign(this.rangeDirection.value),
+      quantity: quantity * Math.sign(this.operator.sign),
     });
   }
 
@@ -99,21 +104,24 @@ export default class RelativeDateRangeForm extends Vue {
     this.$emit('input', { ...this.value, date: value });
   }
 
-  get directions() {
-    return [
-      { label: 'until', value: -1 },
-      { label: 'from', value: +1 },
-    ];
+  get operators() {
+    return [RELATIVE_DATE_RANGE_OPERATORS.until, RELATIVE_DATE_RANGE_OPERATORS.from];
   }
 
-  get rangeDirection() {
-    return this.value.quantity >= 0 ? this.directions[1] : this.directions[0];
+  get operator() {
+    // Current value should have an operator but we introduced it without at first,
+    // relying entierly on quantity's sign to encode it.
+    // We keep this fallback as a reminder of this mistake until someone decide that comments
+    // is not the place for keeping track of our stuttering torward Clean Code :tm:
+    const fallbackOperator = this.value.quantity >= 0 ? this.operators[1] : this.operators[0];
+    return this.operators.find(op => op.label === this.value.operator) ?? fallbackOperator;
   }
 
-  set rangeDirection(direction: { label: string; value: number }) {
+  set operator(operator: { label: string; sign: number }) {
     this.$emit('input', {
       ...this.value,
-      quantity: Math.sign(direction.value) * Math.abs(this.value.quantity),
+      operator: operator.label,
+      quantity: Math.sign(operator.sign) * Math.abs(this.value.quantity),
     });
   }
 }
@@ -175,7 +183,7 @@ export default class RelativeDateRangeForm extends Vue {
   flex: 1 100%;
 }
 
-.widget-relative-date-range-form__input--direction {
+.widget-relative-date-range-form__input--operator {
   flex: 1 0 25%;
   margin-right: 15px;
 }

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateRangeForm.vue
@@ -18,7 +18,7 @@
       <AutocompleteWidget
         class="widget-relative-date-range-form__input widget-relative-date-range-form__input--operator"
         v-model="operator"
-        :options="operators"
+        :options="availableOperators"
         label="label"
       />
       <AutocompleteWidget
@@ -104,7 +104,7 @@ export default class RelativeDateRangeForm extends Vue {
     this.$emit('input', { ...this.value, date: value });
   }
 
-  get operators() {
+  get availableOperators() {
     return [RELATIVE_DATE_RANGE_OPERATORS.until, RELATIVE_DATE_RANGE_OPERATORS.from];
   }
 
@@ -113,8 +113,11 @@ export default class RelativeDateRangeForm extends Vue {
     // relying entierly on quantity's sign to encode it.
     // We keep this fallback as a reminder of this mistake until someone decide that comments
     // is not the place for keeping track of our stuttering torward Clean Code :tm:
-    const fallbackOperator = this.value.quantity >= 0 ? this.operators[1] : this.operators[0];
-    return this.operators.find(op => op.label === this.value.operator) ?? fallbackOperator;
+    const fallbackOperator =
+      this.value.quantity >= 0
+        ? RELATIVE_DATE_RANGE_OPERATORS.from
+        : RELATIVE_DATE_RANGE_OPERATORS.until;
+    return this.availableOperators.find(op => op.label === this.value.operator) ?? fallbackOperator;
   }
 
   set operator(operator: { label: string; sign: number }) {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -28,11 +28,36 @@ export type RelativeDate = {
   duration: Duration;
 };
 
+/**
+ * With:
+ * - "date" a variable that resolve to a date, NOT A DATETIME, meaning only year, month & day
+ * - delta <=> abs(quantity) * duration
+ *
+ * and "Monday 15th" as an exemple date & "2 weeks" as an exemple delta
+ *
+ * We identified 4 possible operators:
+ * - until  = [date - delta ; date] => upper bound is included <=> [Tuesday 2nd  ; Monday 15th]
+ * - before = [date - delta ; date[ => upper bound is excluded <=> [Monday 1st   ; Sunday 14th]
+ * - from   = [date ; date + delta] => lower bound is included <=> [Monday 15th  ; Sunday 28th]
+ * - after  = ]date ; date + delta] => lower bound is excluded <=> [Tuesday 16th ; Monday 29th]
+ *
+ * However, only two of them have been implemented yet. We may or may not tweak those two or even
+ * implement the four of them after getting more user feedback regarding the relevance of current ones.
+ */
+export const RELATIVE_DATE_RANGE_OPERATORS = {
+  until: { label: 'until', sign: -1 },
+  from: { label: 'from', sign: +1 },
+};
+
+export type RelativeDateRangeOperator = keyof typeof RELATIVE_DATE_RANGE_OPERATORS;
+
 // Should be included in RelativeDate
 export type RelativeDateRange = {
   date: string;
-  quantity: number; // can be negative or positive
   duration: Duration;
+  operator: RelativeDateRangeOperator;
+  // Quantity can be negative or positive but the sign is ultimately dictated by the operator
+  quantity: number;
 };
 
 export type CustomDate = Date | RelativeDate;
@@ -126,11 +151,8 @@ export const relativeDateRangeToString = (
   const identifier = extractVariableIdentifier(relativeDateRange.date, variableDelimiters);
   const baseDateLabel = availableVariables.find(v => v.identifier === identifier)?.label;
   const relativeDate = _pick(relativeDateRange, ['quantity', 'duration']);
-  const relativeDateLabel = relativeDateToString(relativeDate, {
-    before: 'until',
-    after: 'from',
-  });
-  return `${relativeDateLabel}${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}${baseDateLabel}`;
+  const relativeDateLabel = relativeDateToString(relativeDate, { before: '', after: '' });
+  return `${relativeDateLabel} ${relativeDateRange.operator}${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}${baseDateLabel}`;
 };
 
 export const isRelativeDateRange = (

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -56,8 +56,7 @@ export type RelativeDateRange = {
   date: string;
   duration: Duration;
   operator: RelativeDateRangeOperator;
-  // Quantity can be negative or positive but the sign is ultimately dictated by the operator
-  quantity: number;
+  quantity: number; // always a positive integer, the sign is dictated by the operator
 };
 
 export type CustomDate = Date | RelativeDate;

--- a/stories/dates/date-range-input.js
+++ b/stories/dates/date-range-input.js
@@ -169,7 +169,7 @@ stories.add('custom (relative date range)', () => ({
       availableVariables: SAMPLE_VARIABLES,
       variableDelimiters: { start: '{{', end: '}}' },
       relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
-      value: { date: '{{today}}', quantity: -1, duration: 'month' },
+      value: { date: '{{today}}', quantity: -1, duration: 'month', operator: 'until' },
     };
   },
 }));

--- a/stories/dates/date-range-input.js
+++ b/stories/dates/date-range-input.js
@@ -169,7 +169,7 @@ stories.add('custom (relative date range)', () => ({
       availableVariables: SAMPLE_VARIABLES,
       variableDelimiters: { start: '{{', end: '}}' },
       relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
-      value: { date: '{{today}}', quantity: -1, duration: 'month', operator: 'until' },
+      value: { quantity: 1, duration: 'month', operator: 'until', date: '{{today}}' },
     };
   },
 }));

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -220,7 +220,12 @@ describe('Date range input', () => {
     });
 
     describe('when clicking on save button', () => {
-      const editedValue: RelativeDateRange = { date: '{{today}}', quantity: -1, duration: 'month' };
+      const editedValue: RelativeDateRange = {
+        date: '{{today}}',
+        quantity: -1,
+        duration: 'month',
+        operator: 'until',
+      };
 
       beforeEach(async () => {
         wrapper.find('RelativeDateRangeForm-stub').vm.$emit('input', editedValue);
@@ -262,7 +267,12 @@ describe('Date range input', () => {
     });
 
     describe('choose right selected tab when opening calendar', () => {
-      const initialValue: RelativeDateRange = { date: '{{today}}', quantity: 1, duration: 'month' };
+      const initialValue: RelativeDateRange = {
+        date: '{{today}}',
+        quantity: 1,
+        duration: 'month',
+        operator: 'from',
+      };
       const updatedValue = { start: new Date(), end: new Date(1) };
       beforeEach(async () => {
         createWrapper({
@@ -390,7 +400,12 @@ describe('Date range input', () => {
   });
 
   describe('with selected value as relative date', () => {
-    const value: RelativeDateRange = { date: '{{today}}', quantity: 1, duration: 'month' };
+    const value: RelativeDateRange = {
+      date: '{{today}}',
+      quantity: 1,
+      duration: 'month',
+      operator: 'from',
+    };
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
@@ -498,7 +513,12 @@ describe('Date range input', () => {
   });
 
   describe('with bounds', () => {
-    const bounds: RelativeDateRange = { date: '{{today}}', quantity: 1, duration: 'month' };
+    const bounds: RelativeDateRange = {
+      date: '{{today}}',
+      quantity: 1,
+      duration: 'month',
+      operator: 'from',
+    };
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -221,10 +221,10 @@ describe('Date range input', () => {
 
     describe('when clicking on save button', () => {
       const editedValue: RelativeDateRange = {
-        date: '{{today}}',
-        quantity: -1,
+        quantity: 1,
         duration: 'month',
         operator: 'until',
+        date: '{{today}}',
       };
 
       beforeEach(async () => {
@@ -305,7 +305,7 @@ describe('Date range input', () => {
       });
 
       describe('when updating RelativeDateRangeForm value', () => {
-        const newValue = { date: '{{today}}', quantity: -1, duration: 'month' };
+        const newValue = { quantity: 1, duration: 'month', operator: 'until', date: '{{today}}' };
         beforeEach(async () => {
           wrapper.find('RelativeDateRangeForm-stub').vm.$emit('input', newValue);
           await wrapper.vm.$nextTick();
@@ -320,7 +320,12 @@ describe('Date range input', () => {
     });
 
     describe('when switching between tabs', () => {
-      const updatedRelativeDateValue = { date: '{{today}}', quantity: -1, duration: 'month' };
+      const updatedRelativeDateValue = {
+        quantity: 1,
+        duration: 'month',
+        operator: 'until',
+        date: '{{today}}',
+      };
       beforeEach(async () => {
         wrapper.find('RelativeDateRangeForm-stub').vm.$emit('input', updatedRelativeDateValue); // update RelativeDateRangeForm value
         await wrapper.vm.$nextTick();

--- a/tests/unit/lib/dates.spec.ts
+++ b/tests/unit/lib/dates.spec.ts
@@ -145,12 +145,22 @@ describe('relativeDateRangeToString', () => {
     { label: 'Tomorrow', identifier: 'tomorrow', value: '' },
   ];
   it('should transform a relative date range to a readable label', () => {
-    const value: RelativeDateRange = { date: '{{tomorrow}}', quantity: -2, duration: 'month' };
+    const value: RelativeDateRange = {
+      date: '{{tomorrow}}',
+      quantity: -2,
+      duration: 'month',
+      operator: 'until',
+    };
     expect(relativeDateRangeToString(value, SAMPLE_VARIABLES, variableDelimiters)).toStrictEqual(
       `2 months until${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}Tomorrow`,
     );
 
-    const value2: RelativeDateRange = { date: '{{tomorrow}}', quantity: 2, duration: 'month' };
+    const value2: RelativeDateRange = {
+      date: '{{tomorrow}}',
+      quantity: 2,
+      duration: 'month',
+      operator: 'from',
+    };
     expect(relativeDateRangeToString(value2, SAMPLE_VARIABLES, variableDelimiters)).toStrictEqual(
       `2 months from${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}Tomorrow`,
     );

--- a/tests/unit/lib/dates.spec.ts
+++ b/tests/unit/lib/dates.spec.ts
@@ -146,10 +146,10 @@ describe('relativeDateRangeToString', () => {
   ];
   it('should transform a relative date range to a readable label', () => {
     const value: RelativeDateRange = {
-      date: '{{tomorrow}}',
-      quantity: -2,
+      quantity: 2,
       duration: 'month',
       operator: 'until',
+      date: '{{tomorrow}}',
     };
     expect(relativeDateRangeToString(value, SAMPLE_VARIABLES, variableDelimiters)).toStrictEqual(
       `2 months until${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}Tomorrow`,
@@ -173,7 +173,9 @@ describe('isRelativeDateRange', () => {
     expect(isRelativeDateRange({ start: new Date() })).toBe(false);
   });
   it('should return true if value is a relative date range', () => {
-    expect(isRelativeDateRange({ date: '{{today}}', quantity: -2, duration: 'year' })).toBe(true);
+    expect(
+      isRelativeDateRange({ quantity: 2, duration: 'year', operator: 'until', date: '{{today}}' }),
+    ).toBe(true);
   });
 });
 

--- a/tests/unit/relative-date-range-form-widget.spec.ts
+++ b/tests/unit/relative-date-range-form-widget.spec.ts
@@ -25,7 +25,7 @@ describe('Relative date range form', () => {
     const date = '{{today}}';
     beforeEach(() => {
       createWrapper({
-        value: { date, quantity: -1, duration: 'month', operator: 'until' },
+        value: { date, quantity: 1, duration: 'month', operator: 'until' },
         variableDelimiters: { start: '{{', end: '}}' },
         availableVariables: SAMPLE_VARIABLES,
       });
@@ -67,7 +67,7 @@ describe('Relative date range form', () => {
         const newDate = `{{${selectedDateVariable.identifier}}}`;
         expect(wrapper.emitted().input[0][0]).toStrictEqual({
           date: newDate,
-          quantity: -1,
+          quantity: 1,
           duration: 'month',
           operator: 'until',
         });
@@ -82,7 +82,7 @@ describe('Relative date range form', () => {
       it('should emit value with updated quantity and the right sign', () => {
         expect(wrapper.emitted().input[0][0]).toStrictEqual({
           date,
-          quantity: -2,
+          quantity: 2,
           duration: 'month',
           operator: 'until',
         });
@@ -99,7 +99,7 @@ describe('Relative date range form', () => {
       it('should emit value with updated duration', () => {
         expect(wrapper.emitted().input[0][0]).toStrictEqual({
           date,
-          quantity: -1,
+          quantity: 1,
           duration: 'year',
           operator: 'until',
         });
@@ -131,7 +131,7 @@ describe('Relative date range form', () => {
     it('should initiate value', () => {
       expect((wrapper.vm as any).value).toStrictEqual({
         date: '',
-        quantity: -1,
+        quantity: 1,
         duration: 'year',
         operator: 'until',
       });

--- a/tests/unit/relative-date-range-form-widget.spec.ts
+++ b/tests/unit/relative-date-range-form-widget.spec.ts
@@ -25,7 +25,7 @@ describe('Relative date range form', () => {
     const date = '{{today}}';
     beforeEach(() => {
       createWrapper({
-        value: { date, quantity: -1, duration: 'month' },
+        value: { date, quantity: -1, duration: 'month', operator: 'until' },
         variableDelimiters: { start: '{{', end: '}}' },
         availableVariables: SAMPLE_VARIABLES,
       });
@@ -49,10 +49,10 @@ describe('Relative date range form', () => {
         wrapper.find('.widget-relative-date-range-form__duration').props('value'),
       ).toStrictEqual({ label: 'Months', value: 'month' });
     });
-    it('should pass corresponding direction to rangeDirection input', () => {
+    it('should pass corresponding direction to operator input', () => {
       expect(
-        wrapper.find('.widget-relative-date-range-form__input--direction').props().value,
-      ).toStrictEqual({ label: 'until', value: -1 });
+        wrapper.find('.widget-relative-date-range-form__input--operator').props().value,
+      ).toStrictEqual({ label: 'until', sign: -1 });
     });
 
     describe('when baseDate is updated', () => {
@@ -69,6 +69,7 @@ describe('Relative date range form', () => {
           date: newDate,
           quantity: -1,
           duration: 'month',
+          operator: 'until',
         });
       });
     });
@@ -83,6 +84,7 @@ describe('Relative date range form', () => {
           date,
           quantity: -2,
           duration: 'month',
+          operator: 'until',
         });
       });
     });
@@ -99,22 +101,24 @@ describe('Relative date range form', () => {
           date,
           quantity: -1,
           duration: 'year',
+          operator: 'until',
         });
       });
     });
 
-    describe('when rangeDirection is updated', () => {
+    describe('when operator is updated', () => {
       beforeEach(async () => {
         wrapper
-          .find('.widget-relative-date-range-form__input--direction')
-          .vm.$emit('input', { label: 'from', value: +1 });
+          .find('.widget-relative-date-range-form__input--operator')
+          .vm.$emit('input', { label: 'from', sign: +1 });
         await wrapper.vm.$nextTick();
       });
-      it('should emit value with updated rangeDirection', () => {
+      it('should emit value with updated operator', () => {
         expect(wrapper.emitted().input[0][0]).toStrictEqual({
           date,
           quantity: 1,
           duration: 'month',
+          operator: 'from',
         });
       });
     });
@@ -140,10 +144,10 @@ describe('Relative date range form', () => {
         wrapper.find('.widget-relative-date-range-form__input--base-date').props().value,
       ).toStrictEqual('');
     });
-    it('should pass "before" as default value to rangeDirection input', () => {
+    it('should pass "before" as default value to operator input', () => {
       expect(
-        wrapper.find('.widget-relative-date-range-form__input--direction').props().value,
-      ).toStrictEqual({ label: 'until', value: -1 });
+        wrapper.find('.widget-relative-date-range-form__input--operator').props().value,
+      ).toStrictEqual({ label: 'until', sign: -1 });
     });
   });
 });

--- a/tests/unit/relative-date-range-form-widget.spec.ts
+++ b/tests/unit/relative-date-range-form-widget.spec.ts
@@ -129,7 +129,12 @@ describe('Relative date range form', () => {
       createWrapper();
     });
     it('should initiate value', () => {
-      expect((wrapper.vm as any).value).toStrictEqual({ date: '', quantity: -1, duration: 'year' });
+      expect((wrapper.vm as any).value).toStrictEqual({
+        date: '',
+        quantity: -1,
+        duration: 'year',
+        operator: 'until',
+      });
     });
     it('should set available variables to empty array', () => {
       expect(
@@ -144,7 +149,7 @@ describe('Relative date range form', () => {
         wrapper.find('.widget-relative-date-range-form__input--base-date').props().value,
       ).toStrictEqual('');
     });
-    it('should pass "before" as default value to operator input', () => {
+    it('should pass "until" as default value to operator input', () => {
       expect(
         wrapper.find('.widget-relative-date-range-form__input--operator').props().value,
       ).toStrictEqual({ label: 'until', sign: -1 });

--- a/tests/unit/transform-value-to-date-or-range.spec.ts
+++ b/tests/unit/transform-value-to-date-or-range.spec.ts
@@ -179,7 +179,7 @@ describe('transformValue', () => {
     },
     {
       identifier: 'relative-date-range',
-      value: { date: '{{hello}}', quantity: -2, duration: 'month' },
+      value: { quantity: -2, duration: 'month', operator: 'until', date: '{{hello}}' },
       label: 'Relative date range',
     },
     {

--- a/tests/unit/transform-value-to-date-or-range.spec.ts
+++ b/tests/unit/transform-value-to-date-or-range.spec.ts
@@ -89,10 +89,10 @@ describe('transformRelativeDateRangeToDateRange', () => {
   const variableDelimiters = { start: '{{', end: '}}' };
   it("should return undefined if variable doesn't exist", () => {
     const relativeDateRange: RelativeDateRange = {
-      date: '{{toto}}',
-      quantity: -2,
+      quantity: 2,
       duration: 'month',
       operator: 'until',
+      date: '{{toto}}',
     };
     expect(
       transformRelativeDateRangeToDateRange(
@@ -104,10 +104,10 @@ describe('transformRelativeDateRangeToDateRange', () => {
   });
   it('should return undefined if variable value is not a date', () => {
     const relativeDateRange: RelativeDateRange = {
-      date: '{{notadate}}',
-      quantity: -2,
+      quantity: 2,
       duration: 'month',
       operator: 'until',
+      date: '{{notadate}}',
     };
     expect(
       transformRelativeDateRangeToDateRange(
@@ -117,13 +117,13 @@ describe('transformRelativeDateRangeToDateRange', () => {
       ),
     ).toBeUndefined();
   });
-  it('should return date range for passed quantity and duration based on variable date (negative number)', () => {
+  it('should return date range for passed quantity and duration based on variable date (until operator)', () => {
     // ({{date}}) 2020-07-03 (included) - 3 months => 2020-04-03 (excluded) (start and end should be inverted to use min date as start)
     const relativeDateRange: RelativeDateRange = {
-      date: '{{date}}',
-      quantity: -3,
+      quantity: 3,
       duration: 'month',
       operator: 'until',
+      date: '{{date}}',
     };
     expect(
       transformRelativeDateRangeToDateRange(
@@ -136,7 +136,7 @@ describe('transformRelativeDateRangeToDateRange', () => {
       end: new Date('2020-07-03T23:59:59.999Z'), // initial day should be wholly included in the range
     });
   });
-  it('should return date range for passed quantity and duration based on variable date (positive number)', () => {
+  it('should return date range for passed quantity and duration based on variable date (from operator)', () => {
     // ({{date}}) 2020-07-03 (included) - 3 months => 2020-10-03 (excluded)
     const relativeDateRange: RelativeDateRange = {
       date: '{{date}}',
@@ -179,7 +179,7 @@ describe('transformValue', () => {
     },
     {
       identifier: 'relative-date-range',
-      value: { quantity: -2, duration: 'month', operator: 'until', date: '{{hello}}' },
+      value: { quantity: 2, duration: 'month', operator: 'until', date: '{{hello}}' },
       label: 'Relative date range',
     },
     {
@@ -320,10 +320,10 @@ describe('transformValue', () => {
     it('should return a date range if value is a relative date range', () => {
       // ({{hello}}) 20/10/2020 - 3 months => 20/07/2020
       const value: RelativeDateRange = {
-        date: 'hello',
-        quantity: -3,
+        quantity: 3,
         duration: 'month',
         operator: 'until',
+        date: 'hello',
       };
       const attendedValue = transformRelativeDateRangeToDateRange(
         value,

--- a/tests/unit/transform-value-to-date-or-range.spec.ts
+++ b/tests/unit/transform-value-to-date-or-range.spec.ts
@@ -92,6 +92,7 @@ describe('transformRelativeDateRangeToDateRange', () => {
       date: '{{toto}}',
       quantity: -2,
       duration: 'month',
+      operator: 'until',
     };
     expect(
       transformRelativeDateRangeToDateRange(
@@ -106,6 +107,7 @@ describe('transformRelativeDateRangeToDateRange', () => {
       date: '{{notadate}}',
       quantity: -2,
       duration: 'month',
+      operator: 'until',
     };
     expect(
       transformRelativeDateRangeToDateRange(
@@ -121,6 +123,7 @@ describe('transformRelativeDateRangeToDateRange', () => {
       date: '{{date}}',
       quantity: -3,
       duration: 'month',
+      operator: 'until',
     };
     expect(
       transformRelativeDateRangeToDateRange(
@@ -139,6 +142,7 @@ describe('transformRelativeDateRangeToDateRange', () => {
       date: '{{date}}',
       quantity: 3,
       duration: 'month',
+      operator: 'from',
     };
     expect(
       transformRelativeDateRangeToDateRange(
@@ -315,7 +319,12 @@ describe('transformValue', () => {
     });
     it('should return a date range if value is a relative date range', () => {
       // ({{hello}}) 20/10/2020 - 3 months => 20/07/2020
-      const value: RelativeDateRange = { date: 'hello', quantity: -3, duration: 'month' };
+      const value: RelativeDateRange = {
+        date: 'hello',
+        quantity: -3,
+        duration: 'month',
+        operator: 'until',
+      };
       const attendedValue = transformRelativeDateRangeToDateRange(
         value,
         relativeAvailableVariables,


### PR DESCRIPTION
Following lessons learned in https://github.com/ToucanToco/weaverbird/pull/1173
Refactor our `RelativeDateRange` type to explicitly include an "operator" instead of deducing it from quantity's sign.