### PR TITLE
feat(filter-step): rename label for from/until date operators TCTC-1443

### DIFF
--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -84,8 +84,8 @@ type LiteralOperator =
   | "doesn't match pattern"
   | 'is null'
   | 'is not null'
-  | 'from'
-  | 'until';
+  | 'starting'
+  | 'ending';
 
 type ShortOperator = FilterSimpleCondition['operator'];
 
@@ -178,8 +178,8 @@ export default class FilterSimpleConditionWidget extends Vue {
   ];
 
   readonly dateOperators: OperatorOption[] = [
-    { operator: 'from', label: 'from', inputWidget: NewDateInput },
-    { operator: 'until', label: 'until', inputWidget: NewDateInput },
+    { operator: 'from', label: 'starting', inputWidget: NewDateInput },
+    { operator: 'until', label: 'ending', inputWidget: NewDateInput },
     ...this.nullOperators,
   ];
 

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -84,8 +84,8 @@ type LiteralOperator =
   | "doesn't match pattern"
   | 'is null'
   | 'is not null'
-  | 'starting'
-  | 'ending';
+  | 'starting in/on'
+  | 'ending in/on';
 
 type ShortOperator = FilterSimpleCondition['operator'];
 
@@ -178,8 +178,8 @@ export default class FilterSimpleConditionWidget extends Vue {
   ];
 
   readonly dateOperators: OperatorOption[] = [
-    { operator: 'from', label: 'starting', inputWidget: NewDateInput },
-    { operator: 'until', label: 'ending', inputWidget: NewDateInput },
+    { operator: 'from', label: 'starting in/on', inputWidget: NewDateInput },
+    { operator: 'until', label: 'ending in/on', inputWidget: NewDateInput },
     ...this.nullOperators,
   ];
 

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -93,9 +93,13 @@ function filterExpression(
       case 'notnull':
         return `"${condition.column}" is not null`;
       case 'from':
-        return `"${condition.column}" from ${relativeDateFilterExpression(condition.value)}`;
+        return `"${condition.column}" starting in/on ${relativeDateFilterExpression(
+          condition.value,
+        )}`;
       case 'until':
-        return `"${condition.column}" until ${relativeDateFilterExpression(condition.value)}`;
+        return `"${condition.column}" ending in/on ${relativeDateFilterExpression(
+          condition.value,
+        )}`;
       default:
         // only for typescript to be happy and see we always have a return value
         return '';

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -329,7 +329,7 @@ describe('Labeller', () => {
           operator: 'from',
         },
       };
-      expect(hrl(step)).toEqual('Keep rows where "column1" from 1/1/2021');
+      expect(hrl(step)).toEqual('Keep rows where "column1" starting in/on 1/1/2021');
     });
     it('generates label for relative date', () => {
       const step: S.FilterStep = {
@@ -340,7 +340,7 @@ describe('Labeller', () => {
           operator: 'from',
         },
       };
-      expect(hrl(step)).toEqual('Keep rows where "column1" from 1 years until {{today}}');
+      expect(hrl(step)).toEqual('Keep rows where "column1" starting in/on 1 years until {{today}}');
     });
   });
 
@@ -354,7 +354,7 @@ describe('Labeller', () => {
           operator: 'until',
         },
       };
-      expect(hrl(step)).toEqual('Keep rows where "column1" until 1/1/2021');
+      expect(hrl(step)).toEqual('Keep rows where "column1" ending in/on 1/1/2021');
     });
     it('generates label for relative date', () => {
       const step: S.FilterStep = {
@@ -365,7 +365,7 @@ describe('Labeller', () => {
           operator: 'until',
         },
       };
-      expect(hrl(step)).toEqual('Keep rows where "column1" until 1 years until {{today}}');
+      expect(hrl(step)).toEqual('Keep rows where "column1" ending in/on 1 years until {{today}}');
     });
     it('generates label for variable', () => {
       const step: S.FilterStep = {
@@ -376,7 +376,7 @@ describe('Labeller', () => {
           operator: 'until',
         },
       };
-      expect(hrl(step)).toEqual('Keep rows where "column1" until <%= date.start %>');
+      expect(hrl(step)).toEqual('Keep rows where "column1" ending in/on <%= date.start %>');
     });
   });
 


### PR DESCRIPTION
Update labels of from/until operator in filter step when filtering on a date