### PR TITLE
feat(mongo_translator): Implemented convert step [TCTC-1832]

### DIFF
--- a/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
@@ -5,6 +5,7 @@ from weaverbird.backends.mongo_translator.steps.append import translate_append
 from weaverbird.backends.mongo_translator.steps.argmax import translate_argmax
 from weaverbird.backends.mongo_translator.steps.argmin import translate_argmin
 from weaverbird.backends.mongo_translator.steps.concatenate import translate_concatenate
+from weaverbird.backends.mongo_translator.steps.convert import translate_convert
 from weaverbird.backends.mongo_translator.steps.domain import translate_domain
 from weaverbird.backends.mongo_translator.steps.filter import translate_filter
 from weaverbird.backends.mongo_translator.steps.formula import translate_formula
@@ -26,6 +27,7 @@ mongo_step_translator: Dict[str, Callable[[Any], list]] = {
     'argmax': translate_argmax,
     'argmin': translate_argmin,
     'concatenate': translate_concatenate,
+    'convert': translate_convert,
     'domain': translate_domain,
     'filter': translate_filter,
     'formula': translate_formula,

--- a/server/src/weaverbird/backends/mongo_translator/steps/convert.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/convert.py
@@ -1,0 +1,34 @@
+from typing import List, Union
+
+from weaverbird.backends.mongo_translator.steps.types import MongoStep
+from weaverbird.pipeline.steps import ConvertStep
+
+TYPE_MAP = {
+    'boolean': 'bool',
+    'date': 'date',
+    'float': 'double',
+    'integer': 'long',  # better to cast into 64-bit integers. 32-bit integers ('int') cannot be casted to dates
+    'text': 'string',
+}
+
+
+def translate_convert(step: ConvertStep) -> List[MongoStep]:
+    mongo_add_fields = {}
+    mongo_type = TYPE_MAP[step.data_type] if step.data_type in TYPE_MAP else ''
+    for column in step.columns:
+        # Mongo cannot cast integers into date but only long into date, so we
+        # manage the cast from int to long when needed.
+        _input: Union[dict, str]
+        if mongo_type == 'date':
+            _input = {
+                '$cond': [
+                    {'$eq': [{'$type': f'${column}'}, 'int']},
+                    {'$toLong': f'${column}'},
+                    f'${column}',
+                ]
+            }
+        else:
+            _input = f'${column}'
+        mongo_add_fields[column] = {'$convert': {'input': _input, 'to': mongo_type}}
+
+    return [{'$addFields': mongo_add_fields}]

--- a/server/src/weaverbird/backends/mongo_translator/steps/convert.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/convert.py
@@ -13,6 +13,9 @@ TYPE_MAP = {
 
 
 def translate_convert(step: ConvertStep) -> List[MongoStep]:
+    # /!\ we want to get the same results than with the mongo typescript
+    # translator, not than with the pandas executor.
+
     mongo_add_fields = {}
     mongo_type = TYPE_MAP[step.data_type] if step.data_type in TYPE_MAP else ''
     for column in step.columns:
@@ -29,6 +32,12 @@ def translate_convert(step: ConvertStep) -> List[MongoStep]:
             }
         else:
             _input = f'${column}'
-        mongo_add_fields[column] = {'$convert': {'input': _input, 'to': mongo_type}}
+        mongo_add_fields[column] = {
+            '$convert': {
+                'input': _input,
+                'to': mongo_type,
+                'onError': None,  # failed conversions result in null instead of crashing
+            }
+        }
 
     return [{'$addFields': mongo_add_fields}]

--- a/server/tests/backends/fixtures/convert/snowflake.json
+++ b/server/tests/backends/fixtures/convert/snowflake.json
@@ -2,8 +2,7 @@
   "exclude": [
     "pandas",
     "mysql",
-    "postgres",
-    "mongo"
+    "postgres"
   ],
   "step": {
     "name": "convert",

--- a/server/tests/backends/fixtures/convert/to_bool.json
+++ b/server/tests/backends/fixtures/convert/to_bool.json
@@ -1,8 +1,7 @@
 {
   "exclude": [
     "snowflake",
-    "mysql",
-    "mongo"
+    "mysql"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/convert/to_bool.json
+++ b/server/tests/backends/fixtures/convert/to_bool.json
@@ -74,6 +74,37 @@
       }
     ]
   },
+  "expected_mongo": {
+    "schema": {
+      "fields": [
+        {
+          "name": "value",
+          "type": "boolean"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "value": true
+      },
+      {
+        "value": false
+      },
+      {
+        "value": false
+      },
+      {
+        "value": true
+      },
+      {
+        "value": true
+      },
+      {
+        "value": true
+      }
+    ]
+  },
   "expected_postgres": {
     "schema": {
       "fields": [

--- a/server/tests/backends/fixtures/convert/to_datetime.json
+++ b/server/tests/backends/fixtures/convert/to_datetime.json
@@ -70,5 +70,33 @@
         "value": null
       }
     ]
+  },
+  "expected_mongo": {
+    "schema": {
+      "fields": [
+        {
+          "name": "value",
+          "type": "datetime"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "value": null
+      },
+      {
+        "value": "2020-11-02T00:00:00.000Z"
+      },
+      {
+        "value": "2020-11-02T00:00:00.000Z"
+      },
+      {
+        "value": "2020-11-02T15:30:00.000Z"
+      },
+      {
+        "value": null
+      }
+    ]
   }
 }

--- a/server/tests/backends/fixtures/convert/to_datetime.json
+++ b/server/tests/backends/fixtures/convert/to_datetime.json
@@ -2,8 +2,7 @@
   "exclude": [
     "snowflake",
     "mysql",
-    "postgres",
-    "mongo"
+    "postgres"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/convert/to_datetime_from_timestamp.json
+++ b/server/tests/backends/fixtures/convert/to_datetime_from_timestamp.json
@@ -2,8 +2,7 @@
   "exclude": [
     "snowflake",
     "mysql",
-    "postgres",
-    "mongo"
+    "postgres"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/convert/to_float.json
+++ b/server/tests/backends/fixtures/convert/to_float.json
@@ -2,8 +2,7 @@
   "exclude": [
     "snowflake",
     "mysql",
-    "postgres",
-    "mongo"
+    "postgres"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/convert/to_integer.json
+++ b/server/tests/backends/fixtures/convert/to_integer.json
@@ -1,8 +1,7 @@
 {
   "exclude": [
     "snowflake",
-    "mysql",
-    "mongo"
+    "mysql"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/convert/to_integer.json
+++ b/server/tests/backends/fixtures/convert/to_integer.json
@@ -45,6 +45,37 @@
       }
     ]
   },
+  "expected_mongo": {
+    "schema": {
+      "fields": [
+        {
+          "name": "value",
+          "type": "number"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "value": 41
+      },
+      {
+        "value": 42
+      },
+      {
+        "value": 43
+      },
+      {
+        "value": null
+      },
+      {
+        "value": null
+      },
+      {
+        "value": null
+      }
+    ]
+  },
   "expected": {
     "schema": {
       "fields": [

--- a/server/tests/backends/fixtures/convert/to_integer_from_datetime.json
+++ b/server/tests/backends/fixtures/convert/to_integer_from_datetime.json
@@ -1,8 +1,7 @@
 {
   "exclude": [
     "mysql",
-    "postgres",
-    "mongo"
+    "postgres"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/convert/to_integer_only_floats.json
+++ b/server/tests/backends/fixtures/convert/to_integer_only_floats.json
@@ -1,8 +1,7 @@
 {
   "exclude": [
     "mysql",
-    "postgres",
-    "mongo"
+    "postgres"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/convert/to_integer_only_strings.json
+++ b/server/tests/backends/fixtures/convert/to_integer_only_strings.json
@@ -44,6 +44,37 @@
       }
     ]
   },
+  "expected_mongo": {
+    "schema": {
+      "fields": [
+        {
+          "name": "VALUE",
+          "type": "number"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "VALUE": null
+      },
+      {
+        "VALUE": null
+      },
+      {
+        "VALUE": null
+      },
+      {
+        "VALUE": null
+      },
+      {
+        "VALUE": null
+      },
+      {
+        "VALUE": null
+      }
+    ]
+  },
   "expected": {
     "schema": {
       "fields": [

--- a/server/tests/backends/fixtures/convert/to_integer_only_strings.json
+++ b/server/tests/backends/fixtures/convert/to_integer_only_strings.json
@@ -1,7 +1,6 @@
 {
   "exclude": [
-    "mysql",
-    "mongo"
+    "mysql"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/convert/to_text.json
+++ b/server/tests/backends/fixtures/convert/to_text.json
@@ -1,8 +1,7 @@
 {
   "exclude": [
     "snowflake",
-    "mysql",
-    "mongo"
+    "mysql"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/convert/to_text.json
+++ b/server/tests/backends/fixtures/convert/to_text.json
@@ -76,6 +76,37 @@
       }
     ]
   },
+  "expected_mongo": {
+    "schema": {
+      "fields": [
+        {
+          "name": "value",
+          "type": "string"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "value": "41"
+      },
+      {
+        "value": "42"
+      },
+      {
+        "value": "43.5"
+      },
+      {
+        "value": "43.6"
+      },
+      {
+        "value": "NaN"
+      },
+      {
+        "value": "meh"
+      }
+    ]
+  },
   "expected_postgres": {
     "schema": {
       "fields": [

--- a/server/tests/backends/mongo_translator/test_mongo_translator_steps.py
+++ b/server/tests/backends/mongo_translator/test_mongo_translator_steps.py
@@ -11,7 +11,8 @@ from tests.utils import assert_dataframes_content_equals, get_spec_from_json_fix
 from weaverbird.backends.mongo_translator.mongo_pipeline_translator import translate_pipeline
 from weaverbird.pipeline import Pipeline
 
-test_cases = retrieve_case('mongo_translator', 'mongo')
+exec_type = 'mongo'
+test_cases = retrieve_case('mongo_translator', exec_type)
 
 
 def unused_port():

--- a/server/tests/backends/mongo_translator/test_mongo_translator_steps.py
+++ b/server/tests/backends/mongo_translator/test_mongo_translator_steps.py
@@ -69,5 +69,11 @@ def test_mongo_translator_pipeline(mongo_database, case_id, case_spec_file_path)
     df = pd.DataFrame(result)
     if '_id' in df:
         df.drop('_id', axis=1, inplace=True)
-    expected_df = pd.read_json(json.dumps(spec['expected']), orient='table')
+    expected_df = pd.read_json(
+        json.dumps(
+            spec[f'expected_{exec_type}' if f'expected_{exec_type}' in spec else 'expected']
+        ),
+        orient='table',
+    )
+
     assert_dataframes_content_equals(df, expected_df)


### PR DESCRIPTION
Translates the concatenate step from `../src/lib/translators/mongo.ts`

:warning: I had to handle some edge cases in order to make it iso with the pandas executor. There are probably still missing cases because type conversion in mongo and pandas have different rules. I also fear that adding these edge cases might decrease performances.