### PR TITLE
feat(filter-step): replace date widget with new date input TCTC-1194

### DIFF
--- a/src/components/stepforms/widgets/DateComponents/CustomVariableList.vue
+++ b/src/components/stepforms/widgets/DateComponents/CustomVariableList.vue
@@ -15,7 +15,7 @@
       :selectedVariables="selectedVariables"
       :availableVariables="availableVariables"
       :enableAdvancedVariable="enableAdvancedVariable"
-      :showOnlyLabel="true"
+      :showOnlyLabel="showOnlyLabel"
       @input="chooseVariable"
       @addAdvancedVariable="addAdvancedVariable"
     />
@@ -50,6 +50,9 @@ export default class CustomVariableList extends Vue {
 
   @Prop({ default: () => 'Custom', type: String })
   customLabel!: string;
+
+  @Prop({ default: true })
+  showOnlyLabel!: boolean;
 
   chooseVariable(variableIdentifier: string) {
     this.$emit('input', variableIdentifier);

--- a/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -35,6 +35,7 @@
           :availableVariables="availableVariables"
           :selectedVariables="selectedVariables"
           :enableCustom="enableCustom"
+          :showOnlyLabel="!isEditorOpened"
           @selectCustomVariable="editCustomVariable"
           @input="selectVariable"
           @addAdvancedVariable="openAdvancedVariableModal"
@@ -352,11 +353,11 @@ export default class NewDateInput extends Vue {
   height: 100%;
 }
 .widget-date-input__editor-side {
-  width: 200px;
-  min-width: 200px;
+  width: 285px;
+  min-width: 285px;
   height: 100%;
   max-height: 400px;
-  flex: 1 200px;
+  flex: 1 285px;
   overflow-x: hidden;
   overflow-y: auto;
 }

--- a/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="widget-date-input">
+  <div
+    class="widget-date-input"
+    :class="{
+      'widget-date-input--opened': isEditorOpened,
+    }"
+  >
     <div class="widget-date-input__container" @click.stop="openEditor">
       <VariableTag
         class="widget-date-input__advanced-variable"
@@ -295,8 +300,19 @@ export default class NewDateInput extends Vue {
   max-width: 400px;
   position: relative;
 }
+
+.widget-date-input--opened {
+  .widget-date-input__container {
+    border-color: $active-color;
+  }
+  .widget-date-input__icon {
+    background-color: $active-color-faded-2;
+    color: $active-color;
+  }
+}
+
 .widget-date-input__container {
-  border: 1px solid $grey-light;
+  border: 1px solid #ddd;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -314,23 +330,15 @@ export default class NewDateInput extends Vue {
 }
 
 .widget-date-input__advanced-variable {
-  width: 100%;
+  width: calc(100% - 45px);
   padding: 5px 10px;
   margin: 0 5px;
 }
 
 .widget-date-input__icon {
-  padding: 10px 15px;
-  background: $grey-extra-light;
-  color: $grey;
-}
-
-.widget-date-input__container:hover {
-  border-color: $active-color;
-  .widget-date-input__icon {
-    background-color: $active-color-faded-2;
-    color: $active-color;
-  }
+  padding: 10px;
+  background: rgba(217, 217, 217, 0.24);
+  color: #000;
 }
 
 .widget-date-input__editor {

--- a/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -8,7 +8,7 @@
     <div class="widget-date-input__container" @click.stop="openEditor">
       <VariableTag
         class="widget-date-input__advanced-variable"
-        v-if="advancedVariable"
+        v-if="variable || advancedVariable"
         :value="value"
         :available-variables="availableVariables"
         :variable-delimiters="variableDelimiters"
@@ -203,9 +203,7 @@ export default class NewDateInput extends Vue {
   }
 
   get label(): string {
-    if (this.variable) {
-      return this.variable.label;
-    } else if (this.value instanceof Date) {
+    if (this.value instanceof Date) {
       return dateToString(this.value);
     } else if (this.value instanceof Object) {
       return relativeDateToString(this.value);

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -54,6 +54,7 @@ import { VueConstructor } from 'vue';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
+import NewDateInput from '@/components/stepforms/widgets/DateComponents/NewDateInput.vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import { ColumnTypeMapping } from '@/lib/dataset/index';
 import {
@@ -101,6 +102,7 @@ export const DEFAULT_FILTER = { column: '', value: '', operator: 'eq' };
     AutocompleteWidget,
     InputTextWidget,
     InputDateWidget,
+    NewDateInput,
   },
 })
 export default class FilterSimpleConditionWidget extends Vue {
@@ -175,8 +177,8 @@ export default class FilterSimpleConditionWidget extends Vue {
   ];
 
   readonly dateOperators: OperatorOption[] = [
-    { operator: 'from', label: 'from', inputWidget: InputDateWidget },
-    { operator: 'until', label: 'until', inputWidget: InputDateWidget },
+    { operator: 'from', label: 'from', inputWidget: NewDateInput },
+    { operator: 'until', label: 'until', inputWidget: NewDateInput },
     ...this.nullOperators,
   ];
 
@@ -201,6 +203,12 @@ export default class FilterSimpleConditionWidget extends Vue {
 
   get enableRelativeDateFiltering(): boolean {
     return this.featureFlags?.RELATIVE_DATE_FILTERING === 'enable';
+  }
+
+  get useDateInput(): boolean {
+    return Boolean(
+      this.hasDateSelectedColumn && this.enableRelativeDateFiltering && this.inputWidget,
+    );
   }
 
   get availableOperators(): OperatorOption[] {

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -37,7 +37,7 @@
       :is="inputWidget"
       :multi-variable="multiVariable"
       :value="value.value"
-      :available-variables="filteredAvailableVariables"
+      :available-variables="availableVariablesForInputWidget"
       :variable-delimiters="variableDelimiters"
       :placeholder="placeholder"
       :data-path="`${dataPath}.value`"
@@ -205,18 +205,18 @@ export default class FilterSimpleConditionWidget extends Vue {
     return this.featureFlags?.RELATIVE_DATE_FILTERING === 'enable';
   }
 
-  get useDateInput(): boolean {
-    return Boolean(
-      this.hasDateSelectedColumn && this.enableRelativeDateFiltering && this.inputWidget,
-    );
+  get dateAvailableVariables(): VariablesBucket | undefined {
+    // keep only date variables
+    return this.availableVariables?.filter(v => v.value instanceof Date);
   }
 
-  get filteredAvailableVariables(): VariablesBucket | undefined {
-    if (!this.useDateInput || !this.availableVariables) {
-      return this.availableVariables;
+  get availableVariablesForInputWidget(): VariablesBucket | undefined {
+    switch (this.inputWidget) {
+      case NewDateInput:
+        return this.dateAvailableVariables;
+      default:
+        return this.availableVariables;
     }
-    // keep only date variables
-    return [...this.availableVariables]?.filter(v => v.value instanceof Date);
   }
 
   get availableOperators(): OperatorOption[] {

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -303,6 +303,7 @@ export default class FilterSimpleConditionWidget extends Vue {
 .filter-form-simple-condition-operator-input,
 .filter-form-simple-condition__container .widget-input-text__container,
 .filter-form-simple-condition__container .widget-input-date__container,
+.filter-form-simple-condition__container .widget-date-input,
 .filter-form-simple-condition__container .widget-multiinputtext__container {
   margin: 4px;
   margin-right: 0;
@@ -315,6 +316,7 @@ export default class FilterSimpleConditionWidget extends Vue {
 
 .filter-form-simple-condition__container ::v-deep .widget-input-text,
 .filter-form-simple-condition__container ::v-deep .widget-input-date,
+.filter-form-simple-condition__container ::v-deep .widget-date-input__container,
 .filter-form-simple-condition__container ::v-deep .multiselect {
   background-color: white;
 

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -37,7 +37,7 @@
       :is="inputWidget"
       :multi-variable="multiVariable"
       :value="value.value"
-      :available-variables="availableVariables"
+      :available-variables="filteredAvailableVariables"
       :variable-delimiters="variableDelimiters"
       :placeholder="placeholder"
       :data-path="`${dataPath}.value`"
@@ -209,6 +209,14 @@ export default class FilterSimpleConditionWidget extends Vue {
     return Boolean(
       this.hasDateSelectedColumn && this.enableRelativeDateFiltering && this.inputWidget,
     );
+  }
+
+  get filteredAvailableVariables(): VariablesBucket | undefined {
+    if (!this.useDateInput || !this.availableVariables) {
+      return this.availableVariables;
+    }
+    // keep only date variables
+    return [...this.availableVariables]?.filter(v => v.value instanceof Date);
   }
 
   get availableOperators(): OperatorOption[] {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -42,7 +42,7 @@ $error: #f3c600;
 %form-widget__field {
   align-items: center;
   background-color: transparent;
-  box-shadow: 0 0 0 1px #f1f1f1 inset;
+  box-shadow: 0 0 0 1px #ddd inset;
   border: none;
   font-family: 'Montserrat', sans-serif;
   font-size: 14px;

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -11,6 +11,29 @@ import { RootState, setupMockStore } from './utils';
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
+const AVAILABLE_VARIABLES_SAMPLE = [
+  {
+    category: 'date',
+    value: new Date(),
+    label: 'Date category',
+  },
+  {
+    category: 'string',
+    value: 'string',
+    label: 'Simple string',
+  },
+  {
+    category: 'number',
+    value: 3,
+    label: 'Number',
+  },
+  {
+    category: 'other',
+    value: new Date(),
+    label: 'Date not in date category',
+  },
+];
+
 describe('Widget FilterSimpleCondition', () => {
   let emptyStore: Store<RootState>;
   beforeEach(() => {
@@ -293,6 +316,7 @@ describe('Widget FilterSimpleCondition', () => {
         propsData: {
           value: { column: 'columnA', value: new Date('2021-01-01'), operator: 'from' },
           columnTypes: { columnA: 'date' },
+          availableVariables: AVAILABLE_VARIABLES_SAMPLE,
           ...customProps,
         },
         store,
@@ -308,6 +332,15 @@ describe('Widget FilterSimpleCondition', () => {
         .props()
         .options.map((o: any) => o.operator);
       expect(operators).toStrictEqual(['from', 'until', 'isnull', 'notnull']);
+    });
+
+    it('should filter available variables to keep only date once', () => {
+      createWrapper(shallowMount);
+      const variables = wrapper
+        .find('.filterValue')
+        .props()
+        .availableVariables.map((v: any) => v.label);
+      expect(variables).toStrictEqual(['Date category', 'Date not in date category']);
     });
 
     it('should use the widget accordingly when changing the operator', async () => {
@@ -398,6 +431,7 @@ describe('Widget FilterSimpleCondition', () => {
         propsData: {
           value: { column: 'columnA', value: new Date('2021-01-01'), operator: 'eq' },
           columnTypes: { columnA: 'date' },
+          availableVariables: AVAILABLE_VARIABLES_SAMPLE,
           ...customProps,
         },
         store,
@@ -415,6 +449,13 @@ describe('Widget FilterSimpleCondition', () => {
       expect(operators).not.toContain('from');
       expect(operators).not.toContain('until');
       expect(operators).not.toHaveLength(0);
+    });
+
+    it('should use all available variables', () => {
+      createWrapper(shallowMount);
+      expect(wrapper.find('.filterValue').props().availableVariables).toStrictEqual(
+        AVAILABLE_VARIABLES_SAMPLE,
+      );
     });
 
     it('should use the date input', () => {

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -313,13 +313,13 @@ describe('Widget FilterSimpleCondition', () => {
     it('should use the widget accordingly when changing the operator', async () => {
       createWrapper(mount);
       // from operator (from mount)
-      expect(wrapper.find('.filterValue').classes()).toContain('widget-input-date__container');
+      expect(wrapper.find('.filterValue').classes()).toContain('widget-date-input');
       // until operator
       wrapper.setProps({
         value: { column: 'columnA', value: new Date('2021-01-01'), operator: 'until' },
       });
       await wrapper.vm.$nextTick();
-      expect(wrapper.find('.filterValue').classes()).toContain('widget-input-date__container');
+      expect(wrapper.find('.filterValue').classes()).toContain('widget-date-input');
       // isnull operator
       wrapper.setProps({
         value: { column: 'columnA', value: null, operator: 'isnull' },

--- a/tests/unit/new-date-input.spec.ts
+++ b/tests/unit/new-date-input.spec.ts
@@ -282,15 +282,14 @@ describe('Date input', () => {
         value: `{{${selectedVariable.identifier}}}`,
       });
     });
-    it('should display variable label as input label', () => {
-      expect(wrapper.find('.widget-date-input__label').text()).toStrictEqual(
-        selectedVariable.label,
-      );
-    });
     it('should pass selected variable identifier to CustomVariableList', () => {
       expect(wrapper.find('CustomVariableList-stub').props().selectedVariables).toStrictEqual(
         selectedVariable.identifier,
       );
+    });
+    it('should display variable tag instead of label', () => {
+      expect(wrapper.find('.widget-date-input__label').exists()).toBe(false);
+      expect(wrapper.find('VariableTag-stub').exists()).toBe(true);
     });
   });
 


### PR DESCRIPTION
:warning: Need to review https://github.com/ToucanToco/weaverbird/pull/1191 first.

Replace date widget with new date input when a date column is selected in filter step
Also filter variables to return only dates one

Before:
![operators](https://user-images.githubusercontent.com/59559689/143069785-767a0e10-17a1-4e1a-824c-5ee7e8446a43.gif)

After:
![date-input](https://user-images.githubusercontent.com/59559689/143069739-16d5c221-fd78-49ef-8121-bdcfffa0e854.gif)


**Design:**

![design](https://user-images.githubusercontent.com/59559689/143075514-eba66158-f60e-45c9-8cc0-27dd9b3646f2.png)


Before:
![before-1](https://user-images.githubusercontent.com/59559689/143076194-1e9d2905-e403-48d1-ac02-6871166f9c5e.png)
![before](https://user-images.githubusercontent.com/59559689/143076420-325c56de-f2e6-43b0-882f-3cd5fcace2e4.png)

After:
![after-1](https://user-images.githubusercontent.com/59559689/143076234-7358db83-ae88-4bd3-8a05-b821bb8d76b7.png)
![after](https://user-images.githubusercontent.com/59559689/143076057-6f108dcf-c488-4f92-8375-d5fad7cafecb.png)

:warning: Optional (added a two last commit to use variable tag for variable and display value for variables in list, not sure if we want to keep them ? Useful for conceptor to know value of variable right ? )
There is a strange behaviour with tooltip when closing the dropdown, ( solved in the commit using !isEditorOpened, video has been made before :wink: )
![hover](https://user-images.githubusercontent.com/59559689/143078494-8f92553d-7d3a-41ba-bf71-38d49b321b62.gif)


