### PR TITLE
fix(variable-input-base): avoid variable to replace single string when selecting a variable in multiple mode TCTC-1047

### DIFF
--- a/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
@@ -95,7 +95,8 @@ export default class VariableInputBase extends Vue {
     } else {
       return this.value.reduce((variables: string[], value: string) => {
         const identifier = extractVariableIdentifier(value, this.variableDelimiters);
-        return identifier ? [...variables, identifier] : variables;
+        // in case value is a simple string we still want to keep it in array
+        return [...variables, identifier || value];
       }, []);
     }
   }
@@ -128,8 +129,11 @@ export default class VariableInputBase extends Vue {
   setVariableDelimiters(value: string | string[]): string | string[] {
     const addVariableDelimiters = (variableIdentifier: string) =>
       `${this.variableDelimiters.start} ${variableIdentifier} ${this.variableDelimiters.end}`;
+    // check if value is a variable
+    const isVariable = (identifier: string): boolean =>
+      Boolean(this.availableVariables.find(v => v.identifier === identifier));
     return Array.isArray(value)
-      ? value.map(v => addVariableDelimiters(v))
+      ? value.map(v => (isVariable(v) ? addVariableDelimiters(v) : v))
       : addVariableDelimiters(value);
   }
 

--- a/tests/unit/variable-input-base.spec.ts
+++ b/tests/unit/variable-input-base.spec.ts
@@ -75,7 +75,7 @@ describe('Variable Input', () => {
   describe('with multiple selected variables', () => {
     beforeEach(async () => {
       wrapper.setProps({
-        value: ['{{ appRequesters.city }}', '{{ appRequesters.country }}'],
+        value: ['{{ appRequesters.city }}', '{{ appRequesters.country }}', 'toto'],
       });
       await wrapper.vm.$nextTick();
     });
@@ -84,6 +84,8 @@ describe('Variable Input', () => {
       expect(wrapper.find('VariableChooser-stub').props().selectedVariables).toStrictEqual([
         'appRequesters.city',
         'appRequesters.country',
+        // toto is a simple string not a variable so keep it unchanged
+        'toto',
       ]);
     });
   });
@@ -176,7 +178,7 @@ describe('Variable Input', () => {
           wrapper.setProps({ isMultiple: true });
           wrapper
             .find('VariableChooser-stub')
-            .vm.$emit('input', ['appRequesters.view', 'appRequesters.city']);
+            .vm.$emit('input', ['appRequesters.view', 'appRequesters.city', 'toto']);
           await wrapper.vm.$nextTick();
         });
 
@@ -187,7 +189,12 @@ describe('Variable Input', () => {
         it('should emit a new values with the chosen variables', () => {
           expect(wrapper.emitted('input')).toHaveLength(1);
           expect(wrapper.emitted('input')[0]).toEqual([
-            ['{{ appRequesters.view }}', '{{ appRequesters.city }}'],
+            [
+              '{{ appRequesters.view }}',
+              '{{ appRequesters.city }}',
+              // toto is a simple string not a variable so keep it unchanged
+              'toto',
+            ],
           ]);
         });
       });


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/59559689/142654009-7b1e8a7f-fbe8-46b2-bed1-2f82d3d75374.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/142654028-cba80eea-6a4c-455b-83a3-2bc041582838.gif)
