### PR TITLE
fix(mongo translator): do not simplify multiple "or" in a "and" conditions TCTC-1467

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog (weaverbird npm package)
 
+## Unreleased
+
+### Fixed
+
+- Mongo Translator (JS implem): properly handle `... AND (... OR ...) AND (... OR ...)` conditions
+
 ## [0.82.0] - 2022-01-25
 
 ### Changed

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -80,7 +80,7 @@ export function _simplifyAndCondition(filterAndCond: FilterComboAndMongo): Mongo
 
   for (const cond of filterAndCond.$and) {
     for (const key in cond) {
-      if (counter[key] > 1 && key !== '$or') {
+      if (counter[key] > 1) {
         andList.push({ [key]: cond[key] });
       } else {
         simplifiedBlock = { ...simplifiedBlock, [key]: cond[key] };


### PR DESCRIPTION
Fix a 3 years old but that was messing up some filtering conditions.
Something like `_1_ AND (_2_ OR _2'_) AND (_3_ OR _3'_)` was "simplified" to : 

```
{
  $match: {
    _1_,
    $or: [_3_, _3'_],
  },
},
```

instead of 

```
{
  $match: {
     _1_,
    $and: [
      { $or: [_2_, _2'_],},
      { $or: [_3_, _3'_], },
    ],
  },
},
```

I also checked the WIP Mongo Translator implem in Python and the bug does not exist there as the "and condition simplifier" have not been ported to (which is probably a good choice I guess :sweat_smile:).

Original JS : 

https://github.com/ToucanToco/weaverbird/blob/48616a39726b41b3d65e3d82396020577730b215/src/lib/translators/mongo.ts#L2072-L2076

Python version : 

https://github.com/ToucanToco/weaverbird/blob/48616a39726b41b3d65e3d82396020577730b215/server/src/weaverbird/backends/mongo_translator/steps/filter.py#L54-L58