### PR TITLE
fix(ui): component InputNumber return value as number

### DIFF
--- a/src/components/stepforms/StatisticsStepForm.vue
+++ b/src/components/stepforms/StatisticsStepForm.vue
@@ -253,8 +253,8 @@ export default class StatisticsStepForm extends BaseStepForm<StatisticsStep> {
   toogleQuantile(quantile: Quantile) {
     // parse quantile
     quantile = {
-      nth: parseInt(quantile.nth),
-      order: parseInt(quantile.order),
+      nth: quantile.nth,
+      order: quantile.order,
       label: quantile.label,
     };
     if (this.isQuantileChecked(quantile)) {

--- a/src/components/stepforms/widgets/InputNumber.vue
+++ b/src/components/stepforms/widgets/InputNumber.vue
@@ -96,7 +96,7 @@ export default class InputNumberWidget extends Mixins(FormWidget) {
   }
 
   updateValue(newValue: string) {
-    this.$emit('input', newValue);
+    this.$emit('input', Number(newValue));
   }
 }
 </script>

--- a/tests/unit/input-number-widget.spec.ts
+++ b/tests/unit/input-number-widget.spec.ts
@@ -93,7 +93,7 @@ describe('Widget Input Number', () => {
     const inputWrapper = wrapper.find('input[type="number"]');
     (inputWrapper.element as HTMLInputElement).value = '2';
     inputWrapper.trigger('input', { value: '2' });
-    expect(wrapper.emitted()).toEqual({ input: [['2']] });
+    expect(wrapper.emitted()).toEqual({ input: [[2]] });
   });
 
   it('should emit "input" event with the updated value when VariableInput is updated', () => {

--- a/tests/unit/statistics-step-form.spec.ts
+++ b/tests/unit/statistics-step-form.spec.ts
@@ -177,11 +177,11 @@ describe('statistics Step Form', () => {
     wrapper
       .findAll('InputNumberWidget-stub')
       .at(0)
-      .vm.$emit('input', '2');
+      .vm.$emit('input', 2);
     wrapper
       .findAll('InputNumberWidget-stub')
       .at(1)
-      .vm.$emit('input', '4');
+      .vm.$emit('input', 4);
     await wrapper.find('.custom-quantile-widget-checkbox').trigger('click');
     expect(wrapper.vm.$data.editedStep.quantiles).toEqual([
       { label: 'last decile', nth: 9, order: 10 },


### PR DESCRIPTION
We returned value as string in input number, it should be a number.
Update statics steps because parseInt is not necessary anymore