### PR TITLE
fix(add-total-steps-rows): avoid to submit form before set aggregations new columns is over TCTC-1300

### DIFF
--- a/src/components/stepforms/AddTotalRowsStepForm.vue
+++ b/src/components/stepforms/AddTotalRowsStepForm.vue
@@ -114,7 +114,8 @@ export default class AddTotalRowsStepForm extends BaseStepForm<AddTotalRowsStep>
   }
 
   async submit() {
-    await setAggregationsNewColumnsInStep(this.editedStep);
+    setAggregationsNewColumnsInStep(this.editedStep);
+    await this.$nextTick();
     this.$$super.submit();
   }
 }

--- a/src/components/stepforms/AddTotalRowsStepForm.vue
+++ b/src/components/stepforms/AddTotalRowsStepForm.vue
@@ -113,8 +113,8 @@ export default class AddTotalRowsStepForm extends BaseStepForm<AddTotalRowsStep>
     this.editedStep.totalDimensions = [...newval];
   }
 
-  submit() {
-    setAggregationsNewColumnsInStep(this.editedStep);
+  async submit() {
+    await setAggregationsNewColumnsInStep(this.editedStep);
     this.$$super.submit();
   }
 }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -160,7 +160,7 @@ export function combinations(arr: any[]): any[][] {
  * @param step a step that includes an aggregation parameter of the form:
  *  { columns: ['A', 'B'], aggfunction: 'sum', newcolumns: []}
  */
-export async function setAggregationsNewColumnsInStep(step: StepWithAggregations) {
+export function setAggregationsNewColumnsInStep(step: StepWithAggregations) {
   const newcolumnOccurences: { [prop: string]: number } = {};
   for (const agg of step.aggregations) {
     agg.newcolumns = [...agg.columns];

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -160,7 +160,7 @@ export function combinations(arr: any[]): any[][] {
  * @param step a step that includes an aggregation parameter of the form:
  *  { columns: ['A', 'B'], aggfunction: 'sum', newcolumns: []}
  */
-export function setAggregationsNewColumnsInStep(step: StepWithAggregations) {
+export async function setAggregationsNewColumnsInStep(step: StepWithAggregations) {
   const newcolumnOccurences: { [prop: string]: number } = {};
   for (const agg of step.aggregations) {
     agg.newcolumns = [...agg.columns];

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -136,6 +136,7 @@ export class BasicStepFormTestRunner {
       wrapper.setData(data);
     }
     wrapper.find('.widget-form-action__button--validate').trigger('click');
+    await this.vue.nextTick();
     const errors = wrapper.vm.$data.errors
       .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
       .sort((err1: ValidationError, err2: ValidationError) =>


### PR DESCRIPTION
Enable to edit add total steps rows.
Before step was not saved correctly

Before:
![before](https://user-images.githubusercontent.com/59559689/144072297-3ea38a89-5ae3-4175-baad-d60a935b82e0.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/144072323-2d27a3a9-7d35-4c21-a8ba-7f3c1a8e4c8d.gif)

