### PR TITLE
fix(relative-date): simplify label for relative date removing suffix and separator

### DIFF
--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -140,11 +140,8 @@ export const relativeDateToString = (
   const duration: string | undefined = DEFAULT_DURATIONS.find(
     d => d.value === relativeDate.duration,
   )?.label;
-  const suffix = ' ' + (relativeDate.quantity < 0 ? 'ago' : '');
-  const relativeDateLabel = `${Math.abs(
-    relativeDate.quantity,
-  )} ${duration?.toLowerCase()}${suffix.trimEnd()}`;
-  return `${relativeDateLabel} ${relativeDate.operator}${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}${baseDateLabel}`;
+  const relativeDateLabel = `${Math.abs(relativeDate.quantity)} ${duration?.toLowerCase()}`;
+  return `${relativeDateLabel} ${relativeDate.operator} ${baseDateLabel}`;
 };
 
 export const isRelativeDate = (value: any): value is RelativeDate => {

--- a/tests/unit/date-range-input.spec.ts
+++ b/tests/unit/date-range-input.spec.ts
@@ -429,9 +429,7 @@ describe('Date range input', () => {
     });
 
     it('should display readable input label', () => {
-      expect(wrapper.find('.widget-date-input__label').text()).toStrictEqual(
-        '1 months from - Today',
-      );
+      expect(wrapper.find('.widget-date-input__label').text()).toStrictEqual('1 months from Today');
     });
 
     it('should select "Relative" tab by default', () => {

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -340,7 +340,7 @@ describe('Labeller', () => {
           operator: 'from',
         },
       };
-      expect(hrl(step)).toEqual('Keep rows where "column1" from 1 years ago until - {{today}}');
+      expect(hrl(step)).toEqual('Keep rows where "column1" from 1 years ago until {{today}}');
     });
   });
 
@@ -365,7 +365,7 @@ describe('Labeller', () => {
           operator: 'until',
         },
       };
-      expect(hrl(step)).toEqual('Keep rows where "column1" until 1 years ago until - {{today}}');
+      expect(hrl(step)).toEqual('Keep rows where "column1" until 1 years ago until {{today}}');
     });
     it('generates label for variable', () => {
       const step: S.FilterStep = {

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -340,7 +340,7 @@ describe('Labeller', () => {
           operator: 'from',
         },
       };
-      expect(hrl(step)).toEqual('Keep rows where "column1" from 1 years ago until {{today}}');
+      expect(hrl(step)).toEqual('Keep rows where "column1" from 1 years until {{today}}');
     });
   });
 
@@ -365,7 +365,7 @@ describe('Labeller', () => {
           operator: 'until',
         },
       };
-      expect(hrl(step)).toEqual('Keep rows where "column1" until 1 years ago until {{today}}');
+      expect(hrl(step)).toEqual('Keep rows where "column1" until 1 years until {{today}}');
     });
     it('generates label for variable', () => {
       const step: S.FilterStep = {

--- a/tests/unit/lib/dates.spec.ts
+++ b/tests/unit/lib/dates.spec.ts
@@ -142,7 +142,7 @@ describe('relativeDateToString', () => {
       date: '{{tomorrow}}',
     };
     expect(relativeDateToString(value, SAMPLE_VARIABLES, variableDelimiters)).toStrictEqual(
-      `2 months until${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}Tomorrow`,
+      `2 months until Tomorrow`,
     );
 
     const value2: RelativeDate = {
@@ -152,7 +152,7 @@ describe('relativeDateToString', () => {
       operator: 'from',
     };
     expect(relativeDateToString(value2, SAMPLE_VARIABLES, variableDelimiters)).toStrictEqual(
-      `2 months from${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}Tomorrow`,
+      `2 months from Tomorrow`,
     );
 
     const unfoundVariable: RelativeDate = {
@@ -163,7 +163,7 @@ describe('relativeDateToString', () => {
     };
     expect(
       relativeDateToString(unfoundVariable, SAMPLE_VARIABLES, variableDelimiters),
-    ).toStrictEqual(`2 months from${CUSTOM_DATE_RANGE_LABEL_SEPARATOR}toto`);
+    ).toStrictEqual(`2 months from toto`);
   });
 });
 

--- a/tests/unit/new-date-input.spec.ts
+++ b/tests/unit/new-date-input.spec.ts
@@ -409,9 +409,7 @@ describe('Date input', () => {
     });
 
     it('should display readable input label', () => {
-      expect(wrapper.find('.widget-date-input__label').text()).toStrictEqual(
-        '1 months from - Today',
-      );
+      expect(wrapper.find('.widget-date-input__label').text()).toStrictEqual('1 months from Today');
     });
 
     it('should select "Relative" tab by default', () => {


### PR DESCRIPTION
Remove suffix and separator for relative date label going from:

2 months ago until - Last week
to
2 months until Last week