### PR TITLE
fix(step): avoid display previous error when creating a new step TCTC-1343

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -8,7 +8,7 @@
         :initialStepValue="stepFormInitialValue"
         :stepFormDefaults="stepFormDefaults"
         :isStepCreation="isStepCreation"
-        :backendError="editedStepBackendError"
+        :backendError="backendError"
         @back="closeStepForm"
         @formSaved="saveStep"
       />
@@ -82,6 +82,10 @@ export default class QueryBuilder extends Vue {
 
   get formComponent() {
     return StepFormsComponents[this.currentStepFormName];
+  }
+
+  get backendError(): string | undefined {
+    return this.isStepCreation ? undefined : this.editedStepBackendError;
   }
 
   editStep(params: PipelineStep, index: number) {


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/59559689/150350602-8e90a3fb-a2b0-4bc6-834c-8a4ac221212e.gif)

After:
![after](https://user-images.githubusercontent.com/59559689/150350620-6f238536-0f01-4d56-b46c-2c249f9165d6.gif)

When we create a new step we don't entre the editStep method so we don't update backendErrorMessage display.
The only way to hide it is to base our display on if the step is a newly created one or not. So i added a computed for this case.

:information_source: Didn't find a way to test it, feel free to help me on it if you have an idea :pray: 
