### PR TITLE
fix(calendars): reset value when selected range is out of updated bounds TCTC-1248

### DIFF
--- a/src/components/DatePicker/Calendar.vue
+++ b/src/components/DatePicker/Calendar.vue
@@ -122,7 +122,7 @@ export default class Calendar extends Vue {
   resetValueOutOfBounds() {
     if (this.availableDates.start && _isEmpty(this.boundedValue)) {
       if (this.value) this.onInput(undefined);
-      this.defaultDate = this.availableDates.start ?? '';
+      this.defaultDate = this.availableDates.start;
     }
   }
 }

--- a/src/components/DatePicker/Calendar.vue
+++ b/src/components/DatePicker/Calendar.vue
@@ -120,7 +120,7 @@ export default class Calendar extends Vue {
 
   @Watch('availableDates')
   resetValueOutOfBounds() {
-    if (_isEmpty(this.boundedValue)) {
+    if (this.availableDates.start && _isEmpty(this.boundedValue)) {
       if (this.value) this.onInput(undefined);
       this.defaultDate = this.availableDates.start ?? '';
     }

--- a/src/components/DatePicker/Calendar.vue
+++ b/src/components/DatePicker/Calendar.vue
@@ -16,9 +16,10 @@
 </template>
 
 <script lang="ts">
+import _isEmpty from 'lodash/isEmpty';
 import _isEqual from 'lodash/isEqual';
 import DatePicker from 'v-calendar/src/components/DatePicker.vue';
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
 import { clampRange, DatePickerHighlight, DateRange, isDateRange } from '@/lib/dates';
 import { LocaleIdentifier } from '@/lib/internationalization';
@@ -115,6 +116,14 @@ export default class Calendar extends Vue {
   // when user start to select a range he has only start value selected, we disable validate button until he select the end value
   onDrag(dragValue: DateRange): void {
     this.$emit('input', { start: dragValue.start, duration: 'day' });
+  }
+
+  @Watch('availableDates')
+  resetValueOutOfBounds() {
+    if (_isEmpty(this.boundedValue)) {
+      if (this.value) this.onInput(undefined);
+      this.defaultDate = this.availableDates.start ?? '';
+    }
   }
 }
 </script>

--- a/src/components/DatePicker/CustomGranularityCalendar.vue
+++ b/src/components/DatePicker/CustomGranularityCalendar.vue
@@ -154,7 +154,6 @@ export default class CustomGranularityCalendar extends Vue {
   }
 
   created() {
-    if (this.selectedRangeStart) this.currentNavRangeStart = this.selectedRangeStart;
     this.updateSelectedRange();
   }
 
@@ -170,8 +169,28 @@ export default class CustomGranularityCalendar extends Vue {
     return this.pickerConfig.selectableRanges.optionToRange(date);
   }
 
-  selectRange(range: DateRange) {
+  selectRange(range: DateRange | undefined) {
     this.$emit('input', range);
+  }
+
+  updateNavStart(): void {
+    if (this.selectedRangeStart) {
+      // update navigation start to retrieve page with available options containing selected date range
+      this.currentNavRangeStart = this.selectedRangeStart;
+    } else if (this.bounds.start) {
+      // update nav start to retrieve page with available options for selected bound start
+      this.currentNavRangeStart = this.pickerConfig.selectableRanges.rangeToOption(
+        this.bounds.start,
+      );
+    }
+  }
+
+  @Watch('bounds')
+  resetRangeOutOfBounds() {
+    if (this.bounds.start && this.value && !this.boundedValue) {
+      this.selectRange(undefined);
+    }
+    this.updateNavStart();
   }
 
   @Watch('granularity')
@@ -179,10 +198,8 @@ export default class CustomGranularityCalendar extends Vue {
     if (this.selectedRangeStart) {
       const range = this.retrieveRangeFromOption(this.selectedRangeStart);
       this.selectRange(range);
-      // update navigation start to retrieve options of same page that selected date range in new granularity
-      // ex: we select 2028 in year tab then switch to month tab, we expect to retrieve 2028's months as options
-      this.currentNavRangeStart = this.selectedRangeStart;
     }
+    this.updateNavStart();
   }
 }
 </script>

--- a/src/components/stepforms/widgets/DateComponents/TabbedRangeCalendars.vue
+++ b/src/components/stepforms/widgets/DateComponents/TabbedRangeCalendars.vue
@@ -46,10 +46,10 @@ import t, { LocaleIdentifier } from '@/lib/internationalization';
   },
 })
 export default class TabbedRangeCalendars extends Vue {
-  @Prop({ default: () => [] })
+  @Prop({ default: () => ({}) })
   value!: CustomDateRange;
 
-  @Prop({ default: () => [] })
+  @Prop({ default: () => ({}) })
   bounds!: DateRange;
 
   @Prop({ default: () => ['year', 'quarter', 'month', 'week', 'day'] })
@@ -69,7 +69,10 @@ export default class TabbedRangeCalendars extends Vue {
 
   @Watch('enabledCalendars')
   onEnabledCalendarsChange() {
-    if (!this.value.duration || !this.enabledCalendars.includes(this.value.duration)) {
+    if (
+      !this.enabledCalendars.includes(this.selectedTab) ||
+      (this.value.duration && !this.enabledCalendars.includes(this.value.duration))
+    ) {
       this.selectedTab = this.enabledCalendars[0];
     }
   }

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -166,7 +166,7 @@ export const isDateRange = (value: undefined | string | CustomDateRange): value 
   return Object.keys(value).length === 0 || _has(value, 'start') || _has(value, 'end');
 };
 
-export const clampRange = (range: DateRange, bounds: DateRange): DateRange => {
+export const clampRange = (range: DateRange, bounds: DateRange): DateRange | undefined => {
   if (range.start == null || range.end == null || bounds.start == null || bounds.end == null) {
     return range;
   }
@@ -176,7 +176,7 @@ export const clampRange = (range: DateRange, bounds: DateRange): DateRange => {
   const rangeContainBounds = range.start < bounds.start && bounds.end < range.end;
 
   if (rangeStartIsOutOfBound && rangeEndIsOutOfBound && !rangeContainBounds) {
-    throw new Error('Cannot clamp range that does not overlap with bounds');
+    return undefined;
   }
 
   const clampedRange = {

--- a/tests/unit/calendar.spec.ts
+++ b/tests/unit/calendar.spec.ts
@@ -97,7 +97,30 @@ describe('Calendar', () => {
       });
 
       it('should emit clamped range', () => {
+        expect(wrapper.emitted('input')).toHaveLength(1);
         expect(wrapper.emitted('input')[0][0]).toStrictEqual(bounds);
+      });
+
+      describe('when value is completely out of updated bounds', () => {
+        const updatedBounds = {
+          start: new Date('09/15/2020'),
+          end: new Date('10/15/2020'),
+          duration: 'day',
+        };
+        beforeEach(async () => {
+          await wrapper.setProps({
+            availableDates: updatedBounds,
+          });
+        });
+        it('should move calendar cursor to start bound', () => {
+          expect(wrapper.find('DatePicker-stub').attributes('from-date')).toStrictEqual(
+            updatedBounds.start.toString(),
+          );
+        });
+        it('should reset value', () => {
+          expect(wrapper.emitted('input')).toHaveLength(2);
+          expect(wrapper.emitted('input')[1][0]).toBeUndefined();
+        });
       });
     });
   });

--- a/tests/unit/lib/dates.spec.ts
+++ b/tests/unit/lib/dates.spec.ts
@@ -244,12 +244,12 @@ describe('clampRange', () => {
     };
     expect(clampRange(rangeOutOfBounds, bounds)).toStrictEqual(bounds);
   });
-  it('should throw an error when range it completely out of bounds without any overlap', () => {
+  it('should return undefined when range it completely out of bounds without any overlap', () => {
     const rangeOutOfBounds: DateRange = {
       start: new Date('2022-11-16T00:00:00'),
       end: new Date('2022-11-18T00:00:00'),
       duration: 'day',
     };
-    expect(() => clampRange(rangeOutOfBounds, bounds)).toThrow();
+    expect(clampRange(rangeOutOfBounds, bounds)).toBeUndefined();
   });
 });

--- a/tests/unit/tabbed-range-calendars.spec.ts
+++ b/tests/unit/tabbed-range-calendars.spec.ts
@@ -49,16 +49,16 @@ describe('TabbedRangeCalendars', () => {
     expect(wrapper.find('Tabs-stub').props('selectedTab')).toBe('year');
   });
 
-  describe('with only some calendar enabled', () => {
+  describe('when updating enabled calendars', () => {
     beforeEach(async () => {
-      await wrapper.setProps({ enabledCalendars: ['quarter', 'year'] });
+      await wrapper.setProps({ enabledCalendars: ['quarter', 'day'] });
     });
 
     it('should only enable those calendar tabs', () => {
-      expect(wrapper.find('Tabs-stub').props('tabs')).toStrictEqual(['quarter', 'year']);
+      expect(wrapper.find('Tabs-stub').props('tabs')).toStrictEqual(['quarter', 'day']);
     });
 
-    it('should select the first tab by default', () => {
+    it('should select the first tab available when previous selected tab is missing', () => {
       expect(wrapper.find('Tabs-stub').props('selectedTab')).toBe('quarter');
     });
   });


### PR DESCRIPTION
Avoid selected range error when upadting bounds and value is now out of bounds.
Reset value instead
Also add a new behaviour to adapt nav to new selected bounds if there is no value selected (avoid user to stay on the same calendar page and have no available options)

:warning: There is a bug with day calendar on my chrome version exclusively don't keep attention on it

![after](https://user-images.githubusercontent.com/59559689/142206829-3e900576-57bd-47f7-96b6-c46949f77efb.gif)


