### PR TITLE
feat(mongo_translator): Implemented concatenate step

### DIFF
--- a/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
@@ -4,6 +4,7 @@ from weaverbird.backends.mongo_translator.steps.aggregate import translate_aggre
 from weaverbird.backends.mongo_translator.steps.append import translate_append
 from weaverbird.backends.mongo_translator.steps.argmax import translate_argmax
 from weaverbird.backends.mongo_translator.steps.argmin import translate_argmin
+from weaverbird.backends.mongo_translator.steps.concatenate import translate_concatenate
 from weaverbird.backends.mongo_translator.steps.domain import translate_domain
 from weaverbird.backends.mongo_translator.steps.filter import translate_filter
 from weaverbird.backends.mongo_translator.steps.formula import translate_formula
@@ -22,6 +23,7 @@ mongo_step_translator: Dict[str, Callable[[Any], list]] = {
     'append': translate_append,
     'argmax': translate_argmax,
     'argmin': translate_argmin,
+    'concatenate': translate_concatenate,
     'domain': translate_domain,
     'filter': translate_filter,
     'formula': translate_formula,

--- a/server/src/weaverbird/backends/mongo_translator/steps/concatenate.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/concatenate.py
@@ -1,0 +1,19 @@
+from typing import Dict, List, Union
+
+from weaverbird.backends.mongo_translator.steps.types import MongoStep
+from weaverbird.pipeline.steps import ConcatenateStep
+
+
+def _convert_to_type(input: Union[str, dict], type_: str) -> Dict[str, Union[str, dict]]:
+    return {'$convert': {'input': input, 'to': type_}}
+
+
+def translate_concatenate(step: ConcatenateStep) -> List[MongoStep]:
+    # NOTE: Translated from "../src/lib/translators/mongo.ts"'s
+    # concatenate() step. The difference is that we're using mongo's
+    # $convert operator here, which requires mongo>=4.0
+    concat_block: List[Union[dict, str]] = [_convert_to_type(f'${step.columns[0]}', 'string')]
+    for col in step.columns[1:]:
+        concat_block += [step.separator, _convert_to_type(f'${col}', 'string')]
+
+    return [{'$addFields': {step.new_column_name: {'$concat': concat_block}}}]

--- a/server/tests/backends/fixtures/concatenate/simple.json
+++ b/server/tests/backends/fixtures/concatenate/simple.json
@@ -1,7 +1,6 @@
 {
   "exclude": [
-    "mysql",
-    "mongo"
+    "mysql"
   ],
   "step": {
     "pipeline": [


### PR DESCRIPTION
Translates the `concatenate` step from `../src/lib/translators/mongo.ts`. 

NOTE: The `$convert` operator is used here, which makes us dependent on mongo>=4.0