### PR TITLE
chore: data-cy for TCTC-191

### DIFF
--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -71,7 +71,7 @@
               </td>
             </tr>
           </thead>
-          <tbody class="data-viewer__body">
+          <tbody data-cy="weaverbird-data-viewer-body" class="data-viewer__body">
             <tr
               class="data-viewer__row"
               data-cy="weaverbird-data-viewer-table-row"


### PR DESCRIPTION
Adds a data-cy attribute for an element, used in the new Cypress test TCTC-191.

No further impact.