### PR TITLE
feat(backend service):  configurable "preview source" rows subset TCTC-1324

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Preview source rows subset configuration
+
 ## [0.76.2] - 2021-11-22
 
 ### Fixed

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -34,6 +34,7 @@
         Delete [{{ selectedSteps.length }}] selected
       </div>
     </div>
+    <PreviewSourceSubset />
     <div class="query-pipeline__tips-container" v-if="hasSupportedSteps">
       <div class="query-pipeline__tips">
         Interact with the widgets and table on the right to add steps
@@ -62,6 +63,7 @@ import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
 
 import DeleteConfirmationModal from './DeleteConfirmationModal.vue';
+import PreviewSourceSubset from './PreviewSourceSubset.vue';
 import Step from './Step.vue';
 
 @Component({
@@ -71,6 +73,7 @@ import Step from './Step.vue';
     Draggable,
     Step,
     FAIcon,
+    PreviewSourceSubset,
   },
 })
 export default class PipelineComponent extends Vue {

--- a/src/components/PreviewSourceSubset.vue
+++ b/src/components/PreviewSourceSubset.vue
@@ -1,0 +1,67 @@
+<template>
+  <div v-if="previewSourceRowsSubset" class="preview-source-rows-subset">
+    <p>Configurable "preview source" subset (beta)</p>
+    <div>
+      <input v-model.number="rowsSubsetInput" type="number" min="1" />
+      rows
+      <button @click="refreshPreview">Refresh</button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { Component, Watch } from 'vue-property-decorator';
+
+import { VQBModule } from '@/store';
+import { MutationCallbacks } from '@/store/mutations';
+
+@Component({
+  name: 'PreviewSourceSubset',
+})
+export default class PreviewSourceSubset extends Vue {
+  rowsSubsetInput: number | string | undefined = this.lastSuccessfulPreviewRowsSubset;
+
+  @VQBModule.Getter('previewSourceRowsSubset') previewSourceRowsSubset?:
+    | number
+    | 'unlimited'
+    | undefined;
+
+  @VQBModule.Action updateDataset!: () => void;
+  @VQBModule.Mutation setPreviewSourceRowsSubset!: MutationCallbacks['setPreviewSourceRowsSubset'];
+
+  get lastSuccessfulPreviewRowsSubset() {
+    return this.previewSourceRowsSubset == 'unlimited'
+      ? 100000000 // we don't support 'unlimited' value (yet ?), use an arbitrary number instead
+      : this.previewSourceRowsSubset;
+  }
+
+  @Watch('lastSuccessfulPreviewRowsSubset', { immediate: true })
+  updateRowsSubset() {
+    this.rowsSubsetInput = this.lastSuccessfulPreviewRowsSubset;
+  }
+
+  refreshPreview() {
+    this.setPreviewSourceRowsSubset({
+      previewSourceRowsSubset:
+        typeof this.rowsSubsetInput === 'number' ? this.rowsSubsetInput : undefined,
+    });
+    this.updateDataset();
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../styles/_variables';
+
+.preview-source-rows-subset {
+  margin: 30px 0;
+  padding-left: 48px;
+  width: 100%;
+  border-top: 1px solid $grey-light;
+
+  input {
+    width: 90px;
+  }
+}
+</style>

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -38,6 +38,7 @@ export interface BackendService {
     pipelines: PipelinesScopeContext,
     limit: number,
     offset: number,
+    sourceRowsSubset?: number | 'unlimited',
   ): BackendResponse<DataSet>;
 }
 

--- a/src/lib/dataset/index.ts
+++ b/src/lib/dataset/index.ts
@@ -50,4 +50,7 @@ export type DataSet = {
    * pagination context (i.e. number of results displayed per page and current page number)
    */
   paginationContext?: PaginationContext;
+  previewContext?: {
+    sourceRowsSubset?: number | 'unlimited';
+  };
 };

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -70,6 +70,7 @@ class Actions {
         state.pipelines,
         state.pagesize,
         pageOffset(state.pagesize, getters.pageno),
+        getters.previewSourceRowsSubset,
       );
       const backendMessages = response.error || response.warning || [];
       commit('logBackendMessages', { backendMessages });

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -88,6 +88,8 @@ const getters: GetterTree<VQBState, any> = {
    */
   pageno: (state: VQBState) =>
     state.dataset.paginationContext ? state.dataset.paginationContext.pageno : 1,
+
+  previewSourceRowsSubset: (state: VQBState) => state.dataset.previewContext?.sourceRowsSubset,
   /**
    * Return current edited pipeline
    */

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -62,6 +62,11 @@ type SetCurrentPage = {
   payload: { pageno: number };
 };
 
+type SetPreviewSourceRowsSubset = {
+  type: 'setPreviewSourceRowsSubset';
+  payload: { previewSourceRowsSubset?: number | 'unlimited' };
+};
+
 type ToggleColumnSelectionMutation = {
   type: 'toggleColumnSelection';
   payload: { column: string };
@@ -94,6 +99,7 @@ export type StateMutation =
   | SelectDomainMutation
   | SelectedStepMutation
   | SetCurrentPage
+  | SetPreviewSourceRowsSubset
   | ToggleColumnSelectionMutation
   | ToggleRequestOnGoing
   | VariableDelimitersMutation;
@@ -311,6 +317,15 @@ class Mutations {
     } else {
       const length = state.dataset.data.length;
       state.dataset.paginationContext = { pageno, pagesize: length, totalCount: length };
+    }
+  }
+
+  setPreviewSourceRowsSubset(
+    state: VQBState,
+    { previewSourceRowsSubset }: { previewSourceRowsSubset?: number | 'unlimited' },
+  ) {
+    if (state.dataset.previewContext) {
+      state.dataset.previewContext.sourceRowsSubset = previewSourceRowsSubset;
     }
   }
 


### PR DESCRIPTION
Not the definitive design, just a quick but still functional implementation.

![image](https://user-images.githubusercontent.com/3978482/144075830-40c032aa-f7ec-41d3-811a-bb428bcfc79a.png)
