### PR TITLE
fix(ui): cumsumstep migration should delete old properties TCTC-1552

### DIFF
--- a/src/components/stepforms/CumSumStepForm.vue
+++ b/src/components/stepforms/CumSumStepForm.vue
@@ -84,20 +84,23 @@ export default class CumSumStepForm extends BaseStepForm<CumSumStep> {
   readonly title: string = 'Compute cumulated sum';
   cumSumWidget = CumSumWidget;
 
-  /** Overload the definition of editedStep in BaseStepForm to guarantee retrocompatibility,
-   *  as we have to manage historical configurations where only one column at a time could be
-   * renamed via the 'valueColumn' and 'newColumn' parameter, now optional and not useful. So we
-   * convert them into a 'toCumSum' array upfront */
-  editedStep = {
-    ...this.stepFormDefaults,
-    ...this.initialStepValue,
-    toCumSum:
-      this.initialStepValue.valueColumn && this.initialStepValue.newColumn
-        ? [[this.initialStepValue.valueColumn, this.initialStepValue.newColumn]]
-        : this.initialStepValue.toCumSum,
-    valueColumn: undefined,
-    newColumn: undefined,
-  };
+  created() {
+    /** Overload the definition of editedStep in BaseStepForm to guarantee retro-compatibility,
+     *  as we have to manage historical configurations where only one column at a time could be
+     * renamed via the 'valueColumn' and 'newColumn' parameter, now optional and not useful. So we
+     * convert them into a 'toCumSum' array upfront */
+    if ('valueColumn' in this.editedStep && this.editedStep.valueColumn) {
+      const valueColumn = this.editedStep.valueColumn;
+      delete this.editedStep.valueColumn;
+      (this.editedStep as CumSumStep).toCumSum = [[valueColumn, '']];
+
+      if ('newColumn' in this.editedStep && this.editedStep.newColumn) {
+        const newColumn = this.editedStep.newColumn;
+        delete this.editedStep.newColumn;
+        (this.editedStep as CumSumStep).toCumSum[0][1] = newColumn;
+      }
+    }
+  }
 
   get toCumSum() {
     return this.editedStep.toCumSum;

--- a/tests/unit/cumsum-step-form.spec.ts
+++ b/tests/unit/cumsum-step-form.spec.ts
@@ -109,6 +109,10 @@ describe('Cumsum Step Form', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.vm.$data.editedStep.toCumSum).toBeDefined();
     expect(wrapper.vm.$data.editedStep.toCumSum).toEqual([['foo', 'bar']]);
+
+    // Old properties must have been deleted
+    expect('valueColumn' in wrapper.vm.$data.editedStep).toBe(false);
+    expect('newlueColumn' in wrapper.vm.$data.editedStep).toBe(false);
   });
 
   it('should pass down "toCumSum" to ListWidget', async () => {


### PR DESCRIPTION
The check introduced in #999 / #1246 for mongo translator to be able to handle legacy cumsum step format need the properties 'valueColumn' and 'newColumn' not be present (not just present to undefined) to interpret correctly new steps with the 'toCumSum' attribute.

This PR fixes the format produced by the CumSumStepForm so these two old attributes are not present anymore.

Before:
![Screenshot from 2022-01-17 15-19-13](https://user-images.githubusercontent.com/932583/149786431-7f896448-4311-4ac8-a387-7e105f0fd448.png)

After:
![Screenshot from 2022-01-17 15-18-44](https://user-images.githubusercontent.com/932583/149786445-af62f6d5-430a-42f9-98ed-d150b953b163.png)
