### PR TITLE
feat(mongo): enable to use variable as base date for relative date filtering TCTC-1321

### DIFF
--- a/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -108,7 +108,6 @@ import {
   CustomDate,
   DateRange,
   dateToString,
-  DEFAULT_RELATIVE_VARIABLES,
   isRelativeDate,
   relativeDateToString,
 } from '@/lib/dates';
@@ -145,9 +144,6 @@ export default class NewDateInput extends Vue {
   @Prop({ default: () => [] })
   availableVariables!: VariablesBucket;
 
-  @Prop({ default: () => DEFAULT_RELATIVE_VARIABLES })
-  relativeAvailableVariables!: VariablesBucket; // variables to use in RelativeDateForm "from"
-
   @Prop({ default: () => ({ start: '', end: '' }) })
   variableDelimiters!: VariableDelimiters;
 
@@ -164,6 +160,10 @@ export default class NewDateInput extends Vue {
 
   get tabs(): string[] {
     return ['Relative', 'Fixed'];
+  }
+
+  get relativeAvailableVariables(): VariablesBucket {
+    return this.availableVariables.filter(v => v.value instanceof Date);
   }
 
   // keep each tab value in memory to enable to switch between tabs without loosing content

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -64,11 +64,6 @@ export const DEFAULT_DURATIONS: DurationOption[] = [
   { label: 'Days', value: 'day' },
 ];
 
-export const DEFAULT_RELATIVE_VARIABLES = [
-  { identifier: 'today', value: '$$NOW', label: 'TODAY' },
-  // TODO: add enabled relative variables here
-];
-
 export const CUSTOM_DATE_RANGE_LABEL_SEPARATOR = ' - ';
 
 export const dateToString = (date: Date, locale?: LocaleIdentifier): string => {

--- a/src/lib/translators/mongo5.ts
+++ b/src/lib/translators/mongo5.ts
@@ -1,4 +1,4 @@
-import { RelativeDate } from '@/lib/dates';
+import { RELATIVE_DATE_OPERATORS, RelativeDate } from '@/lib/dates';
 
 import { Mongo42Translator } from './mongo42';
 
@@ -6,16 +6,18 @@ export class Mongo50Translator extends Mongo42Translator {
   static label = 'Mongo 5.0';
 
   protected translateRelativeDate(value: RelativeDate): object {
+    const operator = RELATIVE_DATE_OPERATORS[value.operator];
     return {
       $dateAdd: {
         startDate: {
           // Base date does not include any hour information
           $dateTrunc: {
-            date: '$$NOW', // TODO: adapt date with selected variable
+            date: value.date,
             unit: 'day',
           },
         },
-        amount: value.quantity,
+        // if relative date has a "before" operator we expect to have a negative quantity
+        amount: Math.sign(operator.sign) * Math.abs(value.quantity),
         unit: value.duration,
       },
     };

--- a/stories/dates/new-date-input.js
+++ b/stories/dates/new-date-input.js
@@ -3,6 +3,25 @@ import { storiesOf } from '@storybook/vue';
 
 const stories = storiesOf('Dates/NewDateInput', module);
 
+
+const RELATIVE_SAMPLE_VARIABLES = [
+  {
+    label: 'Today',
+    identifier: 'today',
+    value: new Date('1/12/2021'),
+  },
+  {
+    label: 'Last month',
+    identifier: 'last_month',
+    value: new Date('11/12/2021'),
+  },
+  {
+    label: 'Last year',
+    identifier: 'last_year',
+    value: new Date('1/12/2020'),
+  },
+];
+
 const SAMPLE_VARIABLES = [
   {
     identifier: 'dates.last_7_days',
@@ -36,21 +55,7 @@ const SAMPLE_VARIABLES = [
     identifier: 'dates.all_time',
     label: 'All time',
   },
-];
-
-const RELATIVE_SAMPLE_VARIABLES = [
-  {
-    label: 'Today',
-    identifier: 'today',
-  },
-  {
-    label: 'Last month',
-    identifier: 'last_month',
-  },
-  {
-    label: 'Last year',
-    identifier: 'last_year',
-  },
+  ...RELATIVE_SAMPLE_VARIABLES,
 ];
 
 stories.add('simple', () => ({
@@ -59,7 +64,6 @@ stories.add('simple', () => ({
       <NewDateInput 
         :available-variables="availableVariables" 
         :variable-delimiters="variableDelimiters"
-        :relative-available-variables="relativeAvailableVariables"
         v-model="value" 
       />
       <pre>{{ value }}</pre>
@@ -74,7 +78,6 @@ stories.add('simple', () => ({
     return {
       availableVariables: SAMPLE_VARIABLES,
       variableDelimiters: { start: '{{', end: '}}' },
-      relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
       value: undefined,
     };
   },
@@ -86,7 +89,6 @@ stories.add('already selected variable', () => ({
       <NewDateInput 
         :available-variables="availableVariables" 
         :variable-delimiters="variableDelimiters"
-        :relative-available-variables="relativeAvailableVariables"
         v-model="value" 
       />
       <pre>{{ value }}</pre>
@@ -101,7 +103,6 @@ stories.add('already selected variable', () => ({
     return {
       availableVariables: SAMPLE_VARIABLES,
       variableDelimiters: { start: '{{', end: '}}' },
-      relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
       value: '{{dates.all_time}}',
     };
   },
@@ -113,7 +114,6 @@ stories.add('custom (fixed date)', () => ({
       <NewDateInput 
         :available-variables="availableVariables" 
         :variable-delimiters="variableDelimiters"
-        :relative-available-variables="relativeAvailableVariables"
         v-model="value" 
       />
       <pre>{{ value }}</pre>
@@ -128,7 +128,6 @@ stories.add('custom (fixed date)', () => ({
     return {
       availableVariables: SAMPLE_VARIABLES,
       variableDelimiters: { start: '{{', end: '}}' },
-      relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
       value: new Date(),
     };
   },
@@ -140,7 +139,6 @@ stories.add('custom (relative date)', () => ({
       <NewDateInput 
         :available-variables="availableVariables" 
         :variable-delimiters="variableDelimiters"
-        :relative-available-variables="relativeAvailableVariables"
         v-model="value" 
       />
       <pre>{{ value }}</pre>
@@ -155,7 +153,6 @@ stories.add('custom (relative date)', () => ({
     return {
       availableVariables: SAMPLE_VARIABLES,
       variableDelimiters: { start: '{{', end: '}}' },
-      relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
       value: { quantity: -1, duration: 'month' },
     };
   },
@@ -167,7 +164,6 @@ stories.add('disable custom selection', () => ({
       <NewDateInput 
         :available-variables="availableVariables" 
         :variable-delimiters="variableDelimiters"
-        :relative-available-variables="relativeAvailableVariables"
         :enableCustom="false"
         v-model="value" 
       />
@@ -183,7 +179,6 @@ stories.add('disable custom selection', () => ({
     return {
       availableVariables: SAMPLE_VARIABLES,
       variableDelimiters: { start: '{{', end: '}}' },
-      relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
       value: undefined,
     };
   },

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -844,8 +844,8 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
             value: {
               duration: 'week',
               quantity: -1,
-              operator: 'until',
-              date: 'today',
+              operator: 'from',
+              date: '{{today}}',
             },
           },
         },
@@ -867,10 +867,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   $dateTrunc: {
                     date: {
                       $dateAdd: {
-                        amount: -1,
+                        amount: 1,
                         startDate: {
                           $dateTrunc: {
-                            date: '$$NOW',
+                            date: '{{today}}',
                             unit: 'day',
                           },
                         },
@@ -898,7 +898,7 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
               duration: 'month',
               quantity: 3,
               operator: 'until',
-              date: 'today',
+              date: '{{last_week}}',
             },
           },
         },
@@ -920,10 +920,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   $dateTrunc: {
                     date: {
                       $dateAdd: {
-                        amount: 3,
+                        amount: -3,
                         startDate: {
                           $dateTrunc: {
-                            date: '$$NOW',
+                            date: '{{last_week}}',
                             unit: 'day',
                           },
                         },

--- a/tests/unit/new-date-input.spec.ts
+++ b/tests/unit/new-date-input.spec.ts
@@ -1,10 +1,18 @@
 import { shallowMount, Wrapper } from '@vue/test-utils';
 
 import NewDateInput from '@/components/stepforms/widgets/DateComponents/NewDateInput.vue';
-import { dateToString, DEFAULT_RELATIVE_VARIABLES, RelativeDate } from '@/lib/dates';
+import { dateToString, RelativeDate } from '@/lib/dates';
 
 jest.mock('@/components/FAIcon.vue');
 jest.mock('@/components/DatePicker/Calendar.vue');
+
+const RELATIVE_SAMPLE_VARIABLES = [
+  {
+    label: 'Today',
+    identifier: 'today',
+    value: new Date(2020, 11),
+  },
+];
 
 const SAMPLE_VARIABLES = [
   {
@@ -39,24 +47,7 @@ const SAMPLE_VARIABLES = [
     identifier: 'dates.all_time',
     label: 'All time',
   },
-];
-
-const RELATIVE_SAMPLE_VARIABLES = [
-  {
-    label: 'Today',
-    identifier: 'today',
-    value: new Date(2020, 11),
-  },
-  {
-    label: 'Last month',
-    identifier: 'last_month',
-    value: '',
-  },
-  {
-    label: 'Last year',
-    identifier: 'last_year',
-    value: '',
-  },
+  ...RELATIVE_SAMPLE_VARIABLES,
 ];
 
 describe('Date input', () => {
@@ -76,7 +67,6 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '{{', end: '}}' },
         value: 'anythingnotokay',
       });
@@ -190,7 +180,6 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '{{', end: '}}' },
       });
     });
@@ -267,6 +256,11 @@ describe('Date input', () => {
         wrapper.find('Tabs-stub').vm.$emit('tabSelected', 'Relative');
         await wrapper.vm.$nextTick();
       });
+      it('should pass filtered available variables using only dates one as relative variables', () => {
+        expect(wrapper.find('RelativeDateForm-stub').props().availableVariables).toStrictEqual(
+          RELATIVE_SAMPLE_VARIABLES,
+        );
+      });
       it('should display correct body component', () => {
         expect(wrapper.find('RelativeDateForm-stub').exists()).toBe(true);
         expect(wrapper.find('Calendar-stub').exists()).toBe(false);
@@ -309,7 +303,6 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '{{', end: '}}' },
         value: `{{${selectedVariable.identifier}}}`,
       });
@@ -330,7 +323,6 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '{{', end: '}}' },
         value: advancedVariable,
       });
@@ -370,7 +362,6 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '{{', end: '}}' },
         value,
       });
@@ -402,7 +393,6 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '{{', end: '}}' },
         value,
       });
@@ -426,7 +416,6 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '{{', end: '}}' },
         enableCustom: false,
       });
@@ -461,7 +450,6 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '{{', end: '}}' },
         bounds,
         value: new Date('2020/2/1'),
@@ -479,10 +467,8 @@ describe('Date input', () => {
     it('should set availableVariables to empty array', () => {
       expect((wrapper.vm as any).availableVariables).toStrictEqual([]);
     });
-    it('should set relativeAvailableVariables to default value array', () => {
-      expect(wrapper.find('RelativeDateForm-stub').props().availableVariables).toStrictEqual(
-        DEFAULT_RELATIVE_VARIABLES,
-      );
+    it('should set relativeAvailableVariables to empty array', () => {
+      expect(wrapper.find('RelativeDateForm-stub').props().availableVariables).toStrictEqual([]);
     });
     it('should set variablesDelimiters to empty string', () => {
       expect((wrapper.vm as any).variableDelimiters).toStrictEqual({ start: '', end: '' });


### PR DESCRIPTION
1. Retrieve relative variables based on date variables in availableVariables in NewDateInput
2. Use selected variable as date base for relative date filtering (mongo)