### PR TITLE
feat(configurable-subset-preview): use correct design TCTC-1339

### DIFF
--- a/src/assets/FA-ICONS.ts
+++ b/src/assets/FA-ICONS.ts
@@ -29,6 +29,7 @@ import {
   faPlus,
   faQuestionCircle,
   faSearch,
+  faSyncAlt,
   faTimes,
   faTrash,
 } from '@fortawesome/free-solid-svg-icons';
@@ -60,6 +61,7 @@ const FA_ICONS = {
   plus: faPlus,
   'question-circle': faQuestionCircle,
   search: faSearch,
+  'sync-alt': faSyncAlt,
   times: faTimes,
   trash: faTrash,
   // Regular icons (should always use `far ` prefix)

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -34,7 +34,6 @@
         Delete [{{ selectedSteps.length }}] selected
       </div>
     </div>
-    <PreviewSourceSubset />
     <div class="query-pipeline__tips-container" v-if="hasSupportedSteps">
       <div class="query-pipeline__tips">
         Interact with the widgets and table on the right to add steps
@@ -63,7 +62,6 @@ import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
 
 import DeleteConfirmationModal from './DeleteConfirmationModal.vue';
-import PreviewSourceSubset from './PreviewSourceSubset.vue';
 import Step from './Step.vue';
 
 @Component({
@@ -73,7 +71,6 @@ import Step from './Step.vue';
     Draggable,
     Step,
     FAIcon,
-    PreviewSourceSubset,
   },
 })
 export default class PipelineComponent extends Vue {

--- a/src/components/PreviewSourceSubset.vue
+++ b/src/components/PreviewSourceSubset.vue
@@ -1,11 +1,18 @@
 <template>
-  <div v-if="previewSourceRowsSubset" class="preview-source-rows-subset">
-    <p>Configurable "preview source" subset (beta)</p>
-    <div>
-      <input v-model.number="rowsSubsetInput" type="number" min="1" />
-      rows
-      <button @click="refreshPreview">Refresh</button>
+  <div class="preview-source-rows-subset">
+    <span class="preview-source-rows-subset__text">Preview source on</span>
+    <div class="preview-source-rows-subset__wrapper">
+      <input
+        class="preview-source-rows-subset__input"
+        v-model.number="rowsSubsetInput"
+        type="number"
+        min="1"
+      />
+      <span class="preview-source-rows-subset__button" @click="refreshPreview">
+        <FAIcon icon="sync-alt" />
+      </span>
     </div>
+    <span class="preview-source-rows-subset__text">rows subset</span>
   </div>
 </template>
 
@@ -13,11 +20,15 @@
 import Vue from 'vue';
 import { Component, Watch } from 'vue-property-decorator';
 
+import FAIcon from '@/components/FAIcon.vue';
 import { VQBModule } from '@/store';
 import { MutationCallbacks } from '@/store/mutations';
 
 @Component({
   name: 'PreviewSourceSubset',
+  components: {
+    FAIcon,
+  },
 })
 export default class PreviewSourceSubset extends Vue {
   rowsSubsetInput: number | string | undefined = this.lastSuccessfulPreviewRowsSubset;
@@ -55,13 +66,45 @@ export default class PreviewSourceSubset extends Vue {
 @import '../styles/_variables';
 
 .preview-source-rows-subset {
-  margin: 30px 0;
-  padding-left: 48px;
+  padding: 7px 12px;
   width: 100%;
-  border-top: 1px solid $grey-light;
+  background: $active-color;
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+}
+.preview-source-rows-subset__text {
+  color: white;
+  letter-spacing: 0.5px;
+  font-weight: 500;
+}
+.preview-source-rows-subset__wrapper {
+  width: 110px;
+  margin: 0 10px;
+  padding: 3px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 
-  input {
-    width: 90px;
+  background: white;
+  height: 100%;
+  border-radius: 2px;
+}
+.preview-source-rows-subset__input {
+  border: none;
+  width: 100%;
+  flex: 1;
+  height: 25px;
+  &:focus {
+    outline: none;
   }
+}
+.preview-source-rows-subset__button {
+  background: $active-color;
+  color: white;
+  padding: 7px;
+  font-size: 10px;
+  border-radius: 2px;
+  cursor: pointer;
 }
 </style>

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -23,6 +23,14 @@
             'query-pipeline-step__actions--disabled': !isEditable,
           }"
         >
+          <div
+            class="query-pipeline-step__action query-pipeline-step__action--expand"
+            data-cy="weaverbird-filter-step"
+            v-if="isExpandable"
+            @click.stop="toggleBody"
+          >
+            <FAIcon icon="filter" />
+          </div>
           <!-- @click.stop is used to avoid to trigger select event when editing a step -->
           <div
             class="query-pipeline-step__action"
@@ -39,6 +47,9 @@
             <FAIcon icon="grip-vertical" />
           </div>
         </div>
+      </div>
+      <div class="query-pipeline-step__expand" v-if="isExpandable && expanded">
+        <PreviewSourceSubset />
       </div>
       <div class="query-pipeline-step__footer" v-if="errorMessage && !isDisabled">
         <div class="query-pipeline-step__error" :title="errorMessage">
@@ -58,10 +69,13 @@ import { PipelineStep } from '@/lib/steps';
 import { VariableDelimiters } from '@/lib/variables';
 import { VQBModule } from '@/store';
 
+import PreviewSourceSubset from './PreviewSourceSubset.vue';
+
 @Component({
   name: 'step',
   components: {
     FAIcon,
+    PreviewSourceSubset,
   },
 })
 export default class Step extends Vue {
@@ -95,12 +109,18 @@ export default class Step extends Vue {
   @Prop()
   readonly indexInPipeline!: number;
 
+  expanded = false;
+
   @VQBModule.Getter stepConfig!: (index: number) => PipelineStep;
 
   @VQBModule.Getter stepErrors!: (index: number) => string | undefined;
 
   get stepName(): string {
     return humanReadableLabel(this.step);
+  }
+
+  get isExpandable(): boolean {
+    return this.isFirst;
   }
 
   get errorMessage(): string | undefined {
@@ -127,6 +147,7 @@ export default class Step extends Vue {
       'query-pipeline-step__container--last-active': this.isLastActive,
       'query-pipeline-step__container--disabled': this.isDisabled,
       'query-pipeline-step__container--errors': this.errorMessage && !this.isDisabled,
+      'query-pipeline-step__container--expanded': this.isExpandable && this.expanded,
     };
   }
 
@@ -154,6 +175,10 @@ export default class Step extends Vue {
 
   toggleDelete(): void {
     if (!this.isFirst) this.$emit('toggleDelete');
+  }
+
+  toggleBody(): void {
+    this.expanded = !this.expanded;
   }
 }
 </script>
@@ -450,6 +475,21 @@ export default class Step extends Vue {
       background-color: $grey-dark;
       border-color: $grey-dark;
     }
+  }
+}
+
+.query-pipeline-step__expand {
+  height: 45px;
+}
+
+.query-pipeline-step__container--expanded {
+  height: 97px;
+  .query-pipeline-step,
+  .query-pipeline-step__action {
+    border-color: $active-color;
+  }
+  .query-pipeline-step__action--expand {
+    color: $active-color;
   }
 }
 </style>

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -115,12 +115,17 @@ export default class Step extends Vue {
 
   @VQBModule.Getter stepErrors!: (index: number) => string | undefined;
 
+  @VQBModule.Getter('previewSourceRowsSubset') previewSourceRowsSubset?:
+    | number
+    | 'unlimited'
+    | undefined;
+
   get stepName(): string {
     return humanReadableLabel(this.step);
   }
 
   get isExpandable(): boolean {
-    return this.isFirst;
+    return Boolean(this.isFirst && this.previewSourceRowsSubset);
   }
 
   get errorMessage(): string | undefined {

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -24,10 +24,10 @@
           }"
         >
           <div
-            class="query-pipeline-step__action query-pipeline-step__action--expand"
+            class="query-pipeline-step__action query-pipeline-step__action--preview-source-subset"
             data-cy="weaverbird-filter-step"
-            v-if="isExpandable"
-            @click.stop="toggleBody"
+            v-if="canConfigurePreviewSourceSubset"
+            @click.stop="togglePreviewSourceSubsetForm"
           >
             <FAIcon icon="filter" />
           </div>
@@ -48,7 +48,10 @@
           </div>
         </div>
       </div>
-      <div class="query-pipeline-step__expand" v-if="isExpandable && expanded">
+      <div
+        class="query-pipeline-step__expand"
+        v-if="canConfigurePreviewSourceSubset && isEditingPreviewSourceSubset"
+      >
         <PreviewSourceSubset />
       </div>
       <div class="query-pipeline-step__footer" v-if="errorMessage && !isDisabled">
@@ -109,7 +112,7 @@ export default class Step extends Vue {
   @Prop()
   readonly indexInPipeline!: number;
 
-  expanded = false;
+  isEditingPreviewSourceSubset = false;
 
   @VQBModule.Getter stepConfig!: (index: number) => PipelineStep;
 
@@ -124,7 +127,7 @@ export default class Step extends Vue {
     return humanReadableLabel(this.step);
   }
 
-  get isExpandable(): boolean {
+  get canConfigurePreviewSourceSubset(): boolean {
     return Boolean(this.isFirst && this.previewSourceRowsSubset);
   }
 
@@ -152,7 +155,8 @@ export default class Step extends Vue {
       'query-pipeline-step__container--last-active': this.isLastActive,
       'query-pipeline-step__container--disabled': this.isDisabled,
       'query-pipeline-step__container--errors': this.errorMessage && !this.isDisabled,
-      'query-pipeline-step__container--expanded': this.isExpandable && this.expanded,
+      'query-pipeline-step__container--preview-source-subset':
+        this.canConfigurePreviewSourceSubset && this.isEditingPreviewSourceSubset,
     };
   }
 
@@ -182,8 +186,8 @@ export default class Step extends Vue {
     if (!this.isFirst) this.$emit('toggleDelete');
   }
 
-  toggleBody(): void {
-    this.expanded = !this.expanded;
+  togglePreviewSourceSubsetForm(): void {
+    this.isEditingPreviewSourceSubset = !this.isEditingPreviewSourceSubset;
   }
 }
 </script>
@@ -487,13 +491,13 @@ export default class Step extends Vue {
   height: 45px;
 }
 
-.query-pipeline-step__container--expanded {
+.query-pipeline-step__container--preview-source-subset {
   height: 97px;
   .query-pipeline-step,
   .query-pipeline-step__action {
     border-color: $active-color;
   }
-  .query-pipeline-step__action--expand {
+  .query-pipeline-step__action--preview-source-subset {
     color: $active-color;
   }
 }

--- a/stories/step.js
+++ b/stories/step.js
@@ -40,7 +40,8 @@ stories
     data() {
       return {
         step: {
-          name: 'custom',
+          name: 'domain',
+          domain: 'Dataset 1',
         },
       };
     },
@@ -49,7 +50,7 @@ stories
     created: function() {
       registerModule(this.$store, {
         backendMessages: [],
-        dataset: { headers: [], data: [] },
+        dataset: { headers: [], data: [], previewContext: { sourceRowsSubset: 100 } },
       });
     },
   }))

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -1,4 +1,4 @@
-import { createLocalVue, createWrapper, mount, shallowMount, Wrapper } from '@vue/test-utils';
+import { createLocalVue, mount, shallowMount, Wrapper } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import PipelineComponent from '@/components/Pipeline.vue';

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -1,4 +1,4 @@
-import { createLocalVue, mount, shallowMount, Wrapper } from '@vue/test-utils';
+import { createLocalVue, createWrapper, mount, shallowMount, Wrapper } from '@vue/test-utils';
 import Vuex from 'vuex';
 
 import PipelineComponent from '@/components/Pipeline.vue';
@@ -258,6 +258,39 @@ describe('Step.vue', () => {
       expect(wrapper.find('.query-pipeline-step__actions').classes()).toContain(
         'query-pipeline-step__actions--disabled',
       );
+    });
+  });
+
+  describe('when step is expandable (source subset)', () => {
+    let wrapper: Wrapper<Step>;
+    beforeEach(() => {
+      wrapper = createStepWrapper({
+        propsData: {
+          key: 0,
+          isActive: true,
+          isDisabled: false,
+          isFirst: true,
+          isLast: false,
+          isEditable: true,
+          step: { name: 'rename', toRename: [['foo', 'bar']] },
+          indexInPipeline: 2,
+        },
+      });
+    });
+    it('should add a filter icon to expand step', () => {
+      expect(wrapper.find('.query-pipeline-step__action--expand').exists()).toBe(true);
+    });
+    it('should hide the preview source subset form', () => {
+      expect(wrapper.find('PreviewSourceSubset-stub').exists()).toBe(false);
+    });
+    describe('when step is expand', () => {
+      beforeEach(async () => {
+        wrapper.find('.query-pipeline-step__action--expand').trigger('click');
+        await wrapper.vm.$nextTick();
+      });
+      it('should display the preview source subset form', () => {
+        expect(wrapper.find('PreviewSourceSubset-stub').exists()).toBe(true);
+      });
     });
   });
 });

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -262,7 +262,7 @@ describe('Step.vue', () => {
     });
   });
 
-  describe('when step is expandable (source subset)', () => {
+  describe('when step enable to edit preview source subset', () => {
     let wrapper: Wrapper<Step>;
     beforeEach(() => {
       const dummyDataset: DataSet = {
@@ -290,16 +290,20 @@ describe('Step.vue', () => {
         },
       });
     });
-    it('should add a filter icon to expand step', () => {
-      expect(wrapper.find('.query-pipeline-step__action--expand').exists()).toBe(true);
-      expect(wrapper.findAll('.query-pipeline-step__action--expand')).toHaveLength(1);
+    it('should add an icon to edit preview source subset', () => {
+      expect(wrapper.find('.query-pipeline-step__action--preview-source-subset').exists()).toBe(
+        true,
+      );
+      expect(wrapper.findAll('.query-pipeline-step__action--preview-source-subset')).toHaveLength(
+        1,
+      );
     });
     it('should hide the preview source subset form', () => {
       expect(wrapper.find('.preview-source-subset').exists()).toBe(false);
     });
-    describe('when step is expand', () => {
+    describe('when editing preview source subset', () => {
       beforeEach(async () => {
-        wrapper.find('.query-pipeline-step__action--expand').trigger('click');
+        wrapper.find('.query-pipeline-step__action--preview-source-subset').trigger('click');
         await wrapper.vm.$nextTick();
       });
       it('should display the preview source subset form', () => {


### PR DESCRIPTION
Move subset preview form to domain step rather than pipeline
It is display using a toggle logic
Add specific style to fit design

Design:
<img width="975" alt="Screenshot 2021-12-12 at 22 40 26" src="https://user-images.githubusercontent.com/59559689/145988714-94ca1a08-a39a-4762-82c9-984f042e8a4d.png">

Storybook:
![filtering](https://user-images.githubusercontent.com/59559689/145988755-2fa7b0cc-e217-4e7b-9b8a-27fcb1347077.gif)

