### PR TITLE
fix(preview source subset): stop click propagation TCTC-1419

### DIFF
--- a/src/components/PreviewSourceSubset.vue
+++ b/src/components/PreviewSourceSubset.vue
@@ -7,8 +7,9 @@
         v-model.number="rowsSubsetInput"
         type="number"
         min="1"
+        @click.stop
       />
-      <span class="preview-source-rows-subset__button" @click="refreshPreview">
+      <span class="preview-source-rows-subset__button" @click.stop="refreshPreview">
         <FAIcon icon="sync-alt" />
       </span>
     </div>


### PR DESCRIPTION
to avoid selecting the "domain" step when
modifying or refreshing the preview source subset