### PR TITLE
fix(sql): inclusion condition with a single value TCTC-1605

### DIFF
--- a/server/src/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
+++ b/server/src/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
@@ -70,7 +70,8 @@ def apply_condition(condition: Condition, query: str) -> str:
             condition.value = sanitize_input(condition.value)
         query += f"{condition.column} {SQL_MATCH_OPERATORS[condition.operator]} '{condition.value}'"
     elif isinstance(condition, InclusionCondition):
-        query += f'{condition.column} {SQL_INCLUSION_OPERATORS[condition.operator]} {str(tuple(condition.value))}'
+        values_tuple_str = '(' + ', '.join([f'\'{v}\'' for v in condition.value]) + ')'
+        query += f'{condition.column} {SQL_INCLUSION_OPERATORS[condition.operator]} {values_tuple_str}'
 
     elif isinstance(condition, DateBoundCondition):
 

--- a/server/src/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
+++ b/server/src/weaverbird/backends/sql_translator/steps/utils/query_transformation.py
@@ -71,7 +71,9 @@ def apply_condition(condition: Condition, query: str) -> str:
         query += f"{condition.column} {SQL_MATCH_OPERATORS[condition.operator]} '{condition.value}'"
     elif isinstance(condition, InclusionCondition):
         values_tuple_str = '(' + ', '.join([f'\'{v}\'' for v in condition.value]) + ')'
-        query += f'{condition.column} {SQL_INCLUSION_OPERATORS[condition.operator]} {values_tuple_str}'
+        query += (
+            f'{condition.column} {SQL_INCLUSION_OPERATORS[condition.operator]} {values_tuple_str}'
+        )
 
     elif isinstance(condition, DateBoundCondition):
 

--- a/server/tests/steps/sql_translator/utils/test_query_transformation.py
+++ b/server/tests/steps/sql_translator/utils/test_query_transformation.py
@@ -176,6 +176,13 @@ def test_apply_condition_inclusion():
         )
         == "SELECT product FROM inventory WHERE origin NOT IN ('france', 'spain', 'italy')"
     )
+    assert (
+        apply_condition(
+            InclusionCondition(column='origin', operator='in', value=['france']),
+            query='SELECT product FROM inventory WHERE ',
+        )
+        == "SELECT product FROM inventory WHERE origin IN ('france')"
+    )
 
 
 def test_apply_condition_conditioncomboand():


### PR DESCRIPTION
A pipeline with a filter step using the 'in' operator but with a single value like `column='origin', operator='in', value=['france']` was translated to `WHERE origin IN ('france',)` instead of `WHERE origin IN ('france')` (notice the useless trailing comma that's invalid SQL).