### PR TITLE
fix(convert-int-to-date): enable to convert year in int to date from types menu [TCTC-1895]

### DIFF
--- a/server/src/weaverbird/backends/pandas_executor/steps/todate.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/todate.py
@@ -11,11 +11,15 @@ def execute_todate(
     execute_pipeline: PipelineExecutor = None,
 ) -> DataFrame:
     format = step.format
-    timestamp_unit = 'ms' if df[step.column].dtype == 'int64' else None
-    # By default int are understood as timestamps, we prefer to convert it to %Y format if values are < 10_000
-    if format is None and df[step.column].dtype == 'int64' and df[step.column].max() < 10_000:
-        format = '%Y'
-        timestamp_unit = None
+    timestamp_unit = None
+
+    if format is None and df[step.column].dtype == 'int64':
+        # By default int are understood as timestamps, we prefer to convert it to %Y format if values are < 10_000
+        if df[step.column].max() < 10_000:
+            format = '%Y'
+        else:
+            # Timestamps are expected in ms (not in ns, which is pandas' default)
+            timestamp_unit = 'ms'
 
     datetime_serie = to_datetime(
         df[step.column], format=format, errors='coerce', unit=timestamp_unit

--- a/server/src/weaverbird/backends/pandas_executor/steps/todate.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/todate.py
@@ -10,8 +10,14 @@ def execute_todate(
     domain_retriever: DomainRetriever = None,
     execute_pipeline: PipelineExecutor = None,
 ) -> DataFrame:
+    format = step.format
     timestamp_unit = 'ms' if df[step.column].dtype == 'int64' else None
+    # By default int are understood as timestamps, we prefer to convert it to %Y format if values are < 10_000
+    if format is None and df[step.column].dtype == 'int64' and df[step.column].max() < 10_000:
+        format = '%Y'
+        timestamp_unit = None
+
     datetime_serie = to_datetime(
-        df[step.column], format=step.format, errors='coerce', unit=timestamp_unit
+        df[step.column], format=format, errors='coerce', unit=timestamp_unit
     )
     return df.assign(**{step.column: datetime_serie})

--- a/server/tests/backends/fixtures/todate/from_integer_year.json
+++ b/server/tests/backends/fixtures/todate/from_integer_year.json
@@ -1,0 +1,48 @@
+{
+  "exclude": [
+    "snowflake",
+    "mysql",
+    "postgres",
+    "mongo"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "todate",
+        "column": "CREATED_DATE"
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "CREATED_DATE",
+          "type": "integer"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "CREATED_DATE": 2018
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "CREATED_DATE",
+          "type": "datetime"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "CREATED_DATE": "2018-01-01T00:00:00.000Z"
+      }
+    ]
+  }
+}

--- a/server/tests/steps/test_todate.py
+++ b/server/tests/steps/test_todate.py
@@ -52,6 +52,24 @@ def test_todate_automatic_guess(sample_df: DataFrame):
     )
 
 
+def test_todate_int_as_year_with_automatic_guess():
+    sample_df = DataFrame({'a_date': [2019, 2020]})
+    step = ToDateStep(name='todate', column='a_date')
+    result = execute_todate(step, sample_df)
+    assert_dataframes_equals(
+        result,
+        DataFrame(
+            {
+                'a_date': [
+                    # We force Pandas to format with %Y:
+                    Timestamp(year=2019, month=1, day=1),
+                    Timestamp(year=2020, month=1, day=1),
+                ]
+            }
+        ),
+    )
+
+
 def test_todate_from_str_timestamp():
     """
     Timestamps to date should support MilliSecond Timestamps (for consistency with Mongo Backend),

--- a/src/components/DataTypesMenu.vue
+++ b/src/components/DataTypesMenu.vue
@@ -115,17 +115,17 @@ export default class DataTypesMenu extends Vue {
   }
 
   openToDateStep() {
-    // if string, we want to open the dedicated todate step where the user can
+    // if string or int, we want to open the dedicated todate step where the user can
     // specify string formats
-    if (this.columnTypes[this.columnName] === 'string') {
+    if (
+      this.columnTypes[this.columnName] === 'string' ||
+      this.columnTypes[this.columnName] === 'integer'
+    ) {
       this.$emit('actionClicked', 'todate');
       this.close();
     }
-    // if date or integer, we can convert the column directly
-    if (
-      this.columnTypes[this.columnName] === 'date' ||
-      this.columnTypes[this.columnName] === 'integer'
-    ) {
+    // if date, we can convert the column directly
+    if (this.columnTypes[this.columnName] === 'date') {
       this.createConvertStep('date');
     }
   }

--- a/src/lib/translators/mongo4.ts
+++ b/src/lib/translators/mongo4.ts
@@ -44,6 +44,14 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
     format = format.replace('%B', '%b');
   }
 
+  const input = {
+    $cond: [
+      { $eq: [{ $type: $$(step.column) }, 'int'] },
+      { $toString: $$(step.column) },
+      $$(step.column),
+    ],
+  };
+
   const monthReplace = {
     $switch: {
       branches: [
@@ -114,13 +122,13 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
           $addFields: {
             [step.column]: {
               $dateFromString: {
-                dateString: $$(step.column),
+                dateString: input,
                 // Mongo does not support "incomplete" date string where the day or month is missing
                 // so we add the first day of the month and of the first month of the year and use the format %d/%m/%Y
                 // to enable '%Y' format to be guessed
                 onError: {
                   $dateFromString: {
-                    dateString: { $concat: ['01/01/', $$(step.column)] },
+                    dateString: { $concat: ['01/01/', input] },
                     format: '%d/%m/%Y',
                   },
                 },
@@ -131,7 +139,7 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
       ];
     case '%d %b %Y':
       return [
-        { $addFields: { _vqbTempArray: { $split: [$$(step.column), ' '] } } },
+        { $addFields: { _vqbTempArray: { $split: [input, ' '] } } },
         {
           $addFields: {
             _vqbTempDay: { $arrayElemAt: ['$_vqbTempArray', 0] },
@@ -158,7 +166,7 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
       ];
     case '%d-%b-%Y':
       return [
-        { $addFields: { _vqbTempArray: { $split: [$$(step.column), '-'] } } },
+        { $addFields: { _vqbTempArray: { $split: [input, '-'] } } },
         {
           $addFields: {
             _vqbTempDay: { $arrayElemAt: ['$_vqbTempArray', 0] },
@@ -185,7 +193,7 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
       ];
     case '%b %Y':
       return [
-        { $addFields: { _vqbTempArray: { $split: [$$(step.column), ' '] } } },
+        { $addFields: { _vqbTempArray: { $split: [input, ' '] } } },
         {
           $addFields: {
             _vqbTempMonth: { $toLower: { $arrayElemAt: ['$_vqbTempArray', 0] } },
@@ -209,7 +217,7 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
       ];
     case '%b-%Y':
       return [
-        { $addFields: { _vqbTempArray: { $split: [$$(step.column), '-'] } } },
+        { $addFields: { _vqbTempArray: { $split: [input, '-'] } } },
         {
           $addFields: {
             _vqbTempMonth: { $toLower: { $arrayElemAt: ['$_vqbTempArray', 0] } },
@@ -235,7 +243,7 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
       // Mongo does not support "incomplete" date string where the day is missing
       // so we add the first day of the month and use the format %Y-%m-%d instead
       return [
-        { $addFields: { _vqbTempDate: { $concat: [$$(step.column), '-01'] } } },
+        { $addFields: { _vqbTempDate: { $concat: [input, '-01'] } } },
         {
           $addFields: {
             [step.column]: { $dateFromString: { dateString: '$_vqbTempDate', format: '%Y-%m-%d' } },
@@ -247,7 +255,7 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
       // Mongo does not support "incomplete" date string where the day is missing
       // so we add the first day of the month and use the format %Y/%m/%d instead
       return [
-        { $addFields: { _vqbTempDate: { $concat: [$$(step.column), '/01'] } } },
+        { $addFields: { _vqbTempDate: { $concat: [input, '/01'] } } },
         {
           $addFields: {
             [step.column]: { $dateFromString: { dateString: '$_vqbTempDate', format: '%Y/%m/%d' } },
@@ -259,7 +267,7 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
       // Mongo does not support "incomplete" date string where the day is missing
       // so we add the first day of the month and use the format %d-%m-%Y instead
       return [
-        { $addFields: { _vqbTempDate: { $concat: ['01-', $$(step.column)] } } },
+        { $addFields: { _vqbTempDate: { $concat: ['01-', input] } } },
         {
           $addFields: {
             [step.column]: { $dateFromString: { dateString: '$_vqbTempDate', format: '%d-%m-%Y' } },
@@ -271,7 +279,7 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
       // Mongo does not support "incomplete" date string where the day is missing
       // so we add the first day of the month and use the format %d/%m/%Y instead
       return [
-        { $addFields: { _vqbTempDate: { $concat: ['01/', $$(step.column)] } } },
+        { $addFields: { _vqbTempDate: { $concat: ['01/', input] } } },
         {
           $addFields: {
             [step.column]: { $dateFromString: { dateString: '$_vqbTempDate', format: '%d/%m/%Y' } },
@@ -283,7 +291,7 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
       // Mongo does not support "incomplete" date string where the day or month is missing
       // so we add the first day of the month and of the first month of the year and use the format %d/%m/%Y
       return [
-        { $addFields: { _vqbTempDate: { $concat: ['01/01/', $$(step.column)] } } },
+        { $addFields: { _vqbTempDate: { $concat: ['01/01/', input] } } },
         {
           $addFields: {
             [step.column]: { $dateFromString: { dateString: '$_vqbTempDate', format: '%d/%m/%Y' } },
@@ -296,7 +304,7 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
         {
           $addFields: {
             [step.column]: {
-              $dateFromString: { dateString: $$(step.column), format: step.format },
+              $dateFromString: { dateString: input, format: step.format },
             },
           },
         },

--- a/src/lib/translators/mongo4.ts
+++ b/src/lib/translators/mongo4.ts
@@ -46,7 +46,9 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
 
   const input = {
     $cond: [
-      { $eq: [{ $type: $$(step.column) }, 'int'] },
+      {
+        $and: [{ $eq: [{ $type: $$(step.column) }, 'int'] }, { $lt: [$$(step.column), 10_000] }],
+      },
       { $toString: $$(step.column) },
       $$(step.column),
     ],

--- a/tests/unit/data-types-menu.spec.ts
+++ b/tests/unit/data-types-menu.spec.ts
@@ -214,8 +214,8 @@ describe('Data Types Menu', () => {
     expect(createConvertStepStub).toBeCalledWith('date');
   });
 
-  it('should call createConvertStep when clicking on "date" on a integer column', async () => {
-    const createConvertStepStub = jest.fn();
+  it('should emit "closed" and actionClicked" with "todate" as payload when clicking \
+  on "date" on an integer column', () => {
     const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA', type: 'integer' }],
@@ -226,11 +226,11 @@ describe('Data Types Menu', () => {
       localVue,
       propsData: { columnName: 'columnA' },
     });
-    wrapper.setMethods({ createConvertStep: createConvertStepStub });
-    const actionsWrapper = wrapper.findAll('.data-types-menu__option--active');
-    actionsWrapper.at(3).trigger('click');
-    await localVue.nextTick();
-    expect(createConvertStepStub).toBeCalledWith('date');
+    const options = wrapper.findAll('.data-types-menu__option--active');
+    options.at(3).trigger('click');
+    expect(wrapper.emitted().closed).toBeTruthy();
+    expect(wrapper.emitted().actionClicked).toBeTruthy();
+    expect(wrapper.emitted().actionClicked[0][0]).toEqual('todate');
   });
 
   it('should not call createConvertStep when clicking on "date" on a float column', async () => {

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -2493,7 +2493,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
             foo: {
               $dateFromString: {
                 dateString: {
-                  $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  $cond: [
+                    {
+                      $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                    },
+                    { $toString: '$foo' },
+                    '$foo',
+                  ],
                 },
                 // enable '%Y' format to be guessed
                 onError: {
@@ -2503,7 +2509,12 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                         '01/01/',
                         {
                           $cond: [
-                            { $eq: [{ $type: '$foo' }, 'int'] },
+                            {
+                              $and: [
+                                { $eq: [{ $type: '$foo' }, 'int'] },
+                                { $lt: ['$foo', 10_000] },
+                              ],
+                            },
                             { $toString: '$foo' },
                             '$foo',
                           ],
@@ -6213,7 +6224,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
               foo: {
                 $dateFromString: {
                   dateString: {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                   // enable '%Y' format to be guessed
                   onError: {
@@ -6223,7 +6240,12 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                           '01/01/',
                           {
                             $cond: [
-                              { $eq: [{ $type: '$foo' }, 'int'] },
+                              {
+                                $and: [
+                                  { $eq: [{ $type: '$foo' }, 'int'] },
+                                  { $lt: ['$foo', 10_000] },
+                                ],
+                              },
                               { $toString: '$foo' },
                               '$foo',
                             ],
@@ -6256,7 +6278,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
               foo: {
                 $dateFromString: {
                   dateString: {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                   format: '%Y-%m-%d',
                 },
@@ -6282,7 +6310,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
               _vqbTempArray: {
                 $split: [
                   {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                   ' ',
                 ],
@@ -6338,7 +6372,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
               _vqbTempArray: {
                 $split: [
                   {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                   '-',
                 ],
@@ -6394,7 +6434,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
               _vqbTempArray: {
                 $split: [
                   {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                   ' ',
                 ],
@@ -6450,7 +6496,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
               _vqbTempArray: {
                 $split: [
                   {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                   ' ',
                 ],
@@ -6497,7 +6549,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
               _vqbTempArray: {
                 $split: [
                   {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                   '-',
                 ],
@@ -6544,7 +6602,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
               _vqbTempArray: {
                 $split: [
                   {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                   ' ',
                 ],
@@ -6591,7 +6655,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
               _vqbTempDate: {
                 $concat: [
                   {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                   '-01',
                 ],
@@ -6622,7 +6692,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
               _vqbTempDate: {
                 $concat: [
                   {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                   '/01',
                 ],
@@ -6654,7 +6730,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                 $concat: [
                   '01-',
                   {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                 ],
               },
@@ -6685,7 +6767,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                 $concat: [
                   '01/',
                   {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                 ],
               },
@@ -6716,7 +6804,13 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                 $concat: [
                   '01/01/',
                   {
-                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                    $cond: [
+                      {
+                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      },
+                      { $toString: '$foo' },
+                      '$foo',
+                    ],
                   },
                 ],
               },

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -2492,12 +2492,23 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
           $addFields: {
             foo: {
               $dateFromString: {
-                dateString: '$foo',
+                dateString: {
+                  $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                },
                 // enable '%Y' format to be guessed
                 onError: {
                   $dateFromString: {
                     dateString: {
-                      $concat: ['01/01/', '$foo'],
+                      $concat: [
+                        '01/01/',
+                        {
+                          $cond: [
+                            { $eq: [{ $type: '$foo' }, 'int'] },
+                            { $toString: '$foo' },
+                            '$foo',
+                          ],
+                        },
+                      ],
                     },
                     format: '%d/%m/%Y',
                   },
@@ -6201,12 +6212,23 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
             $addFields: {
               foo: {
                 $dateFromString: {
-                  dateString: '$foo',
+                  dateString: {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
                   // enable '%Y' format to be guessed
                   onError: {
                     $dateFromString: {
                       dateString: {
-                        $concat: ['01/01/', '$foo'],
+                        $concat: [
+                          '01/01/',
+                          {
+                            $cond: [
+                              { $eq: [{ $type: '$foo' }, 'int'] },
+                              { $toString: '$foo' },
+                              '$foo',
+                            ],
+                          },
+                        ],
                       },
                       format: '%d/%m/%Y',
                     },
@@ -6229,7 +6251,18 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
         ];
         const querySteps = translator.translate(pipeline);
         expect(querySteps).toEqual([
-          { $addFields: { foo: { $dateFromString: { dateString: '$foo', format: '%Y-%m-%d' } } } },
+          {
+            $addFields: {
+              foo: {
+                $dateFromString: {
+                  dateString: {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
+                  format: '%Y-%m-%d',
+                },
+              },
+            },
+          },
           { $project: { _id: 0 } },
         ]);
       });
@@ -6244,7 +6277,18 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
         ];
         const querySteps = translator.translate(pipeline);
         expect(querySteps).toEqual([
-          { $addFields: { _vqbTempArray: { $split: ['$foo', ' '] } } },
+          {
+            $addFields: {
+              _vqbTempArray: {
+                $split: [
+                  {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
+                  ' ',
+                ],
+              },
+            },
+          },
           {
             $addFields: {
               _vqbTempDay: { $arrayElemAt: ['$_vqbTempArray', 0] },
@@ -6289,7 +6333,18 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
         ];
         const querySteps = translator.translate(pipeline);
         expect(querySteps).toEqual([
-          { $addFields: { _vqbTempArray: { $split: ['$foo', '-'] } } },
+          {
+            $addFields: {
+              _vqbTempArray: {
+                $split: [
+                  {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
+                  '-',
+                ],
+              },
+            },
+          },
           {
             $addFields: {
               _vqbTempDay: { $arrayElemAt: ['$_vqbTempArray', 0] },
@@ -6334,7 +6389,18 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
         ];
         const querySteps = translator.translate(pipeline);
         expect(querySteps).toEqual([
-          { $addFields: { _vqbTempArray: { $split: ['$foo', ' '] } } },
+          {
+            $addFields: {
+              _vqbTempArray: {
+                $split: [
+                  {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
+                  ' ',
+                ],
+              },
+            },
+          },
           {
             $addFields: {
               _vqbTempDay: { $arrayElemAt: ['$_vqbTempArray', 0] },
@@ -6379,7 +6445,18 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
         ];
         const querySteps = translator.translate(pipeline);
         expect(querySteps).toEqual([
-          { $addFields: { _vqbTempArray: { $split: ['$foo', ' '] } } },
+          {
+            $addFields: {
+              _vqbTempArray: {
+                $split: [
+                  {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
+                  ' ',
+                ],
+              },
+            },
+          },
           {
             $addFields: {
               _vqbTempMonth: { $toLower: { $arrayElemAt: ['$_vqbTempArray', 0] } },
@@ -6415,7 +6492,18 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
         ];
         const querySteps = translator.translate(pipeline);
         expect(querySteps).toEqual([
-          { $addFields: { _vqbTempArray: { $split: ['$foo', '-'] } } },
+          {
+            $addFields: {
+              _vqbTempArray: {
+                $split: [
+                  {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
+                  '-',
+                ],
+              },
+            },
+          },
           {
             $addFields: {
               _vqbTempMonth: { $toLower: { $arrayElemAt: ['$_vqbTempArray', 0] } },
@@ -6451,7 +6539,18 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
         ];
         const querySteps = translator.translate(pipeline);
         expect(querySteps).toEqual([
-          { $addFields: { _vqbTempArray: { $split: ['$foo', ' '] } } },
+          {
+            $addFields: {
+              _vqbTempArray: {
+                $split: [
+                  {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
+                  ' ',
+                ],
+              },
+            },
+          },
           {
             $addFields: {
               _vqbTempMonth: { $toLower: { $arrayElemAt: ['$_vqbTempArray', 0] } },
@@ -6487,7 +6586,18 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
         ];
         const querySteps = translator.translate(pipeline);
         expect(querySteps).toEqual([
-          { $addFields: { _vqbTempDate: { $concat: ['$foo', '-01'] } } },
+          {
+            $addFields: {
+              _vqbTempDate: {
+                $concat: [
+                  {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
+                  '-01',
+                ],
+              },
+            },
+          },
           {
             $addFields: {
               foo: { $dateFromString: { dateString: '$_vqbTempDate', format: '%Y-%m-%d' } },
@@ -6507,7 +6617,18 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
         ];
         const querySteps = translator.translate(pipeline);
         expect(querySteps).toEqual([
-          { $addFields: { _vqbTempDate: { $concat: ['$foo', '/01'] } } },
+          {
+            $addFields: {
+              _vqbTempDate: {
+                $concat: [
+                  {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
+                  '/01',
+                ],
+              },
+            },
+          },
           {
             $addFields: {
               foo: { $dateFromString: { dateString: '$_vqbTempDate', format: '%Y/%m/%d' } },
@@ -6527,7 +6648,18 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
         ];
         const querySteps = translator.translate(pipeline);
         expect(querySteps).toEqual([
-          { $addFields: { _vqbTempDate: { $concat: ['01-', '$foo'] } } },
+          {
+            $addFields: {
+              _vqbTempDate: {
+                $concat: [
+                  '01-',
+                  {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
+                ],
+              },
+            },
+          },
           {
             $addFields: {
               foo: { $dateFromString: { dateString: '$_vqbTempDate', format: '%d-%m-%Y' } },
@@ -6547,7 +6679,18 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
         ];
         const querySteps = translator.translate(pipeline);
         expect(querySteps).toEqual([
-          { $addFields: { _vqbTempDate: { $concat: ['01/', '$foo'] } } },
+          {
+            $addFields: {
+              _vqbTempDate: {
+                $concat: [
+                  '01/',
+                  {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
+                ],
+              },
+            },
+          },
           {
             $addFields: {
               foo: { $dateFromString: { dateString: '$_vqbTempDate', format: '%d/%m/%Y' } },
@@ -6567,7 +6710,18 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
         ];
         const querySteps = translator.translate(pipeline);
         expect(querySteps).toEqual([
-          { $addFields: { _vqbTempDate: { $concat: ['01/01/', '$foo'] } } },
+          {
+            $addFields: {
+              _vqbTempDate: {
+                $concat: [
+                  '01/01/',
+                  {
+                    $cond: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $toString: '$foo' }, '$foo'],
+                  },
+                ],
+              },
+            },
+          },
           {
             $addFields: {
               foo: { $dateFromString: { dateString: '$_vqbTempDate', format: '%d/%m/%Y' } },


### PR DESCRIPTION
Avoid to have error when trying to convert a year in int to a date.

Before:
We convert to date using convert step it results to an error because translators are not abled to transform a int to a date (it think that it is a timestamp)
![before](https://user-images.githubusercontent.com/59559689/158628548-b812d8e6-6981-4370-927f-cc442fc966b7.gif)

After:
We convert to date using to date step (same behaviour than for str columns conversion). We add an automatic str conversion in pandas and mongo translator to transform int year to str before casting to date
![after](https://user-images.githubusercontent.com/59559689/158628581-d8b5e243-58ad-4e5b-a3dd-ce3e26e71dee.gif)

