### PR TITLE
fix(pandas): some dateextract were failing if some dates were duplicated TCTC-1379

### DIFF
--- a/server/src/weaverbird/backends/pandas_executor/steps/addmissingdates.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/addmissingdates.py
@@ -42,5 +42,7 @@ def execute_addmissingdates(
             group_with_missing_dates['_old_date'],
         )
         del group_with_missing_dates['_old_date']
-        result = pd.concat([result, group_with_missing_dates])
+        # Each group could have duplicate indexes with the previous ones
+        # Ignoring the index prevents duplicate index values
+        result = pd.concat([result, group_with_missing_dates], ignore_index=True)
     return result

--- a/server/src/weaverbird/backends/pandas_executor/steps/date_extract.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/date_extract.py
@@ -149,7 +149,7 @@ def execute_date_extract(
                 result = cast_to_int(result)
 
         # assign won't work if result has duplicates in its index
-        result = result[~result.index.duplicated()]
+        result = result.drop_duplicates()
 
         df = df.assign(**{new_col: result})
 

--- a/server/src/weaverbird/backends/pandas_executor/steps/date_extract.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/date_extract.py
@@ -148,6 +148,9 @@ def execute_date_extract(
             if result.dtype.is_unsigned_integer:
                 result = cast_to_int(result)
 
+        # assign won't work if result has duplicates in its index
+        result = result[~result.index.duplicated()]
+
         df = df.assign(**{new_col: result})
 
     return df

--- a/server/src/weaverbird/backends/pandas_executor/steps/date_extract.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/date_extract.py
@@ -148,9 +148,6 @@ def execute_date_extract(
             if result.dtype.is_unsigned_integer:
                 result = cast_to_int(result)
 
-        # assign won't work if result has duplicates in its index
-        result = result.drop_duplicates()
-
         df = df.assign(**{new_col: result})
 
     return df

--- a/server/tests/backends/fixtures/dateextract/after_add_missing_dates_duplicate_values.json
+++ b/server/tests/backends/fixtures/dateextract/after_add_missing_dates_duplicate_values.json
@@ -1,6 +1,7 @@
 {
   "description": "After a addmissing date on a column having same dates but in different groups, the dateextract step was failing for pandas executor (cannot reindex from a duplicate axis)",
   "exclude": [
+    "snowflake",
     "sql"
   ],
   "step": {

--- a/server/tests/backends/fixtures/dateextract/after_add_missing_dates_duplicate_values.json
+++ b/server/tests/backends/fixtures/dateextract/after_add_missing_dates_duplicate_values.json
@@ -1,0 +1,128 @@
+{
+  "description": "After a addmissing date on a column having same dates but in different groups, the dateextract step was failing for pandas executor (cannot reindex from a duplicate axis)",
+  "exclude": [
+    "sql"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "addmissingdates",
+        "datesColumn": "date",
+        "datesGranularity": "day",
+        "groups": [
+          "label"
+        ]
+      },
+      {
+        "name": "dateextract",
+        "column": "date",
+        "dateInfo": [
+          "isoYear",
+          "isoWeek",
+          "isoDayOfWeek",
+          "previousIsoWeek"
+        ],
+        "newColumns": [
+          "date_isoYear",
+          "date_isoWeek",
+          "date_isoDayOfWeek",
+          "date_previousIsoWeek"
+        ]
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "label",
+          "type": "string"
+        },
+        {
+          "name": "date",
+          "type": "datetime"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "label": "meow",
+        "date": "2021-12-13T00:00:00.000Z"
+      },
+      {
+        "label": "meow",
+        "date": "2021-12-15T00:00:00.000Z"
+      },
+      {
+        "label": "plop",
+        "date": "2021-12-13T00:00:00.000Z"
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "label",
+          "type": "string"
+        },
+        {
+          "name": "date",
+          "type": "datetime"
+        },
+        {
+          "name": "date_isoYear",
+          "type": "number"
+        },
+        {
+          "name": "date_isoWeek",
+          "type": "number"
+        },
+        {
+          "name": "date_isoDayOfWeek",
+          "type": "number"
+        },
+        {
+          "name": "date_previousIsoWeek",
+          "type": "number"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "label": "meow",
+        "date": "2021-12-13T00:00:00.000Z",
+        "date_isoYear": 2021,
+        "date_isoWeek": 50,
+        "date_isoDayOfWeek": 1,
+        "date_previousIsoWeek": 49
+      },
+      {
+        "label": "meow",
+        "date": "2021-12-14T00:00:00.000Z",
+        "date_isoYear": 2021,
+        "date_isoWeek": 50,
+        "date_isoDayOfWeek": 2,
+        "date_previousIsoWeek": 49
+      },
+      {
+        "label": "meow",
+        "date": "2021-12-15T00:00:00.000Z",
+        "date_isoYear": 2021,
+        "date_isoWeek": 50,
+        "date_isoDayOfWeek": 3,
+        "date_previousIsoWeek": 49
+      },
+      {
+        "label": "plop",
+        "date": "2021-12-13T00:00:00.000Z",
+        "date_isoYear": 2021,
+        "date_isoWeek": 50,
+        "date_isoDayOfWeek": 1,
+        "date_previousIsoWeek": 49
+      }
+    ]
+  }
+}

--- a/server/tests/steps/test_addmissingdates.py
+++ b/server/tests/steps/test_addmissingdates.py
@@ -73,7 +73,10 @@ def test_missing_date_years(today):
     assert_dataframes_equals(result, expected_result)
 
 
-def test_missing_date_with_groups(today):
+def test_missing_date_with_groups_correct_indexing(today):
+    """
+    It should not create duplicate values in index
+    """
     dates = [today + timedelta(days=nb_day) for nb_day in list(range(1, 10)) + list(range(12, 20))]
     missing_dates = [today + timedelta(days=10), today + timedelta(days=11)]
 
@@ -103,6 +106,7 @@ def test_missing_date_with_groups(today):
         ]
     ).sort_values(by=['country', 'date'])
     assert_dataframes_equals(result, expected_result)
+    assert not result.index.has_duplicates
 
 
 def test_missing_date_with_groups_various_length(today):


### PR DESCRIPTION
This is very edge case found by adding a "missing dates" step with some
duplicate dates but not in the same group.

While fixing this, I noticed that the tests of the dateextract step were not executed because f a filename mismatch! I fixed this in #1226, so this PR needs to be merged first for the test case to be run.