### PR TITLE
fix(filter-step): update invalid operator when switching relative date feature flag TCTC-1193

### DIFF
--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -8,7 +8,7 @@
     />
     <div class="filter-form__info">Filter rows matching this condition:</div>
     <FilterEditor
-      :filter-tree="this.editedStep.condition"
+      :filter-tree="editedStep.condition"
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
@@ -56,7 +56,7 @@ export default class FilterStepForm extends BaseStepForm<FilterStep> {
 
   readonly title: string = 'Filter';
 
-  mounted() {
+  created() {
     // On creation, if a column is selected, use it to set "column" property of
     // the filter step
     if (this.isStepCreation && this.selectedColumns[0]) {

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -186,6 +186,8 @@ export default class FilterSimpleConditionWidget extends Vue {
     // In absence of condition, emit directly to the parent the default value
     if (isEqual(this.value, DEFAULT_FILTER)) {
       this.$emit('input', DEFAULT_FILTER);
+    } else if (this.hasDateSelectedColumn) {
+      this.updateInvalidDateOperator();
     }
   }
 
@@ -254,6 +256,34 @@ export default class FilterSimpleConditionWidget extends Vue {
       return InputDateWidget;
     }
     return widget;
+  }
+
+  retrieveOperatorOption(operator: string): OperatorOption | undefined {
+    return this.availableOperators.find(o => o.operator === operator);
+  }
+
+  updateInvalidDateOperator(): void {
+    // no need to update operator already exists
+    if (this.retrieveOperatorOption(this.value.operator)) return;
+    // retrieve appropriate date operator when feature flag for relative date has been switched
+    let newOperator = '';
+    switch (this.value.operator) {
+      case 'lt':
+      case 'le':
+        newOperator = 'until';
+        break;
+      case 'gt':
+      case 'ge':
+        newOperator = 'from';
+        break;
+      case 'from':
+        newOperator = 'ge';
+        break;
+      case 'until':
+        newOperator = 'le';
+        break;
+    }
+    this.updateStepOperator(this.retrieveOperatorOption(newOperator) ?? this.operator);
   }
 
   updateStepOperator(newOperator: OperatorOption) {


### PR DESCRIPTION
When relative date feature flag is switched, operators change so it may happen that some previously selected operator missed. We want to replace them with correct available operator:

until -> le
from -> ge
ge/gt -> from
le/lt -> until

If the operator is available fallback to it
If the operator is not in the list (ex: eq) fallback to first available operator

Also fixed the filter step behaviour because it was reassigning default value after the migration of operator