### PR TITLE
feat(new-date-input): send analytics event when user select a (advanced or base) variable TCTC-899

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -111,7 +111,7 @@ setAvailableCodeEditors({
 });
 
 // Example to set send analytics method
-const sendAnalytics = (name, value) => { console.debug('Analytics event send ::', { name, value }) };
+const sendAnalytics = ({name, value}) => { console.debug('Analytics event send ::', { name, value }) };
 defineSendAnalytics(sendAnalytics);
 
 const CASTERS = {

--- a/playground/app.js
+++ b/playground/app.js
@@ -10,6 +10,7 @@ const {
   dereferencePipelines,
   registerModule,
   setAvailableCodeEditors,
+  defineSendAnalytics,
   exampleInterpolateFunc,
 } = vqb;
 
@@ -108,6 +109,10 @@ setAvailableCodeEditors({
     json: codeEditorForLang('json'),
   },
 });
+
+// Example to set send analytics method
+const sendAnalytics = (name, value) => { console.debug('Analytics event send ::', { name, value }) };
+defineSendAnalytics(sendAnalytics);
 
 const CASTERS = {
   date: val => new Date(val),

--- a/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -269,7 +269,7 @@ export default class NewDateInput extends Vue {
     const variableWithDelimiters = `${this.variableDelimiters.start}${value}${this.variableDelimiters.end}`;
     this.$emit('input', variableWithDelimiters);
     this.closeEditor();
-    sendAnalytics('Date input - Select variable', value);
+    sendAnalytics({ name: 'Date input - Select variable', value });
   }
 
   editCustomVariable(): void {
@@ -309,7 +309,7 @@ export default class NewDateInput extends Vue {
     const variableWithDelimiters = `${this.variableDelimiters.start} ${variableIdentifier} ${this.variableDelimiters.end}`;
     this.$emit('input', variableWithDelimiters);
     this.closeAdvancedVariableModal();
-    sendAnalytics('Date input - Select advanced variable', variableIdentifier);
+    sendAnalytics({ name: 'Date input - Select advanced variable', value: variableIdentifier });
   }
 }
 </script>

--- a/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -111,6 +111,7 @@ import {
   isRelativeDate,
   relativeDateToString,
 } from '@/lib/dates';
+import { sendAnalytics } from '@/lib/send-analytics';
 import {
   AvailableVariable,
   extractVariableIdentifier,
@@ -268,6 +269,7 @@ export default class NewDateInput extends Vue {
     const variableWithDelimiters = `${this.variableDelimiters.start}${value}${this.variableDelimiters.end}`;
     this.$emit('input', variableWithDelimiters);
     this.closeEditor();
+    sendAnalytics('Date input - Select variable', value);
   }
 
   editCustomVariable(): void {
@@ -307,6 +309,7 @@ export default class NewDateInput extends Vue {
     const variableWithDelimiters = `${this.variableDelimiters.start} ${variableIdentifier} ${this.variableDelimiters.end}`;
     this.$emit('input', variableWithDelimiters);
     this.closeAdvancedVariableModal();
+    sendAnalytics('Date input - Select advanced variable', variableIdentifier);
   }
 }
 </script>

--- a/src/lib/send-analytics.ts
+++ b/src/lib/send-analytics.ts
@@ -8,9 +8,9 @@
   - value: any (the data refering to this event that can be of any type depending on the context)
 */
 
-type SendAnalyticsManager = (_name: string, _value: any) => void;
+type SendAnalyticsManager = (_params: any) => void;
 
-let sendAnalytics: SendAnalyticsManager = (_name: string, _value: any) => {};
+let sendAnalytics: SendAnalyticsManager = (_params: any) => {};
 
 function defineSendAnalytics(sendAnalyticsManager: SendAnalyticsManager) {
   sendAnalytics = sendAnalyticsManager;

--- a/src/lib/send-analytics.ts
+++ b/src/lib/send-analytics.ts
@@ -1,0 +1,19 @@
+/*
+  This module enable to update the method used when the sendAnalytics method is called in the app
+  It would do nothing by default
+
+  You can set the function to use to send analytics by using the `defineSendAnalytics`
+  it will retrieve two parameters:
+  - name: string (the name of the referent event. ex: 'Save step xxx'
+  - value: any (the data refering to this event that can be of any type depending on the context)
+*/
+
+type SendAnalyticsManager = (_name: string, _value: any) => void;
+
+let sendAnalytics: SendAnalyticsManager = (_name: string, _value: any) => {};
+
+function defineSendAnalytics(sendAnalyticsManager: SendAnalyticsManager) {
+  sendAnalytics = sendAnalyticsManager;
+}
+
+export { sendAnalytics, defineSendAnalytics };

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ export { getTranslator } from './lib/translators';
 export { mongoResultsToDataset, inferTypeFromDataset } from './lib/dataset/mongo';
 export { pandasDataTableToDataset } from './lib/dataset/pandas';
 export { setAvailableCodeEditors } from './components/code-editor';
+export { defineSendAnalytics } from './lib/send-analytics';
 
 // export store entrypoints
 export { dereferencePipelines, getPipelineNamesReferencing } from '@/lib/dereference-pipeline';

--- a/tests/unit/lib/send-analytics.spec.ts
+++ b/tests/unit/lib/send-analytics.spec.ts
@@ -2,13 +2,15 @@ import { defineSendAnalytics, sendAnalytics } from '@/lib/send-analytics';
 
 describe('defineSendAnalytics', () => {
   it('should populate the send analytics method', () => {
-    const sendAnalyticsManager = (name: string, value: any) =>
+    const sendAnalyticsManager = ({ name, value }: { name: string; value: any }) =>
       `i will do anything you want! ${name} :: ${value}`;
     defineSendAnalytics(sendAnalyticsManager);
-    // verify that method has been populate
-    expect(sendAnalytics('analytics', 'plop')).toEqual(sendAnalyticsManager('analytics', 'plop'));
+    // verify that the exported sendAnalytics method has been changed
+    expect(sendAnalytics({ name: 'analytics', value: 'plop' })).toEqual(
+      sendAnalyticsManager({ name: 'analytics', value: 'plop' }),
+    );
     // verify that params are retrieved
-    expect(sendAnalytics('analytics', 'plop')).toEqual(
+    expect(sendAnalytics({ name: 'analytics', value: 'plop' })).toEqual(
       'i will do anything you want! analytics :: plop',
     );
   });

--- a/tests/unit/lib/send-analytics.spec.ts
+++ b/tests/unit/lib/send-analytics.spec.ts
@@ -1,0 +1,15 @@
+import { defineSendAnalytics, sendAnalytics } from '@/lib/send-analytics';
+
+describe('defineSendAnalytics', () => {
+  it('should populate the send analytics method', () => {
+    const sendAnalyticsManager = (name: string, value: any) =>
+      `i will do anything you want! ${name} :: ${value}`;
+    defineSendAnalytics(sendAnalyticsManager);
+    // verify that method has been populate
+    expect(sendAnalytics('analytics', 'plop')).toEqual(sendAnalyticsManager('analytics', 'plop'));
+    // verify that params are retrieved
+    expect(sendAnalytics('analytics', 'plop')).toEqual(
+      'i will do anything you want! analytics :: plop',
+    );
+  });
+});

--- a/tests/unit/new-date-input.spec.ts
+++ b/tests/unit/new-date-input.spec.ts
@@ -121,10 +121,10 @@ describe('Date input', () => {
         expect(wrapper.emitted().input[0][0]).toBe(`{{${selectedVariable}}}`);
       });
       it('should send analytics event', () => {
-        expect(sendAnalyticsSpy).toHaveBeenCalledWith(
-          'Date input - Select variable',
-          selectedVariable,
-        );
+        expect(sendAnalyticsSpy).toHaveBeenCalledWith({
+          name: 'Date input - Select variable',
+          value: selectedVariable,
+        });
       });
       it('should hide editor', () => {
         expect(wrapper.find('popover-stub').props().visible).toBe(false);
@@ -183,10 +183,10 @@ describe('Date input', () => {
         expect(wrapper.emitted('input')[0]).toEqual(['{{ Test }}']);
       });
       it('should send analytics event', () => {
-        expect(sendAnalyticsSpy).toHaveBeenCalledWith(
-          'Date input - Select advanced variable',
-          'Test',
-        );
+        expect(sendAnalyticsSpy).toHaveBeenCalledWith({
+          name: 'Date input - Select advanced variable',
+          value: 'Test',
+        });
       });
     });
   });

--- a/tests/unit/new-date-input.spec.ts
+++ b/tests/unit/new-date-input.spec.ts
@@ -2,6 +2,7 @@ import { shallowMount, Wrapper } from '@vue/test-utils';
 
 import NewDateInput from '@/components/stepforms/widgets/DateComponents/NewDateInput.vue';
 import { dateToString, RelativeDate } from '@/lib/dates';
+import * as sendAnalyticsUtils from '@/lib/send-analytics';
 
 jest.mock('@/components/FAIcon.vue');
 jest.mock('@/components/DatePicker/Calendar.vue');
@@ -52,7 +53,9 @@ const SAMPLE_VARIABLES = [
 
 describe('Date input', () => {
   let wrapper: Wrapper<NewDateInput>;
+  let sendAnalyticsSpy: jest.SpyInstance;
   const createWrapper = (propsData = {}) => {
+    sendAnalyticsSpy = jest.spyOn(sendAnalyticsUtils, 'sendAnalytics');
     wrapper = shallowMount(NewDateInput, {
       sync: false,
       propsData,
@@ -117,6 +120,12 @@ describe('Date input', () => {
       it('should emit the selected variable identifier with delimiters', () => {
         expect(wrapper.emitted().input[0][0]).toBe(`{{${selectedVariable}}}`);
       });
+      it('should send analytics event', () => {
+        expect(sendAnalyticsSpy).toHaveBeenCalledWith(
+          'Date input - Select variable',
+          selectedVariable,
+        );
+      });
       it('should hide editor', () => {
         expect(wrapper.find('popover-stub').props().visible).toBe(false);
       });
@@ -172,6 +181,12 @@ describe('Date input', () => {
       it('should emit the new value with delimiters', () => {
         expect(wrapper.emitted('input')).toHaveLength(1);
         expect(wrapper.emitted('input')[0]).toEqual(['{{ Test }}']);
+      });
+      it('should send analytics event', () => {
+        expect(sendAnalyticsSpy).toHaveBeenCalledWith(
+          'Date input - Select advanced variable',
+          'Test',
+        );
       });
     });
   });


### PR DESCRIPTION
Add a new util to populate a sendAnalytics method from outside of weaverbird
Add a case in playground for UAT
Use it to send events when user select a variable or advanced variable in NewDateInput

Example in playground with method populated with a console.debug only:
![analytics](https://user-images.githubusercontent.com/59559689/144093865-49f5fc98-b385-47cd-9c91-cc0775672fff.gif)


