### PR TITLE
feat(date-range-input): enable to use a compact mode for mobile purpose TCTC-755

### DIFF
--- a/src/components/DatePicker/CustomGranularityCalendar.vue
+++ b/src/components/DatePicker/CustomGranularityCalendar.vue
@@ -1,5 +1,11 @@
 <template>
-  <div class="custom-granularity-calendar" data-cy="weaverbird-custom-granularity-calendar">
+  <div
+    class="custom-granularity-calendar"
+    :class="{
+      'custom-granularity-calendar--compact': compactMode,
+    }"
+    data-cy="weaverbird-custom-granularity-calendar"
+  >
     <div class="custom-granularity-calendar__header">
       <div
         class="custom-granularity-calendar__header-btn header-btn__previous"
@@ -82,6 +88,9 @@ export default class CustomGranularityCalendar extends Vue {
 
   @Prop({ type: String, required: false })
   locale?: LocaleIdentifier;
+
+  @Prop({ default: false })
+  compactMode!: boolean;
 
   currentNavRangeStart: DateTime = DateTime.now();
 
@@ -262,11 +271,21 @@ export default class CustomGranularityCalendar extends Vue {
 }
 
 .custom-granularity-calendar__option-description {
-  line-height: 23px;
   font-size: 12px;
+  padding-top: 7px;
 }
 
 .custom-granularity-calendar__body--quarter .custom-granularity-calendar__option {
   padding: 20px 0;
+}
+
+.custom-granularity-calendar--compact {
+  width: 100%;
+  .custom-granularity-calendar__body {
+    grid-gap: 10px;
+  }
+  .custom-granularity-calendar__option-description {
+    font-size: 11px;
+  }
 }
 </style>

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tabs">
+  <div class="tabs" :class="{ 'tabs--compact': compactMode }">
     <div ref="tabsContainer" class="tabs__tabs-container">
       <div
         v-for="tab in tabs"
@@ -38,6 +38,9 @@ export default class Tabs extends Vue {
 
   @Prop({ default: () => (tab: string) => `${tab}` })
   formatTab!: Function;
+
+  @Prop({ default: false })
+  compactMode!: boolean;
 
   created() {
     // select first available tab if necessary
@@ -108,6 +111,12 @@ export default class Tabs extends Vue {
   &:hover {
     background: unset;
     color: rgba($grey-light, 0.9);
+  }
+}
+
+.tabs--compact {
+  .tabs__tabs-container {
+    overflow-x: auto;
   }
 }
 </style>

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -21,7 +21,7 @@
       class="widget-date-input__editor"
       :alwaysOpened="alwaysOpened"
       :visible="isEditorOpened"
-      :align="alignLeft"
+      :align="popoverAlignement"
       :forcePositionUpdate="forcePopoverToUpdatePosition"
       :style="themeCSSVariables"
       bottom
@@ -189,9 +189,14 @@ export default class DateRangeInput extends Vue {
 
   isEditorOpened = false;
   isEditingCustomVariable = false; // force to expand custom part of editor
-  alignLeft: string = POPOVER_ALIGN.LEFT;
   selectedTab = 'Relative';
   forcePopoverToUpdatePosition = 0;
+
+  get popoverAlignement(): string {
+    return this.compactMode && this.isEditingCustomVariable
+      ? POPOVER_ALIGN.CENTER
+      : POPOVER_ALIGN.LEFT;
+  }
 
   get accessibleVariables(): VariablesBucket {
     // some variables are required for date computations but should not be part of the variable list displayed to users

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -2,7 +2,10 @@
   <div
     class="widget-date-input"
     :style="themeCSSVariables"
-    :class="{ 'widget-date-input--colored-background': coloredBackground }"
+    :class="{
+      'widget-date-input--colored-background': coloredBackground,
+      'widget-date-input--compact': compactMode,
+    }"
   >
     <div class="widget-date-input__container" @click.stop="openEditor">
       <span class="widget-date-input__label" v-html="label" />
@@ -25,7 +28,7 @@
     >
       <div class="widget-date-input__editor-container">
         <CustomVariableList
-          v-if="hasVariables"
+          v-if="displayVariableList"
           class="widget-date-input__editor-side"
           :availableVariables="accessibleVariables"
           :selectedVariables="selectedVariables"
@@ -37,7 +40,7 @@
         <div
           class="widget-date-input__editor-content"
           v-if="enableCustom"
-          v-show="isCustom || !hasVariables"
+          v-show="displayCustomEditor"
           ref="custom-editor"
         >
           <Tabs
@@ -177,6 +180,9 @@ export default class DateRangeInput extends Vue {
   @Prop()
   dateRangeFormatter!: (dr: DateRange, locale?: LocaleIdentifier) => string | undefined;
 
+  @Prop({ default: false })
+  compactMode!: boolean;
+
   isEditorOpened = false;
   isEditingCustomVariable = false; // force to expand custom part of editor
   alignLeft: string = POPOVER_ALIGN.LEFT;
@@ -242,6 +248,18 @@ export default class DateRangeInput extends Vue {
 
   get isCustom(): boolean {
     return this.hasCustomValue || this.isEditingCustomVariable;
+  }
+
+  get displayCustomEditor(): boolean {
+    if (!this.hasVariables) return true;
+    // in compact mode always force click on custom option to open the custom editor
+    return this.compactMode ? this.isEditingCustomVariable : this.isCustom;
+  }
+
+  get displayVariableList(): boolean {
+    // in compact mode display variable list only when custom editor is not opened
+    if (this.compactMode) return !this.displayCustomEditor;
+    return this.hasVariables;
   }
 
   get isFixedTabSelected(): boolean {
@@ -502,5 +520,9 @@ export default class DateRangeInput extends Vue {
       }
     }
   }
+}
+
+.widget-date-input--compact {
+  display: inline-block;
 }
 </style>

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -20,6 +20,7 @@
     </div>
     <popover
       class="widget-date-input__editor"
+      :class="{ 'widget-date-input__editor--compact': compactMode }"
       :alwaysOpened="alwaysOpened"
       :visible="isEditorOpened"
       :align="popoverAlignement"
@@ -59,6 +60,7 @@
                 :enabledCalendars="enabledCalendars"
                 :bounds="boundsAsDateRange"
                 :locale="locale"
+                :compactMode="compactMode"
               />
             </div>
             <RelativeDateRangeForm
@@ -464,6 +466,7 @@ export default class DateRangeInput extends Vue {
   justify-content: space-between;
   flex: 1 100%;
   border-left: 1px solid #eeedf0;
+  width: 100%;
 }
 .widget-date-input__editor-header {
   flex: 0;
@@ -476,11 +479,6 @@ export default class DateRangeInput extends Vue {
   flex: 1;
   height: 278px;
   min-height: 278px;
-  .vc-container {
-    border: none;
-    margin: 1px;
-    width: 100%;
-  }
   .widget-relative-date-range-form {
     margin: 20px;
     width: 400px;
@@ -550,5 +548,9 @@ export default class DateRangeInput extends Vue {
   .widget-date-input__label {
     padding-right: 0;
   }
+}
+
+.widget-date-input__editor--compact {
+  max-width: calc(100% - 20px);
 }
 </style>

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -6,6 +6,7 @@
       'widget-date-input--colored-background': coloredBackground,
       'widget-date-input--compact': compactMode,
       'widget-date-input--hide-label': hideLabel,
+      'widget-date-input--reset': !!value,
     }"
   >
     <div class="widget-date-input__container" @click.stop="openEditor">
@@ -410,6 +411,7 @@ export default class DateRangeInput extends Vue {
   padding: 10px 15px;
   cursor: pointer;
   opacity: 0.5;
+  font-size: 14px;
 
   &:hover {
     opacity: 1;
@@ -425,6 +427,7 @@ export default class DateRangeInput extends Vue {
   padding: 10px 15px;
   background: $grey-extra-light;
   color: $grey;
+  font-size: 14px;
 }
 
 .widget-date-input__container:hover {
@@ -522,6 +525,9 @@ export default class DateRangeInput extends Vue {
   .widget-date-input__reset-button {
     color: white;
   }
+  .widget-date-input__reset-button + .widget-date-input__type-icon {
+    padding-left: 0;
+  }
   .widget-date-input__container {
     &,
     &:hover {
@@ -530,7 +536,6 @@ export default class DateRangeInput extends Vue {
       .widget-date-input__type-icon {
         background: none;
         color: white;
-        padding-left: 0;
       }
     }
   }
@@ -539,5 +544,11 @@ export default class DateRangeInput extends Vue {
 .widget-date-input--hide-label {
   display: inline-block;
   width: auto;
+}
+
+.widget-date-input--reset {
+  .widget-date-input__label {
+    padding-right: 0;
+  }
 }
 </style>

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -5,10 +5,11 @@
     :class="{
       'widget-date-input--colored-background': coloredBackground,
       'widget-date-input--compact': compactMode,
+      'widget-date-input--hide-label': hideLabel,
     }"
   >
     <div class="widget-date-input__container" @click.stop="openEditor">
-      <span class="widget-date-input__label" v-html="label" />
+      <span class="widget-date-input__label" v-if="!hideLabel" v-html="label" />
       <div class="widget-date-input__reset-button" v-if="!!value" @click.stop="resetValue">
         <FAIcon icon="times" class="widget-date-input__reset-button-icon" />
       </div>
@@ -183,6 +184,9 @@ export default class DateRangeInput extends Vue {
   @Prop({ default: false })
   compactMode!: boolean;
 
+  @Prop({ default: false })
+  hidePlaceholder!: boolean;
+
   isEditorOpened = false;
   isEditingCustomVariable = false; // force to expand custom part of editor
   alignLeft: string = POPOVER_ALIGN.LEFT;
@@ -287,6 +291,10 @@ export default class DateRangeInput extends Vue {
     }
   }
 
+  get hideLabel(): boolean {
+    return this.hidePlaceholder && !this.value;
+  }
+
   get customLabel(): string {
     if (this.enableRelativeDate) {
       return this.t('CUSTOM');
@@ -373,6 +381,7 @@ export default class DateRangeInput extends Vue {
 
 .widget-date-input {
   max-width: 400px;
+  width: 100%;
   position: relative;
 }
 .widget-date-input__container {
@@ -522,7 +531,8 @@ export default class DateRangeInput extends Vue {
   }
 }
 
-.widget-date-input--compact {
+.widget-date-input--hide-label {
   display: inline-block;
+  width: auto;
 }
 </style>

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -391,7 +391,50 @@ export default class DateRangeInput extends Vue {
   max-width: 400px;
   width: 100%;
   position: relative;
+
+  &.widget-date-input--hide-label {
+    // resize container to fit calendar icon only
+    display: inline-block;
+    width: auto;
+  }
+
+  &.widget-date-input--reset {
+    .widget-date-input__label {
+      // reduce padding between reset button and label
+      padding-right: 0;
+    }
+  }
+
+  &.widget-date-input--compact.widget-date-input--reset {
+    // hide calendar icon in compact mode to have more space to display label
+    .widget-date-input__type-icon {
+      display: none;
+    }
+  }
+
+  &.widget-date-input--colored-background {
+    .widget-date-input__label,
+    .widget-date-input__reset-button {
+      color: white;
+    }
+    .widget-date-input__reset-button + .widget-date-input__type-icon {
+      // in colored mode, reduce padding because there is no background under calendar icon
+      padding-left: 0;
+    }
+    .widget-date-input__container {
+      &,
+      &:hover {
+        background: var(--weaverbird-theme-emphasis-color, $active-color);
+        border-color: var(--weaverbird-theme-emphasis-color, $active-color);
+        .widget-date-input__type-icon {
+          background: none;
+          color: white;
+        }
+      }
+    }
+  }
 }
+
 .widget-date-input__container {
   border: 1px solid $grey-light;
   display: flex;
@@ -444,6 +487,11 @@ export default class DateRangeInput extends Vue {
   margin-top: 3px;
   background-color: #fff;
   box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.25);
+
+  & .widget-date-input__editor--compact {
+    // in compact mode use 100% of document width to display calendars
+    max-width: calc(100% - 20px);
+  }
 }
 .widget-date-input__editor-container {
   display: flex;
@@ -516,48 +564,5 @@ export default class DateRangeInput extends Vue {
   opacity: 0.5;
   pointer-events: none;
   cursor: not-allowed;
-}
-
-.widget-date-input--colored-background {
-  .widget-date-input__label,
-  .widget-date-input__reset-button {
-    color: white;
-  }
-  .widget-date-input__reset-button + .widget-date-input__type-icon {
-    padding-left: 0;
-  }
-  .widget-date-input__container {
-    &,
-    &:hover {
-      background: var(--weaverbird-theme-emphasis-color, $active-color);
-      border-color: var(--weaverbird-theme-emphasis-color, $active-color);
-      .widget-date-input__type-icon {
-        background: none;
-        color: white;
-      }
-    }
-  }
-}
-
-.widget-date-input--hide-label {
-  display: inline-block;
-  width: auto;
-}
-
-.widget-date-input--reset {
-  .widget-date-input__label {
-    padding-right: 0;
-  }
-}
-
-.widget-date-input__editor--compact {
-  max-width: calc(100% - 20px);
-}
-
-.widget-date-input--compact.widget-date-input--reset {
-  // hide calendar icon in compact mode to have more space to display label
-  .widget-date-input__type-icon {
-    display: none;
-  }
 }
 </style>

--- a/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -553,4 +553,11 @@ export default class DateRangeInput extends Vue {
 .widget-date-input__editor--compact {
   max-width: calc(100% - 20px);
 }
+
+.widget-date-input--compact.widget-date-input--reset {
+  // hide calendar icon in compact mode to have more space to display label
+  .widget-date-input__type-icon {
+    display: none;
+  }
+}
 </style>

--- a/src/components/stepforms/widgets/DateComponents/TabbedRangeCalendars.vue
+++ b/src/components/stepforms/widgets/DateComponents/TabbedRangeCalendars.vue
@@ -1,11 +1,12 @@
 <template>
-  <div>
+  <div :class="{ 'tabbed-ranged-calendar--compact': compactMode }">
     <Tabs
       v-if="enabledCalendars.length > 1"
       :tabs="enabledCalendars"
       :selectedTab="selectedTab"
       @tabSelected="selectTab"
       :format-tab="translateTab"
+      :compactMode="compactMode"
     />
     <div class="widget-multi-date-input__body">
       <Calendar
@@ -21,6 +22,7 @@
         :granularity="calendarGranularity"
         :bounds="bounds"
         :locale="locale"
+        :compactMode="compactMode"
       />
     </div>
   </div>
@@ -55,6 +57,9 @@ export default class TabbedRangeCalendars extends Vue {
 
   @Prop({ type: String, required: false })
   locale?: LocaleIdentifier;
+
+  @Prop({ default: false })
+  compactMode!: boolean;
 
   selectedTab = this.enabledCalendars[0];
 
@@ -104,6 +109,17 @@ export default class TabbedRangeCalendars extends Vue {
 
 <style scoped lang="scss">
 .widget-multi-date-input__body {
-  padding: 20px 24px;
+  padding: 20px;
+  ::v-deep .vc-container {
+    border: none;
+    margin: 1px;
+    padding: 0;
+    width: 100%;
+  }
+}
+.tabbed-ranged-calendar--compact {
+  .widget-multi-date-input__body {
+    padding: 10px;
+  }
 }
 </style>

--- a/stories/dates/date-range-input.js
+++ b/stories/dates/date-range-input.js
@@ -290,17 +290,37 @@ stories.add('without any variable', () => ({
 }));
 
 stories.add('always open (preview mode)', () => ({
+  props: {
+    compactMode: {
+      default: boolean('Compact mode', false),
+    },
+    hidePlaceholder: {
+      default: boolean('Hide placeholder', false),
+    },
+    coloredBackground: {
+      default: boolean('Colored background', true),
+    },
+    enableCustom: {
+      default: boolean('Enable custom', true),
+    },
+    enableVariables: {
+      default: boolean('Enable variables', true),
+    },
+  },
   template: `
     <div>
       <DateRangeInput
         v-model="value"
         :enable-relative-date="true"
-        :enable-custom="true"
+        :enable-custom="enableCustom"
         :alwaysOpened="true"
         :enabledCalendars="['day', 'week', 'month', 'quarter', 'year']"
         :available-variables="availableVariables"
         :relative-available-variables="relativeAvailableVariables"
         :variable-delimiters="variableDelimiters"
+        :hidePlaceholder="hidePlaceholder"
+        :coloredBackground="coloredBackground"
+        :compactMode="compactMode"
       />
       <pre style="margin-top: 500px;">{{ value }}</pre>
     </div>
@@ -314,12 +334,16 @@ stories.add('always open (preview mode)', () => ({
     return {
       value: undefined,
       actualRangeValue: undefined,
-      availableVariables: SAMPLE_VARIABLES,
       variableDelimiters: { start: '{{', end: '}}' },
       relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
     };
   },
 
+  computed: {
+    availableVariables() {
+      return this.enableVariables ? SAMPLE_VARIABLES : [];
+    },
+  },
 }));
 stories.add('localized (fr)', () => ({
   template: `
@@ -388,7 +412,6 @@ stories.add('custom css variables', () => ({
     };
   },
 }));
-
 
 stories.add('compact mode', () => ({
   props: {

--- a/stories/dates/date-range-input.js
+++ b/stories/dates/date-range-input.js
@@ -391,6 +391,14 @@ stories.add('custom css variables', () => ({
 
 
 stories.add('compact mode', () => ({
+  props: {
+    hidePlaceholder: {
+      default: boolean('Hide placeholder', true),
+    },
+    coloredBackground: {
+      default: boolean('Colored background', true),
+    },
+  },
   template: `
     <div>
       <DateRangeInput
@@ -402,6 +410,8 @@ stories.add('compact mode', () => ({
         :relative-available-variables="relativeAvailableVariables"
         :variable-delimiters="variableDelimiters"
         :compactMode="true"
+        :hidePlaceholder="hidePlaceholder"
+        :coloredBackground="coloredBackground"
       />
       <pre>{{ value }}</pre>
       <pre>{{ actualRangeValue }}</pre>

--- a/stories/dates/date-range-input.js
+++ b/stories/dates/date-range-input.js
@@ -388,3 +388,37 @@ stories.add('custom css variables', () => ({
     };
   },
 }));
+
+
+stories.add('compact mode', () => ({
+  template: `
+    <div>
+      <DateRangeInput
+        v-model="value"
+        :enable-relative-date="true"
+        :enable-custom="true"
+        :enabledCalendars="['day', 'week', 'month', 'quarter', 'year']"
+        :available-variables="availableVariables"
+        :relative-available-variables="relativeAvailableVariables"
+        :variable-delimiters="variableDelimiters"
+        :compactMode="true"
+      />
+      <pre>{{ value }}</pre>
+      <pre>{{ actualRangeValue }}</pre>
+    </div>
+  `,
+
+  components: {
+    DateRangeInput,
+  },
+
+  data() {
+    return {
+      value: undefined,
+      actualRangeValue: undefined,
+      availableVariables: SAMPLE_VARIABLES,
+      variableDelimiters: { start: '{{', end: '}}' },
+      relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
+    };
+  },
+}));

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -1,5 +1,6 @@
 import { shallowMount, Wrapper } from '@vue/test-utils';
 
+import { POPOVER_ALIGN } from '@/components/constants';
 import DateRangeInput from '@/components/stepforms/widgets/DateComponents/DateRangeInput.vue';
 import {
   CUSTOM_DATE_RANGE_LABEL_SEPARATOR,
@@ -123,6 +124,11 @@ describe('Date range input', () => {
         SAMPLE_VARIABLES,
       );
     });
+    it('should align popover left', () => {
+      expect(wrapper.find('.widget-date-input__editor').props().align).toStrictEqual(
+        POPOVER_ALIGN.LEFT,
+      );
+    });
 
     describe('reset button', () => {
       let resetButtonWrapper: Wrapper<any>;
@@ -186,6 +192,11 @@ describe('Date range input', () => {
       });
       it('should force popover to update position to always display custom editor in visible part of screen', () => {
         expect(wrapper.find('.widget-date-input__editor').props().forcePositionUpdate).toBe(1);
+      });
+      it('should align popover left', () => {
+        expect(wrapper.find('.widget-date-input__editor').props().align).toStrictEqual(
+          POPOVER_ALIGN.LEFT,
+        );
       });
     });
   });
@@ -565,6 +576,11 @@ describe('Date range input', () => {
         });
         it('should hide variable list', () => {
           expect(wrapper.find('CustomVariableList-stub').exists()).toBe(false);
+        });
+        it('should align popover center', () => {
+          expect(wrapper.find('.widget-date-input__editor').props().align).toStrictEqual(
+            POPOVER_ALIGN.CENTER,
+          );
         });
       });
     });

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -589,6 +589,24 @@ describe('Date range input', () => {
     });
   });
 
+  describe('hide placeholder', () => {
+    beforeEach(() => {
+      createWrapper({
+        availableVariables: SAMPLE_VARIABLES,
+        relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
+        variableDelimiters: { start: '{{', end: '}}' },
+        hidePlaceholder: true,
+      });
+    });
+    it('should hide label when no value selected', () => {
+      expect(wrapper.find('.widget-date-input__label').exists()).toBe(false);
+    });
+    it('should show label when a value is selected', async () => {
+      await wrapper.setProps({ value: { start: new Date(), end: new Date(1) } });
+      expect(wrapper.find('.widget-date-input__label').exists()).toBe(true);
+    });
+  });
+
   describe('empty', () => {
     beforeEach(() => {
       createWrapper();

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -542,6 +542,53 @@ describe('Date range input', () => {
     });
   });
 
+  describe('compact mode', () => {
+    describe('default', () => {
+      beforeEach(() => {
+        createWrapper({
+          availableVariables: SAMPLE_VARIABLES,
+          relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
+          variableDelimiters: { start: '{{', end: '}}' },
+          compactMode: true,
+        });
+      });
+      it('should add specific class to wrapper', () => {
+        expect(wrapper.classes()).toContain('widget-date-input--compact');
+      });
+      describe('when clicking on custom option', () => {
+        beforeEach(async () => {
+          wrapper.find('CustomVariableList-stub').vm.$emit('selectCustomVariable');
+          await wrapper.vm.$nextTick();
+        });
+        it('should show custom editor', () => {
+          expect(wrapper.find({ ref: 'custom-editor' }).isVisible()).toBe(true);
+        });
+        it('should hide variable list', () => {
+          expect(wrapper.find('CustomVariableList-stub').exists()).toBe(false);
+        });
+      });
+    });
+    describe('when selected value is not a variable', () => {
+      beforeEach(() => {
+        createWrapper({
+          availableVariables: SAMPLE_VARIABLES,
+          variableDelimiters: { start: '{{', end: '}}' },
+          value: { start: new Date(), end: new Date(1) },
+          compactMode: true,
+        });
+      });
+      it('should only display variable list by default', () => {
+        expect(wrapper.find('CustomVariableList-stub').exists()).toBe(true);
+        expect(wrapper.find({ ref: 'custom-editor' }).isVisible()).toBe(false);
+      });
+      it('should use "custom" as selected variable', () => {
+        expect(wrapper.find('CustomVariableList-stub').props().selectedVariables).toStrictEqual(
+          'custom',
+        );
+      });
+    });
+  });
+
   describe('empty', () => {
     beforeEach(() => {
       createWrapper();


### PR DESCRIPTION
Add compact class and custom css to define a mobile version (passed as props to define endpoint outside)
Enable to hide placeholder (display only calendar icon, when no value is selected)
Use correct alignement for popover on mobile
Add all cases as knobs to storybook

Info:
The calendar will be removed on compact mode when a value is selected in order to display label more clearly.

![compact](https://user-images.githubusercontent.com/59559689/141974131-4ff958e1-b089-44be-b8ec-8908fac750a3.gif)

![compact-mobile](https://user-images.githubusercontent.com/59559689/141974119-44a9fb6a-6dc8-436c-b49c-eae8e6e7d8e3.gif)

