### PR TITLE
fix(filter-step): keep relative date selected when switching from/until operators TCTC-1193

### DIFF
--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -60,6 +60,7 @@ import { ColumnTypeMapping } from '@/lib/dataset/index';
 import {
   keepCurrentValueIfArrayType,
   keepCurrentValueIfCompatibleDate,
+  keepCurrentValueIfCompatibleRelativeDate,
   keepCurrentValueIfCompatibleType,
 } from '@/lib/helpers';
 import { FilterSimpleCondition } from '@/lib/steps';
@@ -263,6 +264,8 @@ export default class FilterSimpleConditionWidget extends Vue {
       updatedValue.value = keepCurrentValueIfArrayType(updatedValue.value, []);
     } else if (updatedValue.operator === 'isnull' || updatedValue.operator === 'notnull') {
       updatedValue.value = null;
+    } else if (this.hasDateSelectedColumn && this.enableRelativeDateFiltering) {
+      updatedValue.value = keepCurrentValueIfCompatibleRelativeDate(updatedValue.value, '');
     } else if (this.hasDateSelectedColumn) {
       // when using date widget, we need value to be a valid date
       // null as date will become "01/01/1970" as default value for input

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -160,6 +160,11 @@ export const relativeDateRangeToString = (
   return `${relativeDateLabel} ${relativeDateRange.operator}${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}${baseDateLabel}`;
 };
 
+export const isRelativeDate = (value: any): value is RelativeDateRange => {
+  if (!(value instanceof Object)) return false;
+  return _has(value, 'duration') && _has(value, 'quantity');
+};
+
 export const isRelativeDateRange = (
   value: string | CustomDateRange | undefined,
 ): value is RelativeDateRange => {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -30,7 +30,10 @@ export type RelativeDate = {
 
 export function isRelativeDate(val: any): val is RelativeDate {
   return (
-    typeof val == 'object' && typeof val.quantity == 'number' && typeof val.duration == 'string'
+    val &&
+    typeof val == 'object' &&
+    typeof val.quantity == 'number' &&
+    typeof val.duration == 'string'
   );
 }
 

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -160,11 +160,6 @@ export const relativeDateRangeToString = (
   return `${relativeDateLabel} ${relativeDateRange.operator}${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}${baseDateLabel}`;
 };
 
-export const isRelativeDate = (value: any): value is RelativeDateRange => {
-  if (!(value instanceof Object)) return false;
-  return _has(value, 'duration') && _has(value, 'quantity');
-};
-
 export const isRelativeDateRange = (
   value: string | CustomDateRange | undefined,
 ): value is RelativeDateRange => {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,7 +1,8 @@
 import { DataSetColumnType } from './dataset';
+import { CustomDate, isRelativeDate } from './dates';
 import { AddTotalRowsStep, RollupStep } from './steps';
 
-type ValueType = number | boolean | string | null | object | Date;
+type ValueType = number | boolean | string | null | object | CustomDate;
 /** We do not include AggregateStep as this step has some specifities that do
  *  not factorize well in the setAggregationsNewColumnsInStep helper function
  *  defined below */
@@ -108,6 +109,15 @@ export function keepCurrentValueIfCompatibleDate(
   defaultValue: ValueType,
 ): ValueType {
   return isDate(value) || typeof value === 'string' ? value : defaultValue;
+}
+
+export function keepCurrentValueIfCompatibleRelativeDate(
+  value: ValueType,
+  defaultValue: ValueType,
+) {
+  return isRelativeDate(value) || value instanceof Date || typeof value === 'string'
+    ? value
+    : defaultValue;
 }
 
 /**

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -385,10 +385,10 @@ describe('Widget FilterSimpleCondition', () => {
         value: { column: 'columnA', value: 1, operator: 'matches' },
       });
       const operatorWrapper = wrapper.findAll('autocompletewidget-stub').at(1);
-      // eq operator
+      // from operator
       operatorWrapper.vm.$emit('input', { operator: 'from' });
       expect(wrapper.emitted().input[0]).toEqual([
-        { column: 'columnA', value: null, operator: 'from' },
+        { column: 'columnA', value: '', operator: 'from' },
       ]);
     });
     it('should transform invalid dates to valid date when changing the column type', async () => {
@@ -462,6 +462,48 @@ describe('Widget FilterSimpleCondition', () => {
       createWrapper(mount);
       const widgetWrappers = wrapper.findAll('.filterValue');
       expect(widgetWrappers.at(0).classes()).toContain('widget-input-date__container');
+    });
+
+    it('should emit a new condition with the correct type of value when changing the operator', () => {
+      createWrapper(shallowMount);
+      const operatorWrapper = wrapper.findAll('autocompletewidget-stub').at(1);
+      // eq operator
+      operatorWrapper.vm.$emit('input', { operator: 'eq' });
+      expect(wrapper.emitted().input[0]).toEqual([
+        { column: 'columnA', value: new Date('2021-01-01'), operator: 'eq' },
+      ]);
+      // isnull operator
+      operatorWrapper.vm.$emit('input', { operator: 'isnull' });
+      expect(wrapper.emitted().input[1]).toEqual([
+        { column: 'columnA', value: null, operator: 'isnull' },
+      ]);
+      // notnull operator
+      operatorWrapper.vm.$emit('input', { operator: 'notnull' });
+      expect(wrapper.emitted().input[2]).toEqual([
+        { column: 'columnA', value: null, operator: 'notnull' },
+      ]);
+    });
+    it('should transform invalid dates to valid date when changing the operator', () => {
+      createWrapper(shallowMount, {
+        value: { column: 'columnA', value: 1, operator: 'matches' },
+      });
+      const operatorWrapper = wrapper.findAll('autocompletewidget-stub').at(1);
+      // eq operator
+      operatorWrapper.vm.$emit('input', { operator: 'eq' });
+      expect(wrapper.emitted().input[0]).toEqual([
+        { column: 'columnA', value: null, operator: 'eq' },
+      ]);
+    });
+    it('should transform invalid dates to valid date when changing the column type', async () => {
+      createWrapper(shallowMount, {
+        value: { column: 'columnA', value: new Date('2021-01-01'), operator: 'eq' },
+      });
+      wrapper.setProps({ columnTypes: { columnA: 'string' } });
+      await wrapper.vm.$nextTick();
+      // relaunch operator validation automatically when changing the column type
+      expect(wrapper.emitted().input[0]).toEqual([
+        { column: 'columnA', value: '', operator: 'eq' },
+      ]);
     });
   });
 });

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -6,6 +6,7 @@ import {
   generateNewColumnName,
   keepCurrentValueIfArrayType,
   keepCurrentValueIfCompatibleDate,
+  keepCurrentValueIfCompatibleRelativeDate,
   keepCurrentValueIfCompatibleType,
   setAggregationsNewColumnsInStep,
 } from '@/lib/helpers';
@@ -153,6 +154,24 @@ describe('castFromString', () => {
     });
     it('should return selected value if its a string', () => {
       expect(keepCurrentValueIfCompatibleDate('<%= lala %>', null)).toEqual('<%= lala %>');
+    });
+  });
+
+  describe('keepCurrentValueIfCompatibleRelativeDate', () => {
+    it('should return default if selected value is not a date/relative date or string', () => {
+      expect(keepCurrentValueIfCompatibleRelativeDate(3, null)).toEqual(null);
+      expect(keepCurrentValueIfCompatibleRelativeDate(null, null)).toEqual(null);
+    });
+    it('should return selected value if its a well formatted date', () => {
+      const value = new Date('12/04/2021');
+      expect(keepCurrentValueIfCompatibleRelativeDate(value, null)).toEqual(value);
+    });
+    it('should return selected value if its a well formatted relative date', () => {
+      const value = { duration: 'month', quantity: 1 };
+      expect(keepCurrentValueIfCompatibleRelativeDate(value, null)).toEqual(value);
+    });
+    it('should return selected value if its a string', () => {
+      expect(keepCurrentValueIfCompatibleRelativeDate('<%= lala %>', null)).toEqual('<%= lala %>');
     });
   });
 

--- a/tests/unit/lib/dates.spec.ts
+++ b/tests/unit/lib/dates.spec.ts
@@ -5,6 +5,7 @@ import {
   dateRangeToString,
   dateToString,
   isDateRange,
+  isRelativeDate,
   isRelativeDateRange,
   RelativeDateRange,
   relativeDateRangeToString,
@@ -164,6 +165,16 @@ describe('relativeDateRangeToString', () => {
     expect(relativeDateRangeToString(value2, SAMPLE_VARIABLES, variableDelimiters)).toStrictEqual(
       `2 months from${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}Tomorrow`,
     );
+  });
+});
+
+describe('isRelativeDate', () => {
+  it('should return false if value is not a relative date', () => {
+    expect(isRelativeDate('{{today}}')).toBe(false);
+    expect(isRelativeDate({ start: new Date() })).toBe(false);
+  });
+  it('should return true if value is a relative date', () => {
+    expect(isRelativeDate({ quantity: 2, duration: 'year' })).toBe(true);
   });
 });
 


### PR DESCRIPTION
Keep a relative date selected when switching between relative date operators.
Before:
Relative date was transformed to a simple date because we didn't authorize relative date in Date validator
![before](https://user-images.githubusercontent.com/59559689/143251422-faa550bb-7e8e-4acc-8d81-f4df0b3d2786.gif)

After:
Add a new condition to enable relative date, keep it unchanged if operator is from/until
![validation](https://user-images.githubusercontent.com/59559689/143251258-43a6dbcf-502b-46ef-bac0-4e4c7578ba62.gif)

UAT:
Apply feature flag for relative date as enabled
Create a filter step on a date column
Select from operator
Select a relative date as value
Switch to until operator (should keep relative date value unchanged)

