### PR TITLE
feat(filter-step): use specific operator for date columns TCTC-1193

### DIFF
--- a/src/components/stepforms/schemas/filter.ts
+++ b/src/components/stepforms/schemas/filter.ts
@@ -120,6 +120,8 @@ export default {
             'notmatches',
             'isnull',
             'notnull',
+            'from',
+            'until',
           ],
           title: 'Operator',
           description: 'The filter operator',

--- a/src/components/stepforms/schemas/ifthenelse.ts
+++ b/src/components/stepforms/schemas/ifthenelse.ts
@@ -148,6 +148,8 @@ export default {
             'notmatches',
             'isnull',
             'notnull',
+            'from',
+            'until',
           ],
           title: 'Operator',
           description: 'The filter operator',

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -81,7 +81,9 @@ type LiteralOperator =
   | 'matches pattern'
   | "doesn't match pattern"
   | 'is null'
-  | 'is not null';
+  | 'is not null'
+  | 'from'
+  | 'until';
 
 type ShortOperator = FilterSimpleCondition['operator'];
 

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -229,8 +229,7 @@ export default class FilterSimpleConditionWidget extends Vue {
   }
 
   get inputWidget(): VueConstructor<Vue> | undefined {
-    const widget = this.availableOperators.find(d => d.operator === this.value.operator)
-      ?.inputWidget;
+    const widget = this.operator.inputWidget;
     if (
       this.hasDateSelectedColumn &&
       widget === InputTextWidget &&

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -24,7 +24,7 @@
         class="filterOperator"
         :value="operator"
         @input="updateStepOperator"
-        :options="operators"
+        :options="availableOperators"
         placeholder="Filter operator"
         :trackBy="`operator`"
         :label="`label`"
@@ -55,7 +55,7 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
-import { ColumnTypeMapping } from '@/lib/dataset/index.ts';
+import { ColumnTypeMapping } from '@/lib/dataset/index';
 import {
   keepCurrentValueIfArrayType,
   keepCurrentValueIfCompatibleDate,
@@ -100,6 +100,7 @@ export const DEFAULT_FILTER = { column: '', value: '', operator: 'eq' };
   components: {
     AutocompleteWidget,
     InputTextWidget,
+    InputDateWidget,
   },
 })
 export default class FilterSimpleConditionWidget extends Vue {
@@ -132,6 +133,8 @@ export default class FilterSimpleConditionWidget extends Vue {
 
   @VQBModule.Getter('columnNames') columnNamesFromStore!: string[];
 
+  @VQBModule.State('featureFlags') featureFlags!: Record<string, any>;
+
   @VQBModule.Mutation setSelectedColumns!: MutationCallbacks['setSelectedColumns'];
 
   @Prop()
@@ -152,7 +155,12 @@ export default class FilterSimpleConditionWidget extends Vue {
     this.updateStepOperator(this.operator);
   }
 
-  readonly operators: OperatorOption[] = [
+  readonly nullOperators: OperatorOption[] = [
+    { operator: 'isnull', label: 'is null' },
+    { operator: 'notnull', label: 'is not null' },
+  ];
+
+  readonly baseOperators: OperatorOption[] = [
     { operator: 'eq', label: 'equals', inputWidget: InputTextWidget },
     { operator: 'ne', label: "doesn't equal", inputWidget: InputTextWidget },
     { operator: 'gt', label: 'is greater than', inputWidget: InputTextWidget },
@@ -163,8 +171,13 @@ export default class FilterSimpleConditionWidget extends Vue {
     { operator: 'nin', label: 'is not one of', inputWidget: MultiInputTextWidget },
     { operator: 'matches', label: 'matches pattern', inputWidget: InputTextWidget },
     { operator: 'notmatches', label: "doesn't match pattern", inputWidget: InputTextWidget },
-    { operator: 'isnull', label: 'is null' },
-    { operator: 'notnull', label: 'is not null' },
+    ...this.nullOperators,
+  ];
+
+  readonly dateOperators: OperatorOption[] = [
+    { operator: 'from', label: 'from', inputWidget: InputDateWidget },
+    { operator: 'until', label: 'until', inputWidget: InputDateWidget },
+    ...this.nullOperators,
   ];
 
   created() {
@@ -186,6 +199,17 @@ export default class FilterSimpleConditionWidget extends Vue {
     }
   }
 
+  get enableRelativeDateFiltering(): boolean {
+    return this.featureFlags?.RELATIVE_DATE_FILTERING === 'enable';
+  }
+
+  get availableOperators(): OperatorOption[] {
+    if (this.hasDateSelectedColumn && this.enableRelativeDateFiltering) {
+      return this.dateOperators;
+    }
+    return this.baseOperators;
+  }
+
   get placeholder() {
     if (this.value.operator === 'matches' || this.value.operator === 'notmatches') {
       return 'Enter a regex, e.g. "[Ss]ales"';
@@ -198,19 +222,23 @@ export default class FilterSimpleConditionWidget extends Vue {
   }
 
   get operator(): OperatorOption {
-    return this.operators.filter(d => d.operator === this.value.operator)[0];
+    return (
+      this.availableOperators.find(d => d.operator === this.value.operator) ??
+      this.availableOperators[0]
+    );
   }
 
   get inputWidget(): VueConstructor<Vue> | undefined {
-    const widget = this.operators.filter(d => d.operator === this.value.operator)[0].inputWidget;
-    if (this.hasDateSelectedColumn && widget === InputTextWidget) {
+    const widget = this.availableOperators.find(d => d.operator === this.value.operator)
+      ?.inputWidget;
+    if (
+      this.hasDateSelectedColumn &&
+      widget === InputTextWidget &&
+      !this.enableRelativeDateFiltering
+    ) {
       return InputDateWidget;
     }
-    if (widget) {
-      return widget;
-    } else {
-      return undefined;
-    }
+    return widget;
   }
 
   updateStepOperator(newOperator: OperatorOption) {

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -11,6 +11,7 @@
  * const label = humanReadableLabel(step);
  * ```
  */
+import { CustomDate, dateToString, relativeDateToString } from '@/lib/dates';
 import { StepMatcher } from '@/lib/matcher';
 import * as S from '@/lib/steps';
 
@@ -37,6 +38,19 @@ const MULTIVALUE_SEP = ', ';
 
 function formatMulticol(columns: string[]) {
   return columns.map(col => `"${col}"`).join(MULTIVALUE_SEP);
+}
+
+/**
+ * Compute a human-readable label from a relative date filter step condition.
+ */
+function relativeDateFilterExpression(value: CustomDate | string): string {
+  if (value instanceof Date) {
+    return dateToString(value);
+  } else if (value instanceof Object) {
+    return relativeDateToString(value);
+  } else {
+    return value;
+  }
 }
 
 /**
@@ -78,6 +92,10 @@ function filterExpression(
         return `"${condition.column}" is null`;
       case 'notnull':
         return `"${condition.column}" is not null`;
+      case 'from':
+        return `"${condition.column}" from ${relativeDateFilterExpression(condition.value)}`;
+      case 'until':
+        return `"${condition.column}" until ${relativeDateFilterExpression(condition.value)}`;
       default:
         // only for typescript to be happy and see we always have a return value
         return '';

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -252,7 +252,7 @@ type FilterConditionComparison = {
 
 type FilterConditionDate = {
   column: string;
-  value: CustomDate;
+  value: CustomDate | string;
   operator: 'from' | 'until';
 };
 

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -1,7 +1,7 @@
 /**
  * This module defines the supported unit-of-transformation steps.
  */
-import { RelativeDateRange } from '@/lib/dates';
+import { CustomDate } from '@/lib/dates';
 
 export type BasicDatePart =
   | 'year'
@@ -241,12 +241,19 @@ export type FilterComboOr = {
 export type FilterSimpleCondition =
   | FilterConditionComparison
   | FilterConditionEquality
-  | FilterConditionInclusion;
+  | FilterConditionInclusion
+  | FilterConditionDate;
 
 type FilterConditionComparison = {
   column: string;
-  value: number | string | Date | RelativeDateRange;
+  value: number | string;
   operator: 'gt' | 'ge' | 'lt' | 'le';
+};
+
+type FilterConditionDate = {
+  column: string;
+  value: CustomDate;
+  operator: 'from' | 'until';
 };
 
 type FilterConditionEquality = {

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -277,6 +277,9 @@ function buildCondExpression(
     notnull: '$ne',
     matches: '$regexMatch',
     notmatches: '$regexMatch',
+    // TODO: for now we raised an execption until this two operator will be developped
+    from: '',
+    until: '',
   };
   if (S.isFilterComboAnd(cond)) {
     if (cond.and.length == 1) {
@@ -344,6 +347,9 @@ function buildMatchTree(
     nin: '$nin',
     isnull: '$eq',
     notnull: '$ne',
+    // TODO: for now we raised an execption until this two operator will be developped
+    from: '',
+    until: '',
   };
 
   if (S.isFilterComboAnd(cond) && parentComboOp !== 'or') {

--- a/src/lib/translators/mongo42.ts
+++ b/src/lib/translators/mongo42.ts
@@ -5,5 +5,9 @@ import { Mongo40Translator } from './mongo4';
 export class Mongo42Translator extends Mongo40Translator {
   static label = 'Mongo 4.2';
 
-  protected unsupportedOperatorsInConditions: FilterSimpleCondition['operator'][] = [];
+  protected unsupportedOperatorsInConditions: FilterSimpleCondition['operator'][] = [
+    // TODO: for now we raised an execption until this two operator will be developped
+    'from',
+    'until',
+  ];
 }

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -319,6 +319,67 @@ describe('Labeller', () => {
     expect(hrl(step)).toEqual('Keep rows where "column1" is not null');
   });
 
+  describe('generates label for simple filter steps / operator "from"', () => {
+    it('generates label for date object', () => {
+      const step: S.FilterStep = {
+        name: 'filter',
+        condition: {
+          column: 'column1',
+          value: new Date(Date.UTC(2021, 0, 1)),
+          operator: 'from',
+        },
+      };
+      expect(hrl(step)).toEqual('Keep rows where "column1" from 1/1/2021');
+    });
+    it('generates label for relative date', () => {
+      const step: S.FilterStep = {
+        name: 'filter',
+        condition: {
+          column: 'column1',
+          value: { quantity: -1, duration: 'year' },
+          operator: 'from',
+        },
+      };
+      expect(hrl(step)).toEqual('Keep rows where "column1" from 1 years ago');
+    });
+  });
+
+  describe('generates label for simple filter steps / operator "until"', () => {
+    it('generates label for date object', () => {
+      const step: S.FilterStep = {
+        name: 'filter',
+        condition: {
+          column: 'column1',
+          value: new Date(Date.UTC(2021, 0, 1)),
+          operator: 'until',
+        },
+      };
+      expect(hrl(step)).toEqual('Keep rows where "column1" until 1/1/2021');
+    });
+    it('generates label for relative date', () => {
+      const step: S.FilterStep = {
+        name: 'filter',
+        condition: {
+          column: 'column1',
+          value: { quantity: -1, duration: 'year' },
+          operator: 'until',
+        },
+      };
+      expect(hrl(step)).toEqual('Keep rows where "column1" until 1 years ago');
+    });
+    it('generates label for variable', () => {
+      const step: S.FilterStep = {
+        name: 'filter',
+        condition: {
+          column: 'column1',
+          value: '<%= date.start %>',
+          operator: 'until',
+        },
+      };
+      expect(hrl(step)).toEqual('Keep rows where "column1" until <%= date.start %>');
+    });
+  });
+
   it('generates label for "and" filter steps', () => {
     const step: S.FilterStep = {
       name: 'filter',


### PR DESCRIPTION
When selecting a date column, transform the operators to have specific one : 'until'/'from'/'isnull'/'notnull' other column type refers to unchanged older types.

![operators](https://user-images.githubusercontent.com/59559689/143053195-9e7d4c52-3ae4-4d54-b9be-479c23387026.gif)


