### PR TITLE
fix: fix import path for render

### DIFF
--- a/server/src/weaverbird/backends/sql_translator/steps/append.py
+++ b/server/src/weaverbird/backends/sql_translator/steps/append.py
@@ -1,12 +1,12 @@
 from distutils import log
 
-from server.src.weaverbird.backends.sql_translator.steps.utils.query_transformation import (
-    build_selection_query,
-)
 from weaverbird.backends.sql_translator.steps.utils.combination import (
     resolve_sql_pipeline_for_combination,
 )
-from weaverbird.backends.sql_translator.steps.utils.query_transformation import build_union_query
+from weaverbird.backends.sql_translator.steps.utils.query_transformation import (
+    build_selection_query,
+    build_union_query,
+)
 from weaverbird.backends.sql_translator.types import (
     SQLDialect,
     SQLPipelineTranslator,


### PR DESCRIPTION
In render's log we have: 
```Jan 25 05:35:10 PM  ... line 3, in <module>    from server.src.weaverbird.backends.sql_translator.steps.utils.query_transformation import (ModuleNotFoundError: No module named 'server'``` 

This PR fixes that.