### PR TITLE
fix(ui): trully load all unique column values TCTC-1688

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog (weaverbird npm package)
 
+## Unreleased
+
+### Changed
+
+- backendService: make 'executePipeline' limit & offset parameter optional
+
+### Fixed
+
+- Columns "load all values" truly load all values, it is not limited to 10K rows anymore
+
 ## [0.81.0] - 2022-01-24
 
 ### Added

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -32,8 +32,8 @@ export interface BackendService {
   executePipeline(
     pipeline: Pipeline,
     pipelines: PipelinesScopeContext,
-    limit: number,
-    offset: number,
+    limit?: number,
+    offset?: number,
     sourceRowsSubset?: number | 'unlimited',
   ): BackendResponse<DataSet>;
 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -191,8 +191,6 @@ class Actions {
     const response = await context.state.backendService.executePipeline(
       loadUniqueValuesPipeline,
       context.state.pipelines,
-      10000, // FIXME: limit is hard-coded
-      0,
     );
     if (!response.error) {
       context.commit('setDataset', {

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -995,8 +995,6 @@ describe('action tests', () => {
       expect(dummyService.executePipeline).toHaveBeenCalledWith(
         expectedPipeline,
         expect.objectContaining({ default_pipeline: pipeline }),
-        10000,
-        0,
       );
       expect(commitSpy).toHaveBeenCalledTimes(3);
       // call 1:


### PR DESCRIPTION
The "load all values" button bottom of the unique column values list was a lie, it was only loading unique values found in the first 10K rows. Some users noticed dat. Let's fix it !

![image](https://user-images.githubusercontent.com/3978482/150993984-e36a6187-792b-4c4b-8ab0-d9dcb557e171.png)
