### PR TITLE
fix(mongo): support years as strings in python implem TCTC-1831

### DIFF
--- a/server/src/weaverbird/backends/mongo_translator/steps/todate.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/todate.py
@@ -25,7 +25,7 @@ def translate_todate(step: ToDateStep) -> List[MongoStep]:
                             'onError': {
                                 '$cond': [
                                     # Integer values may be either years or timestamps
-                                    {'$eq': [{'$type': f'${step.column}'}, 'int']},
+                                    {'$in': [{'$type': f'${step.column}'}, ['int', 'long']]},
                                     {
                                         '$cond': [
                                             # We decide that values lower than 10_000 will be interpreted as years...

--- a/server/src/weaverbird/backends/mongo_translator/steps/todate.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/todate.py
@@ -151,15 +151,7 @@ def translate_todate(step: ToDateStep) -> List[MongoStep]:
 
     elif date_format == '%Y':
         return [
-            {'$addFields': {'_vqbTempDate': {'$concat': [col_as_string, '-01-01']}}},
-            {
-                '$addFields': {
-                    step.column: {
-                        '$dateFromString': {'dateString': '$_vqbTempDate', 'format': '%Y-%m-%d'}
-                    },
-                },
-            },
-            _clean_temp_fields(),
+            _concat_fields_to_date(step.column, [col_as_string, '-01-01'], '%Y-%m-%d'),
         ]
 
     else:

--- a/server/src/weaverbird/backends/mongo_translator/steps/todate.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/todate.py
@@ -36,6 +36,7 @@ def translate_todate(step: ToDateStep) -> List[MongoStep]:
                                                         '$concat': [col_as_string, '-01-01']
                                                     },
                                                     'format': '%Y-%m-%d',
+                                                    'onError': {'$literal': None},
                                                 }
                                             },
                                             # ...and greater values will be interpreted as timestamps
@@ -48,8 +49,15 @@ def translate_todate(step: ToDateStep) -> List[MongoStep]:
                                             },
                                         ]
                                     },
-                                    # otherwise, we have no idea what date it corresponds to
-                                    {'$literal': None},
+                                    # otherwise, try to interpret as years
+                                    {
+                                        '$dateFromString': {
+                                            'dateString': {'$concat': [col_as_string, '-01-01']},
+                                            'format': '%Y-%m-%d',
+                                            # and give up if it doesn't work
+                                            'onError': {'$literal': None},
+                                        }
+                                    },
                                 ]
                             },
                         }

--- a/server/tests/backends/fixtures/todate/str_as_year_with_automatic_guess.json
+++ b/server/tests/backends/fixtures/todate/str_as_year_with_automatic_guess.json
@@ -1,0 +1,54 @@
+{
+  "exclude": [
+    "snowflake",
+    "mysql",
+    "pandas",
+    "postgres"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "todate",
+        "column": "a_date"
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "a_date",
+          "type": "string"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "a_date": 2019
+      },
+      {
+        "a_date": 2020
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "a_date",
+          "type": "datetime"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "a_date": "2019-01-01T00:00:00.000Z"
+      },
+      {
+        "a_date": "2020-01-01T00:00:00.000Z"
+      }
+    ]
+  }
+}

--- a/src/lib/translators/mongo4.ts
+++ b/src/lib/translators/mongo4.ts
@@ -47,7 +47,10 @@ function transformToDate(step: Readonly<ToDateStep>): MongoStep[] {
   const input = {
     $cond: [
       {
-        $and: [{ $eq: [{ $type: $$(step.column) }, 'int'] }, { $lt: [$$(step.column), 10_000] }],
+        $and: [
+          { $in: [{ $type: $$(step.column) }, ['int', 'long']] },
+          { $lt: [$$(step.column), 10_000] },
+        ],
       },
       { $toString: $$(step.column) },
       $$(step.column),

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -2495,7 +2495,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                 dateString: {
                   $cond: [
                     {
-                      $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                      $and: [
+                        { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                        { $lt: ['$foo', 10_000] },
+                      ],
                     },
                     { $toString: '$foo' },
                     '$foo',
@@ -2511,7 +2514,7 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                           $cond: [
                             {
                               $and: [
-                                { $eq: [{ $type: '$foo' }, 'int'] },
+                                { $in: [{ $type: '$foo' }, ['int', 'long']] },
                                 { $lt: ['$foo', 10_000] },
                               ],
                             },
@@ -6226,7 +6229,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   dateString: {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',
@@ -6242,7 +6248,7 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                             $cond: [
                               {
                                 $and: [
-                                  { $eq: [{ $type: '$foo' }, 'int'] },
+                                  { $in: [{ $type: '$foo' }, ['int', 'long']] },
                                   { $lt: ['$foo', 10_000] },
                                 ],
                               },
@@ -6280,7 +6286,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   dateString: {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',
@@ -6312,7 +6321,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',
@@ -6374,7 +6386,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',
@@ -6436,7 +6451,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',
@@ -6498,7 +6516,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',
@@ -6551,7 +6572,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',
@@ -6604,7 +6628,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',
@@ -6657,7 +6684,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',
@@ -6694,7 +6724,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',
@@ -6732,7 +6765,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',
@@ -6769,7 +6805,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',
@@ -6806,7 +6845,10 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
                   {
                     $cond: [
                       {
-                        $and: [{ $eq: [{ $type: '$foo' }, 'int'] }, { $lt: ['$foo', 10_000] }],
+                        $and: [
+                          { $in: [{ $type: '$foo' }, ['int', 'long']] },
+                          { $lt: ['$foo', 10_000] },
+                        ],
                       },
                       { $toString: '$foo' },
                       '$foo',


### PR DESCRIPTION
This was working with the TypeScript implementation, so I added a test case and supported it in python one.

Also include a small fix to handle cases where years are in type "long" and not "int"