### PR TITLE
feat: domains can be replaced by references to other queries  TCTC-1548

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -433,15 +433,6 @@ async function buildVueApp() {
               },
             },
           ],
-          fromRef: [
-            {
-              name: 'domain',
-              domain: {
-                type: 'ref',
-                uid: 'xxx-yyy-zzz'
-              }
-            }
-          ]
         },
         translator: TRANSLATOR,
         backendService: backendService,

--- a/playground/app.js
+++ b/playground/app.js
@@ -443,7 +443,6 @@ async function buildVueApp() {
             }
           ]
         },
-        currentDomain: TRANSLATOR == 'snowflake' ? 'SALES' :'sales',
         translator: TRANSLATOR,
         backendService: backendService,
         // based on lodash templates (ERB syntax)

--- a/playground/app.js
+++ b/playground/app.js
@@ -433,6 +433,15 @@ async function buildVueApp() {
               },
             },
           ],
+          fromRef: [
+            {
+              name: 'domain',
+              domain: {
+                type: 'ref',
+                uid: 'xxx-yyy-zzz'
+              }
+            }
+          ]
         },
         currentDomain: TRANSLATOR == 'snowflake' ? 'SALES' :'sales',
         translator: TRANSLATOR,

--- a/server/src/weaverbird/backends/pandas_executor/steps/utils/combination.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/utils/combination.py
@@ -1,11 +1,11 @@
 from pandas import DataFrame
 
 from weaverbird.backends.pandas_executor.types import DomainRetriever, PipelineExecutor
-from weaverbird.pipeline.steps.utils.combination import PipelineOrDomainName
+from weaverbird.pipeline.steps.utils.combination import PipelineOrDomainNameOrReference, Reference
 
 
 def resolve_pipeline_for_combination(
-    pipeline: PipelineOrDomainName,
+    pipeline: PipelineOrDomainNameOrReference,
     domain_retriever: DomainRetriever,
     pipeline_executor: PipelineExecutor,
 ) -> DataFrame:
@@ -14,7 +14,7 @@ def resolve_pipeline_for_combination(
     """
     from weaverbird.pipeline import Pipeline
 
-    if isinstance(pipeline, str):
+    if isinstance(pipeline, str) or isinstance(pipeline, Reference):
         return domain_retriever(pipeline)
     else:
         # NOTE execution report of the sub-pipeline is discarded

--- a/server/src/weaverbird/backends/pandas_executor/types.py
+++ b/server/src/weaverbird/backends/pandas_executor/types.py
@@ -4,7 +4,7 @@ from pandas import DataFrame
 from pydantic import BaseModel, Field
 
 from weaverbird.pipeline import Pipeline
-from weaverbird.pipeline.steps.domain import Reference
+from weaverbird.pipeline.steps.utils.combination import Reference
 
 
 class StepExecutionReport(BaseModel):

--- a/server/src/weaverbird/backends/pandas_executor/types.py
+++ b/server/src/weaverbird/backends/pandas_executor/types.py
@@ -1,9 +1,10 @@
-from typing import Any, Callable, List, Optional, Protocol, Tuple
+from typing import Any, Callable, List, Optional, Protocol, Tuple, Union
 
 from pandas import DataFrame
 from pydantic import BaseModel, Field
 
 from weaverbird.pipeline import Pipeline
+from weaverbird.pipeline.steps.domain import Reference
 
 
 class StepExecutionReport(BaseModel):
@@ -16,7 +17,7 @@ class PipelineExecutionReport(BaseModel):
     steps_reports: List[StepExecutionReport] = Field(min_items=0)
 
 
-DomainRetriever = Callable[[str], DataFrame]
+DomainRetriever = Callable[[Union[str, Reference]], DataFrame]
 PipelineExecutor = Callable[[Pipeline, DomainRetriever], Tuple[DataFrame, PipelineExecutionReport]]
 
 

--- a/server/src/weaverbird/pipeline/steps/append.py
+++ b/server/src/weaverbird/pipeline/steps/append.py
@@ -5,12 +5,12 @@ from pydantic import Field
 from weaverbird.pipeline.steps.utils.base import BaseStep
 from weaverbird.pipeline.steps.utils.render_variables import StepWithVariablesMixin
 
-from .utils.combination import PipelineOrDomainName
+from .utils.combination import PipelineOrDomainNameOrReference
 
 
 class AppendStep(BaseStep):
     name = Field('append', const=True)
-    pipelines: List[PipelineOrDomainName]
+    pipelines: List[PipelineOrDomainNameOrReference]
 
 
 class AppendStepWithVariable(AppendStep, StepWithVariablesMixin):

--- a/server/src/weaverbird/pipeline/steps/domain.py
+++ b/server/src/weaverbird/pipeline/steps/domain.py
@@ -1,8 +1,15 @@
-from pydantic import Field
+from typing import Literal, Union
+
+from pydantic import BaseModel, Field
 
 from weaverbird.pipeline.steps.utils.base import BaseStep
 
 
+class Reference(BaseModel):
+    type: Literal['ref']
+    uid: str
+
+
 class DomainStep(BaseStep):
     name = Field('domain', const=True)
-    domain: str
+    domain: Union[str, Reference]

--- a/server/src/weaverbird/pipeline/steps/domain.py
+++ b/server/src/weaverbird/pipeline/steps/domain.py
@@ -1,13 +1,9 @@
-from typing import Literal, Union
+from typing import Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from weaverbird.pipeline.steps.utils.base import BaseStep
-
-
-class Reference(BaseModel):
-    type: Literal['ref']
-    uid: str
+from weaverbird.pipeline.steps.utils.combination import Reference
 
 
 class DomainStep(BaseStep):

--- a/server/src/weaverbird/pipeline/steps/join.py
+++ b/server/src/weaverbird/pipeline/steps/join.py
@@ -6,14 +6,14 @@ from weaverbird.pipeline.steps.utils.base import BaseStep
 from weaverbird.pipeline.steps.utils.render_variables import StepWithVariablesMixin
 from weaverbird.pipeline.types import ColumnName
 
-from .utils.combination import PipelineOrDomainName
+from .utils.combination import PipelineOrDomainNameOrReference
 
 JoinColumnsPair = Tuple[ColumnName, ColumnName]
 
 
 class JoinStep(BaseStep):
     name = Field('join', const=True)
-    right_pipeline: Union[PipelineOrDomainName]
+    right_pipeline: Union[PipelineOrDomainNameOrReference]
     type: Literal['left', 'inner', 'left outer']
     on: List[JoinColumnsPair] = Field(..., min_items=1)
 

--- a/server/src/weaverbird/pipeline/steps/utils/combination.py
+++ b/server/src/weaverbird/pipeline/steps/utils/combination.py
@@ -1,3 +1,12 @@
-from typing import List, Union
+from typing import List, Literal, Union
+
+from pydantic import BaseModel
+
+
+class Reference(BaseModel):
+    type: Literal['ref']
+    uid: str
+
 
 PipelineOrDomainName = Union[List[dict], str]  # can be either a domain name or a complete pipeline
+PipelineOrDomainNameOrReference = Union[PipelineOrDomainName, Reference]

--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -41,7 +41,6 @@ import FAIcon from '@/components/FAIcon.vue';
 import PipelineComponent from '@/components/Pipeline.vue';
 import { Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
 import { VQBModule } from '@/store';
-import { VQBState } from '@/store/state';
 
 import { version } from '../../package.json';
 import StepFormsComponents from './stepforms';

--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -71,7 +71,6 @@ export default class QueryBuilder extends Vue {
     initialValue: object;
   }) => void;
   @VQBModule.Mutation resetStepFormInitialValue!: () => void;
-  @VQBModule.Action setCurrentDomain!: (payload: Pick<VQBState, 'currentDomain'>) => void;
   @VQBModule.Action selectStep!: (payload: { index: number }) => void;
   @VQBModule.Mutation setPipeline!: (payload: { pipeline: Pipeline }) => void;
   @VQBModule.Getter stepErrors!: (index: number) => string | undefined;
@@ -94,19 +93,14 @@ export default class QueryBuilder extends Vue {
 
   saveStep(step: PipelineStep) {
     const newPipeline: Pipeline = [...this.pipeline];
-    // FIXME: not sure about that specific implem to handle `domain` step
     const index = step.name === 'domain' ? 0 : this.computedActiveStepIndex + 1;
     if (this.isStepCreation) {
       newPipeline.splice(index, 0, step);
     } else {
       newPipeline.splice(index, 1, step);
     }
-    if (step.name === 'domain') {
-      this.setCurrentDomain({ currentDomain: step.domain });
-    } else {
-      this.setPipeline({ pipeline: newPipeline });
-      this.selectStep({ index });
-    }
+    this.setPipeline({ pipeline: newPipeline });
+    this.selectStep({ index });
     this.closeStepForm();
     // Reset value from DataViewer
     this.resetStepFormInitialValue();

--- a/src/lib/dereference-pipeline.ts
+++ b/src/lib/dereference-pipeline.ts
@@ -1,4 +1,4 @@
-import { Pipeline, PipelineStep, Reference } from '@/lib/steps';
+import { Pipeline, PipelineStep, Reference, ReferenceToExternalQuery } from '@/lib/steps';
 
 export type PipelinesScopeContext = {
   [pipelineName: string]: Pipeline;
@@ -7,8 +7,11 @@ export type PipelinesScopeContext = {
 /**
  * Return a pipeline for the corresponding domain
  */
-function _getPipelineForDomain(reference: string, pipelines: PipelinesScopeContext): Pipeline {
-  if (Object.keys(pipelines).includes(reference)) {
+function _getPipelineForDomain(
+  reference: string | ReferenceToExternalQuery,
+  pipelines: PipelinesScopeContext,
+): Pipeline {
+  if (typeof reference === 'string' && Object.keys(pipelines).includes(reference)) {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return dereferencePipelines(pipelines[reference], pipelines);
   } else {

--- a/src/lib/dereference-pipeline.ts
+++ b/src/lib/dereference-pipeline.ts
@@ -1,4 +1,11 @@
-import { Pipeline, PipelineStep, Reference, ReferenceToExternalQuery } from '@/lib/steps';
+import {
+  isReferenceToExternalQuery,
+  isReferenceToOtherPipeline,
+  Pipeline,
+  PipelineStep,
+  Reference,
+  ReferenceToExternalQuery,
+} from '@/lib/steps';
 
 export type PipelinesScopeContext = {
   [pipelineName: string]: Pipeline;
@@ -93,7 +100,7 @@ function _getPipelineNamesReferencedBy(
   cachedResults: Map<string, Array<string>>,
 ): Array<string> {
   const referenceNames: Array<string> = [];
-  if (typeof reference === 'string') {
+  if (isReferenceToOtherPipeline(reference)) {
     // if reference is a String
     const pipelineName = reference as string;
     // we add it to the results
@@ -111,6 +118,8 @@ function _getPipelineNamesReferencedBy(
       // we retreive the result
       referenceNames.push(...cachedResults.get(pipelineName));
     }
+  } else if (isReferenceToExternalQuery(reference)) {
+    // do nothing - it should not be dereferenced by the UI
   } else {
     // if reference is a Pipeline
     const pipeline = reference as Pipeline;

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -203,7 +203,7 @@ class StepLabeller implements StepMatcher<string> {
   }
 
   domain(step: Readonly<S.DomainStep>) {
-    const sourceLabel = S.isReferenceToOtherQuery(step.domain)
+    const sourceLabel = S.isReferenceToExternalQuery(step.domain)
       ? `query ${step.domain.uid}`
       : `"${step.domain}"`;
     return `Source: ${sourceLabel}`;

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -203,7 +203,10 @@ class StepLabeller implements StepMatcher<string> {
   }
 
   domain(step: Readonly<S.DomainStep>) {
-    return `Source: "${step.domain}"`;
+    const sourceLabel = S.isReferenceToOtherQuery(step.domain)
+      ? `query ${step.domain.uid}`
+      : `"${step.domain}"`;
+    return `Source: ${sourceLabel}`;
   }
 
   duplicate(step: Readonly<S.DuplicateColumnStep>) {

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -41,16 +41,28 @@ export type DateInfo = BasicDatePart | AdvancedDateInfo;
 
 type PrimitiveType = number | boolean | string | Date;
 type Templatable<T> = T | string;
-export type Reference = Pipeline | string;
+export type ReferenceToOtherQuery = { type: 'ref'; uid: string };
+export type Reference = Pipeline | string | ReferenceToOtherQuery;
 export type TotalDimension = { totalColumn: string; totalRowsLabel: string };
 
 /**
  * Some step can contains either:
  * - a reference to the pipeline i.e. the name of the pipeline, then a string
  * - the pipeline itself
+ * - a reference to another pipeline, stored elsewhere, that should be resolved by the server
  */
 export function isReference(pipelineOrReference: Reference): pipelineOrReference is string {
   return typeof pipelineOrReference === 'string';
+}
+
+export function isReferenceToOtherQuery(
+  pipelineOrReference: Reference,
+): pipelineOrReference is ReferenceToOtherQuery {
+  return (
+    typeof pipelineOrReference === 'object' &&
+    'type' in pipelineOrReference &&
+    pipelineOrReference.type == 'ref'
+  );
 }
 
 export function isPipelineStep(step: any): step is PipelineStep {
@@ -210,7 +222,7 @@ export type StatisticsStep = {
 
 export type DomainStep = {
   name: 'domain';
-  domain: string;
+  domain: string | ReferenceToOtherQuery;
 };
 
 export type DuplicateColumnStep = {

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -41,8 +41,8 @@ export type DateInfo = BasicDatePart | AdvancedDateInfo;
 
 type PrimitiveType = number | boolean | string | Date;
 type Templatable<T> = T | string;
-export type ReferenceToOtherQuery = { type: 'ref'; uid: string };
-export type Reference = Pipeline | string | ReferenceToOtherQuery;
+export type ReferenceToExternalQuery = { type: 'ref'; uid: string };
+export type Reference = Pipeline | string | ReferenceToExternalQuery;
 export type TotalDimension = { totalColumn: string; totalRowsLabel: string };
 
 /**
@@ -51,13 +51,15 @@ export type TotalDimension = { totalColumn: string; totalRowsLabel: string };
  * - the pipeline itself
  * - a reference to another pipeline, stored elsewhere, that should be resolved by the server
  */
-export function isReference(pipelineOrReference: Reference): pipelineOrReference is string {
+export function isReferenceToOtherPipeline(
+  pipelineOrReference: Reference,
+): pipelineOrReference is string {
   return typeof pipelineOrReference === 'string';
 }
 
-export function isReferenceToOtherQuery(
+export function isReferenceToExternalQuery(
   pipelineOrReference: Reference,
-): pipelineOrReference is ReferenceToOtherQuery {
+): pipelineOrReference is ReferenceToExternalQuery {
   return (
     typeof pipelineOrReference === 'object' &&
     'type' in pipelineOrReference &&
@@ -222,7 +224,7 @@ export type StatisticsStep = {
 
 export type DomainStep = {
   name: 'domain';
-  domain: string | ReferenceToOtherQuery;
+  domain: string | ReferenceToExternalQuery;
 };
 
 export type DuplicateColumnStep = {

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -67,6 +67,15 @@ export function isReferenceToExternalQuery(
   );
 }
 
+export function isReference(
+  pipelineOrReference: Reference,
+): pipelineOrReference is string | ReferenceToExternalQuery {
+  return (
+    isReferenceToOtherPipeline(pipelineOrReference) ||
+    isReferenceToExternalQuery(pipelineOrReference)
+  );
+}
+
 export function isPipelineStep(step: any): step is PipelineStep {
   return typeof step === 'object' && 'name' in step;
 }

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -132,7 +132,7 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   append(step: Readonly<S.AppendStep>) {
     const pipelines = [];
     for (const pipeline of step.pipelines) {
-      if (S.isReference(pipeline) || S.isReferenceToOtherQuery(pipeline)) {
+      if (S.isReferenceToOtherPipeline(pipeline) || S.isReferenceToExternalQuery(pipeline)) {
         // the pipeline is referenced in: `submit` function in `src/components/stepforms/StepForm.vue`
         pipelines.push(pipeline);
       } else {
@@ -318,7 +318,7 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   }
 
   join(step: Readonly<S.JoinStep>) {
-    if (S.isReference(step.right_pipeline) || S.isReferenceToOtherQuery(step.right_pipeline)) {
+    if (S.isReferenceToOtherPipeline(step.right_pipeline) || S.isReferenceToExternalQuery(step.right_pipeline)) {
       // the pipeline is referenced in: `submit` function in `src/components/stepforms/StepForm.vue`
       return { ...step };
     } else {

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -318,7 +318,10 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   }
 
   join(step: Readonly<S.JoinStep>) {
-    if (S.isReferenceToOtherPipeline(step.right_pipeline) || S.isReferenceToExternalQuery(step.right_pipeline)) {
+    if (
+      S.isReferenceToOtherPipeline(step.right_pipeline) ||
+      S.isReferenceToExternalQuery(step.right_pipeline)
+    ) {
       // the pipeline is referenced in: `submit` function in `src/components/stepforms/StepForm.vue`
       return { ...step };
     } else {

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -132,7 +132,7 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   append(step: Readonly<S.AppendStep>) {
     const pipelines = [];
     for (const pipeline of step.pipelines) {
-      if (S.isReference(pipeline)) {
+      if (S.isReference(pipeline) || S.isReferenceToOtherQuery(pipeline)) {
         // the pipeline is referenced in: `submit` function in `src/components/stepforms/StepForm.vue`
         pipelines.push(pipeline);
       } else {
@@ -318,7 +318,7 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
   }
 
   join(step: Readonly<S.JoinStep>) {
-    if (S.isReference(step.right_pipeline)) {
+    if (S.isReference(step.right_pipeline) || S.isReferenceToOtherQuery(step.right_pipeline)) {
       // the pipeline is referenced in: `submit` function in `src/components/stepforms/StepForm.vue`
       return { ...step };
     } else {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -151,14 +151,6 @@ class Actions {
     dispatch('updateDataset');
   }
 
-  setCurrentDomain(
-    { commit, dispatch }: ActionContext<VQBState, any>,
-    payload: Pick<VQBState, 'currentDomain'>,
-  ) {
-    commit('setCurrentDomain', payload);
-    dispatch('updateDataset');
-  }
-
   setCurrentPage(
     { commit, dispatch }: ActionContext<VQBState, any>,
     { pageno }: { pageno: number },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -68,8 +68,8 @@ export function unregisterModule(rootStore: Store<any>) {
 /**
  * Vuex store factory
  * Example usage:
- * `> setupStore({domains: ['foo', 'bar'], currentDomain: 'foo'})`
- * => will create an empty state, except for `domains` and `currentDomain` fields.
+ * `> setupStore({domains: ['foo', 'bar']})`
+ * => will create an empty state, except for `domains`  field.
  *
  * @param initialState the parts of the state we want not to be empty at creation time.
  * @param plugins an optional list of store plugins (e.g. a backend database plugin)

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -42,11 +42,6 @@ type SetCurrentPipelineNameMutation = {
   payload: { name: string };
 };
 
-type SelectDomainMutation = {
-  type: 'setCurrentDomain';
-  payload: Pick<VQBState, 'currentDomain'>;
-};
-
 type SelectedStepMutation = {
   type: 'selectStep';
   payload: { index: number };
@@ -96,7 +91,6 @@ export type StateMutation =
   | PipelineMutation
   | SetCurrentPipelineNameMutation
   | SelectedColumnsMutation
-  | SelectDomainMutation
   | SelectedStepMutation
   | SetCurrentPage
   | SetPreviewSourceRowsSubset
@@ -207,9 +201,6 @@ class Mutations {
 
   setDomains(state: VQBState, { domains }: Pick<VQBState, 'domains'>) {
     state.domains = domains;
-    if (!state.currentDomain || (domains.length && !domains.includes(state.currentDomain))) {
-      state.currentDomain = domains[0];
-    }
   }
 
   @resetPagination
@@ -218,12 +209,6 @@ class Mutations {
       return;
     }
     Vue.set(state.pipelines, state.currentPipelineName, pipeline);
-    if (pipeline.length) {
-      const firstStep = pipeline[0];
-      if (firstStep.name === 'domain') {
-        state.currentDomain = firstStep.domain;
-      }
-    }
   }
 
   setPipelines(state: VQBState, { pipelines }: Pick<VQBState, 'pipelines'>) {
@@ -310,26 +295,6 @@ class Mutations {
     const lastAddedStepIndex = addIndex + steps.length - 1;
     // select last added step
     state.selectedStepIndex = lastAddedStepIndex;
-  }
-
-  /**
-   * change current selected domain and reset pipeline accordingly.
-   */
-  @resetPagination
-  setCurrentDomain(state: VQBState, { currentDomain }: Pick<VQBState, 'currentDomain'>) {
-    const pipeline = currentPipeline(state);
-    if (state.currentPipelineName === undefined || pipeline === undefined) {
-      return;
-    }
-    state.currentDomain = currentDomain;
-    if (currentDomain) {
-      const domainStep: DomainStep = { name: 'domain', domain: currentDomain };
-      if (pipeline.length) {
-        state.pipelines[state.currentPipelineName] = [domainStep, ...pipeline.slice(1)];
-      } else {
-        state.pipelines[state.currentPipelineName] = [domainStep];
-      }
-    }
   }
 
   setSelectedColumns(state: VQBState, { column }: { column: string | undefined }) {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -6,7 +6,7 @@ import Vue from 'vue';
 import { MutationTree } from 'vuex';
 
 import { BackendError, BackendWarning } from '@/lib/backend';
-import { DomainStep, Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
+import { Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
 import { setVariableDelimiters } from '@/lib/translators';
 
 import { currentPipeline, VQBState } from './state';

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -32,11 +32,6 @@ export interface VQBState {
   pagesize: number;
   backendMessages: BackendError[] | BackendWarning[];
 
-  /**
-   * FIXME should be a getter from the current pipeline
-   * the domain currently selected.
-   */
-  currentDomain?: string;
   currentPipelineName?: string;
   currentStepFormName?: PipelineStepName;
   selectedStepIndex: number; // last step currently active

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -138,6 +138,17 @@ describe('Labeller', () => {
     expect(hrl(step)).toEqual('Source: "the-domain"');
   });
 
+  it('generates label for domain steps that reference other queries', () => {
+    const step: S.DomainStep = {
+      name: 'domain',
+      domain: {
+        type: 'ref',
+        uid: 'xxx-yyy-zzz',
+      },
+    };
+    expect(hrl(step)).toEqual('Source: query xxx-yyy-zzz');
+  });
+
   it('generates label for duplicate steps', () => {
     const step: S.DuplicateColumnStep = {
       name: 'duplicate',

--- a/tests/unit/lib/dereference-pipeline.spec.ts
+++ b/tests/unit/lib/dereference-pipeline.spec.ts
@@ -229,6 +229,17 @@ describe('getPipelineNamesReferencedBy', () => {
 });
 
 describe('getPipelineNamesReferencing', () => {
+  it('should not consider external query references', () => {
+    const pipelines: PipelinesScopeContext = {
+      dataset0: [{ name: 'domain', domain: { type: 'ref', uid: 'xxx-yyy-zzz' } }],
+      dataset1: [{ name: 'domain', domain: 'dataset0' }],
+      dataset2: [{ name: 'domain', domain: { type: 'ref', uid: 'aaa-bbb-ccc' } }],
+    };
+    expect(getPipelineNamesReferencing('dataset0', pipelines)).toEqual(['dataset1']);
+    expect(getPipelineNamesReferencing('dataset1', pipelines)).toEqual([]);
+    expect(getPipelineNamesReferencing('dataset2', pipelines)).toEqual([]);
+  });
+
   it('should handle a complex pipeline (nested dataset)', () => {
     const pipelines: PipelinesScopeContext = {
       toto: [{ name: 'domain', domain: 'lutte' }],

--- a/tests/unit/query-builder.spec.ts
+++ b/tests/unit/query-builder.spec.ts
@@ -90,6 +90,7 @@ describe('Query Builder', () => {
         store = setupMockStore(
           buildStateWithOnePipeline([{ name: 'domain', domain: 'foo' }], {
             currentStepFormName: 'domain',
+            stepFormInitialValue: { name: 'domain', domain: 'foo' },
           }),
         );
         wrapper = shallowMount(QueryBuilder, {
@@ -111,14 +112,6 @@ describe('Query Builder', () => {
         expect(store.getters[VQBnamespace('pipeline')]).toEqual([
           { name: 'domain', domain: 'bar' },
         ]);
-      });
-
-      it('should compute the right currentDomain', async () => {
-        wrapper.find('domainstepform-stub').vm.$emit('formSaved', {
-          name: 'domain',
-          domain: 'bar',
-        });
-        expect(store.state.vqb.currentDomain).toEqual('bar');
       });
     });
 

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -536,70 +536,11 @@ describe('mutation tests', () => {
     });
   });
 
-  it('sets current domain on empty pipeline', () => {
-    const state = buildStateWithOnePipeline([], { currentDomain: 'foo' });
-    expect(state.currentDomain).toEqual('foo');
-    mutations.setCurrentDomain(state, { currentDomain: 'bar' });
-    expect(state.currentDomain).toEqual('bar');
-    expect(getters.pipeline(state, {}, {}, {})).toEqual([{ name: 'domain', domain: 'bar' }]);
-  });
-
-  it('sets current domain on non empty pipeline', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', toRename: [['foo', 'bar']] },
-      { name: 'rename', toRename: [['baz', 'spam']] },
-    ];
-    const state = buildState({
-      currentDomain: 'foo',
-      ...buildStateWithOnePipeline(pipeline, {
-        dataset: {
-          headers: [],
-          data: [],
-          paginationContext: { pageno: 2, pagesize: 10, totalCount: 10 },
-        },
-      }),
-    });
-    expect(state.currentDomain).toEqual('foo');
-    mutations.setCurrentDomain(state, { currentDomain: 'bar' });
-    expect(state.currentDomain).toEqual('bar');
-    expect(getters.pipeline(state, {}, {}, {})).toEqual([
-      { name: 'domain', domain: 'bar' },
-      { name: 'rename', toRename: [['foo', 'bar']] },
-      { name: 'rename', toRename: [['baz', 'spam']] },
-    ]);
-    // make sure the pagination is reset
-    expect(state.dataset.paginationContext?.pageno).toEqual(1);
-  });
-
-  it('do nothing without any current pipeline', () => {
-    const state = buildState({});
-    mutations.setCurrentDomain(state, { currentDomain: 'bar' });
-    expect(state.currentDomain).toBeUndefined();
-  });
-
   it('sets domain list', () => {
     const state = buildState({});
     expect(state.domains).toEqual([]);
     mutations.setDomains(state, { domains: ['foo', 'bar'] });
     expect(state.domains).toEqual(['foo', 'bar']);
-    expect(state.currentDomain).toEqual('foo');
-  });
-
-  it('updates current domain when inconsistent with setDomains', () => {
-    const state = buildState({ currentDomain: 'babar' });
-    expect(state.domains).toEqual([]);
-    mutations.setDomains(state, { domains: ['foo', 'bar'] });
-    expect(state.domains).toEqual(['foo', 'bar']);
-    expect(state.currentDomain).toEqual('foo');
-  });
-
-  it('leaves current domain untouched when consistent with setDomains', () => {
-    const state = buildState({ currentDomain: 'bar' });
-    expect(state.domains).toEqual([]);
-    mutations.setDomains(state, { domains: ['foo', 'bar'] });
-    expect(state.domains).toEqual(['foo', 'bar']);
-    expect(state.currentDomain).toEqual('bar');
   });
 
   it('sets currentPipelineName', () => {
@@ -643,38 +584,6 @@ describe('mutation tests', () => {
       // make sure the pagination is reset
       expect(state.dataset.paginationContext?.pageno).toEqual(1);
     });
-  });
-
-  it('should set current domain when updating pipeline with domain', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', toRename: [['foo', 'bar']] },
-    ];
-    const state = buildState(
-      buildStateWithOnePipeline([{ name: 'domain', domain: 'babar' }], {
-        currentDomain: 'babar',
-      }),
-    );
-    expect(getters.pipeline(state, {}, {}, {})).toEqual([{ name: 'domain', domain: 'babar' }]);
-    expect(state.currentDomain).toEqual('babar');
-    mutations.setPipeline(state, { pipeline });
-    expect(getters.pipeline(state, {}, {}, {})).toEqual(pipeline);
-    expect(state.currentDomain).toEqual('foo');
-  });
-
-  it('should not set current domain when updating pipeline without domain', () => {
-    const pipeline: Pipeline = [
-      { name: 'domain', domain: 'foo' },
-      { name: 'rename', toRename: [['foo', 'bar']] },
-    ];
-    const state = buildState(
-      buildStateWithOnePipeline([{ name: 'rename', toRename: [['foo', 'bar']] }], {
-        currentDomain: 'foo',
-      }),
-    );
-    mutations.setPipeline(state, { pipeline });
-    expect(getters.pipeline(state, {}, {}, {})).toEqual(pipeline);
-    expect(state.currentDomain).toEqual('foo');
   });
 
   it('sets pipelines', () => {


### PR DESCRIPTION
These references will not resolved by weaverbird, but can be used by its host to create dependencies and enable query reuse and factorization.

I've added a few layers of protections to ensure the  (front-end) mongo translator will fail if we ever try to pass references to it. These references are intended to be resolved back-end side.

I the process, I cleaned the way domain was handled in the UI store. (There is no need for it to have a special treatment anymore, and it leads to code simplification/deletion ace6347 )