### PR TITLE
fix: add missing translator to date conversion components [TCTC-1607]

### DIFF
--- a/src/components/stepforms/FromDateStepForm.vue
+++ b/src/components/stepforms/FromDateStepForm.vue
@@ -114,6 +114,12 @@ export default class FromDateStepForm extends BaseStepForm<FromDateStep> {
         'https://docs.mongodb.com/manual/reference/operator/aggregation/dateToString/#format-specifiers',
     },
     {
+      id: 'mongo50',
+      label: 'Mongo 5.0',
+      doc:
+        'https://docs.mongodb.com/manual/reference/operator/aggregation/dateToString/#format-specifiers',
+    },
+    {
       id: 'pandas',
       label: 'Pandas',
       doc: 'https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes',

--- a/src/components/stepforms/ToDateStepForm.vue
+++ b/src/components/stepforms/ToDateStepForm.vue
@@ -120,6 +120,12 @@ export default class ToDateStepForm extends BaseStepForm<ToDateStep> {
         'https://docs.mongodb.com/manual/reference/operator/aggregation/dateFromString/index.html#datefromstring-format-specifiers',
     },
     {
+      id: 'mongo50',
+      label: 'Mongo 5.0',
+      doc:
+        'https://docs.mongodb.com/manual/reference/operator/aggregation/dateFromString/index.html#datefromstring-format-specifiers',
+    },
+    {
       id: 'pandas',
       label: 'Pandas',
       doc: 'https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes',


### PR DESCRIPTION
https://toucantoco.atlassian.net/browse/TCTC-1607

Missing translators made it so that some `.find` returned `undefined` and access to `(undefined).label` made everything crash, thus the bug.

This PR adds the missing Mongo 5.0 translator.