### PR TITLE
Mongo translator: implement `addmissingdates` and `dateextract` steps TCTC-2491

### DIFF
--- a/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
@@ -8,6 +8,7 @@ from weaverbird.backends.mongo_translator.steps.argmin import translate_argmin
 from weaverbird.backends.mongo_translator.steps.concatenate import translate_concatenate
 from weaverbird.backends.mongo_translator.steps.convert import translate_convert
 from weaverbird.backends.mongo_translator.steps.custom import translate_custom
+from weaverbird.backends.mongo_translator.steps.date_extract import translate_date_extract
 from weaverbird.backends.mongo_translator.steps.delete import translate_delete
 from weaverbird.backends.mongo_translator.steps.domain import translate_domain
 from weaverbird.backends.mongo_translator.steps.filter import translate_filter
@@ -44,6 +45,7 @@ mongo_step_translator: Dict[str, Callable[[Any], list]] = {
     'concatenate': translate_concatenate,
     'convert': translate_convert,
     'custom': translate_custom,
+    'dateextract': translate_date_extract,
     'delete': translate_delete,
     'domain': translate_domain,
     'filter': translate_filter,

--- a/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
@@ -1,5 +1,6 @@
 from typing import Any, Callable, Dict
 
+from weaverbird.backends.mongo_translator.steps.addmissingdates import translate_addmissingdates
 from weaverbird.backends.mongo_translator.steps.aggregate import translate_aggregate
 from weaverbird.backends.mongo_translator.steps.append import translate_append
 from weaverbird.backends.mongo_translator.steps.argmax import translate_argmax
@@ -35,6 +36,7 @@ from weaverbird.backends.mongo_translator.steps.uppercase import translate_upper
 # each of this function take a particular step as input
 # so it is not possible to use `Dict[str, Callable[[BaseStep], list]]
 mongo_step_translator: Dict[str, Callable[[Any], list]] = {
+    'addmissingdates': translate_addmissingdates,
     'aggregate': translate_aggregate,
     'append': translate_append,
     'argmax': translate_argmax,

--- a/server/src/weaverbird/backends/mongo_translator/steps/addmissingdates.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/addmissingdates.py
@@ -1,0 +1,215 @@
+from typing import List
+
+from weaverbird.backends.mongo_translator.steps.types import MongoStep
+from weaverbird.pipeline.steps.addmissingdates import AddMissingDatesStep, DatesGranularity
+
+
+def _add_missing_dates_year(step: AddMissingDatesStep) -> List[MongoStep]:
+    groups = step.groups or []
+    # add missing dates by looping over the unique dates array and adding a given date
+    # if it's not already present in the original dataset
+    add_missing_years_as_dates: MongoStep = {
+        '$map': {
+            # loop over a sorted array of all years between min and max year
+            'input': {'$range': ['$_vqbMinYear', {'$add': ['$_vqbMaxYear', 1]}]},
+            # use a variable "currentYear" as cursor
+            'as': 'currentYear',
+            # and apply the following expression to every "currentYear"
+            'in': {
+                '$let': {
+                    # use a variable yearIndex that represents the index of the "currentYear"
+                    # cursor in the original array
+                    'vars': {
+                        'yearIndex': {'$indexOfArray': ['$_vqbArray._vqbYear', '$$currentYear']},
+                    },
+                    'in': {
+                        '$cond': [
+                            # if "currentYear" is found in the original array
+                            {'$ne': ['$$yearIndex', -1]},
+                            # just get the original document in the original array
+                            {'$arrayElemAt': ['$_vqbArray', '$$yearIndex']},
+                            # else add a new document with the missing date (we convert the year back to a date object)
+                            # and the group fields (every other field will be undefined)
+                            {
+                                **{col: f'$_id.{col}' for col in groups},
+                                step.dates_column: {'$dateFromParts': {'year': '$$currentYear'}},
+                            },
+                        ],
+                    },
+                }
+            },
+        }
+    }
+
+    return [
+        # Extract the year of the date in a new column
+        {'$addFields': {'_vqbYear': {'$year': f'${step.dates_column}'}}},
+        # Group by logic to create an array with all original documents, and get the
+        # min and max date of all documents confounded
+        {
+            '$group': {
+                '_id': {col: f'${col}' for col in groups} if groups else None,
+                '_vqbArray': {'$push': '$$ROOT'},
+                '_vqbMinYear': {'$min': '$_vqbYear'},
+                '_vqbMaxYear': {'$max': '$_vqbYear'},
+            },
+        },
+        # That at this stage that all the magic happens (cf. supra)
+        {'$addFields': {'_vqbAllDates': add_missing_years_as_dates}},
+    ]
+
+
+def _generate_date_from_parts(mongo_date: str, granularity: DatesGranularity) -> MongoStep:
+    date_from_parts = {'year': {'$year': mongo_date}}
+    if granularity in ('day', 'month'):
+        date_from_parts['month'] = {'$month': mongo_date}
+    if granularity == 'day':
+        date_from_parts['day'] = {'$dayOfMonth': mongo_date}
+
+    return date_from_parts
+
+
+def _add_missing_dates_day_or_month(step: AddMissingDatesStep) -> List[MongoStep]:
+    groups = step.groups or []
+    # Create a sorted array of all dates (in days) ranging from min to
+    # max dates found in the whole dataset. At this stage for the
+    # month granularity, we will get duplicate dates because we need
+    # to first generate all days one by one to increment the calendar
+    # safely, before converting every day of a given  month to the 1st
+    # of this month (via the $dateFromPart expression). We take care
+    # of making month dates unique in a '$reduce' stage explained
+    # later
+    all_days_range = {
+        '$map': {
+            # create a array of integers ranging from 0 to the number of days separating the min and max date
+            'input': {'$range': [0, {'$add': ['$_vqbMinMaxDiffInDays', 1]}]},
+            # use a cursor 'currentDurationInDays' that will loop over the array
+            'as': 'currentDurationInDays',
+            # apply the following operations to every element of the array via the cursor 'currentDurationInDays'
+            'in': {
+                '$let': {
+                    # create a variable 'currentDay' that will correspond to the day resulting from the addition of the
+                    # duration 'currentDurationInDays' (converted back to milliseconds) to the min date.
+                    'vars': {
+                        'currentDay': {
+                            '$add': [
+                                '$_vqbMinDay',
+                                {'$multiply': ['$$currentDurationInDays', 60 * 60 * 24 * 1000]},
+                            ],
+                        },
+                    },
+                    # use the variable in the following expression, in which we recreate a date which granularity will
+                    # depend on the user-specified granularity
+                    'in': {
+                        '$dateFromParts': _generate_date_from_parts(
+                            '$$currentDay', step.dates_granularity
+                        ),
+                    },
+                },
+            },
+        },
+    }
+
+    # For the month granularity only, use a $reduce stage to reduce the allDaysRange
+    # array into an array of unique days.
+    unique_days_for_month_granularity = {
+        '$reduce': {
+            'input': all_days_range,
+            'initialValue': [],
+            'in': {
+                '$cond': [
+                    # if the date is not found in the reduced array
+                    {'$eq': [{'$indexOfArray': ['$$value', '$$this']}, -1]},
+                    # then add the date to it
+                    {'$concatArrays': ['$$value', ['$$this']]},
+                    # else add nothing to it
+                    {'$concatArrays': ['$$value', []]},
+                ],
+            },
+        },
+    }
+
+    # add missing dates by looping over the unique dates array and adding a given date
+    # if it's not already present in the original dataset
+    add_missing_dates = {
+        '$map': {
+            # loop over unique dates array
+            'input': all_days_range
+            if step.dates_granularity == 'day'
+            else unique_days_for_month_granularity,
+            # use a variable "date" as cursor
+            'as': 'date',
+            # and apply the following expression to every "date"
+            'in': {
+                '$let': {
+                    # use a variable dateIndex that represents the index
+                    # of the "date" cursor in the original array of documents
+                    'vars': {'dateIndex': {'$indexOfArray': ['$_vqbArray._vqbDay', '$$date']}},
+                    'in': {
+                        '$cond': [
+                            # if "date" is found in the original array
+                            {'$ne': ['$$dateIndex', -1]},
+                            # just get the original document in the original array
+                            {'$arrayElemAt': ['$_vqbArray', '$$dateIndex']},
+                            # else add a new document with the missing
+                            # date and the group fieldds (every other
+                            # field will be undefined)
+                            {
+                                **{col: f'$_id.{col}' for col in groups},
+                                step.dates_column: '$$date',
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    }
+
+    return [
+        {
+            '$addFields': {
+                '_vqbDay': {
+                    '$dateFromParts': _generate_date_from_parts(
+                        f'${step.dates_column}', step.dates_granularity
+                    ),
+                },
+            },
+        },
+        # Group by logic to create an array with all original documents, and get the
+        # min and max date of all documents confounded
+        {
+            '$group': {
+                '_id': {col: f'${col}' for col in groups} if step.groups else None,
+                # '_id': groups or None,
+                '_vqbArray': {'$push': '$$ROOT'},
+                '_vqbMinDay': {'$min': '$_vqbDay'},
+                '_vqbMaxDay': {'$max': '$_vqbDay'},
+            },
+        },
+        # Compute the time difference between the min and max date in days (the
+        # subtraction between two dates in mongo gives a duration in milliseconds)
+        {
+            '$addFields': {
+                '_vqbMinMaxDiffInDays': {
+                    '$divide': [{'$subtract': ['$_vqbMaxDay', '$_vqbMinDay']}, 60 * 60 * 24 * 1000],
+                },
+            },
+        },
+        # That at this stage that all the magic happens (cf. supra)
+        {'$addFields': {'_vqbAllDates': add_missing_dates}},
+    ]
+
+
+def translate_addmissingdates(step: AddMissingDatesStep) -> List[MongoStep]:
+    return (
+        _add_missing_dates_year(step)
+        if step.dates_granularity == 'year'
+        else _add_missing_dates_day_or_month(step)
+    ) + [
+        # Get back to 1 row per document
+        {'$unwind': '$_vqbAllDates'},
+        # Change the root to get back to the document granularity
+        {'$replaceRoot': {'newRoot': '$_vqbAllDates'}},
+        # Remove remaining temporary column
+        {'$project': {'_vqbYear' if step.dates_granularity == 'year' else '_vqbDay': 0}},
+    ]

--- a/server/src/weaverbird/backends/mongo_translator/steps/date_extract.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/date_extract.py
@@ -1,0 +1,320 @@
+from copy import deepcopy
+from typing import List
+
+from weaverbird.backends.mongo_translator.steps.types import MongoStep
+from weaverbird.pipeline.steps import DateExtractStep
+
+
+def _truncate_date_to_day(expr: dict) -> MongoStep:
+    return {
+        '$dateTrunc': {
+            'unit': 'day',
+            'date': expr,
+        },
+    }
+
+
+def _extract_quarter(step: DateExtractStep) -> MongoStep:
+    return {
+        '$switch': {
+            'branches': [
+                {'case': {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 1]}, 'then': 1},
+                {'case': {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 2]}, 'then': 2},
+                {'case': {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 3]}, 'then': 3},
+            ],
+            'default': 4,
+        },
+    }
+
+
+def _extract_first_day_of_year(step: DateExtractStep) -> MongoStep:
+    return {
+        '$dateFromParts': {'year': {'$year': f'${step.column}'}, 'month': 1, 'day': 1},
+    }
+
+
+def _extract_first_day_of_month(step: DateExtractStep) -> MongoStep:
+    return {
+        '$dateFromParts': {
+            'year': {'$year': f'${step.column}'},
+            'month': {'$month': f'${step.column}'},
+            'day': 1,
+        },
+    }
+
+
+def _extract_first_day_of_week(step: DateExtractStep) -> MongoStep:
+    return _truncate_date_to_day(
+        {
+            # We subtract to the target date a number of days corresponding to (dayOfWeek - 1)
+            '$subtract': [
+                f'${step.column}',
+                {
+                    '$multiply': [
+                        {'$subtract': [{'$dayOfWeek': f'${step.column}'}, 1]},
+                        24 * 60 * 60 * 1000,
+                    ],
+                },
+            ],
+        }
+    )
+
+
+def _extract_first_day_of_quarter(step: DateExtractStep) -> MongoStep:
+    return {
+        '$dateFromParts': {
+            'year': {'$year': f'${step.column}'},
+            'month': {
+                '$switch': {
+                    'branches': [
+                        {
+                            'case': {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 1]},
+                            'then': 1,
+                        },
+                        {
+                            'case': {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 2]},
+                            'then': 4,
+                        },
+                        {
+                            'case': {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 3]},
+                            'then': 7,
+                        },
+                    ],
+                    'default': 10,
+                },
+            },
+            'day': 1,
+        },
+    }
+
+
+def _extract_first_day_of_iso_week(step: DateExtractStep) -> MongoStep:
+    return _truncate_date_to_day(
+        {
+            # We subtract to the target date a number of days corresponding to (isoDayOfWeek - 1)
+            '$subtract': [
+                f'${step.column}',
+                {
+                    '$multiply': [
+                        {'$subtract': [{'$isoDayOfWeek': f'${step.column}'}, 1]},
+                        24 * 60 * 60 * 1000,
+                    ],
+                },
+            ],
+        }
+    )
+
+
+def _extract_previous_day(step: DateExtractStep) -> MongoStep:
+    return _truncate_date_to_day(
+        {
+            # We subtract to the target date 1 day in milliseconds
+            '$subtract': [f'${step.column}', 24 * 60 * 60 * 1000],
+        }
+    )
+
+
+def _extract_first_day_of_previous_year(step: DateExtractStep) -> MongoStep:
+    return {
+        '$dateFromParts': {
+            'year': {'$subtract': [{'$year': f'${step.column}'}, 1]},
+            'month': 1,
+            'day': 1,
+        },
+    }
+
+
+def _extract_first_day_of_previous_month(step: DateExtractStep) -> MongoStep:
+    return {
+        '$dateFromParts': {
+            'year': {
+                '$cond': [
+                    {'$eq': [{'$month': f'${step.column}'}, 1]},
+                    {'$subtract': [{'$year': f'${step.column}'}, 1]},
+                    {'$year': f'${step.column}'},
+                ],
+            },
+            'month': {
+                '$cond': [
+                    {'$eq': [{'$month': f'${step.column}'}, 1]},
+                    12,
+                    {'$subtract': [{'$month': f'${step.column}'}, 1]},
+                ],
+            },
+            'day': 1,
+        },
+    }
+
+
+def _extract_first_day_of_previous_week(step: DateExtractStep) -> MongoStep:
+    return _truncate_date_to_day(
+        {
+            # We subtract to the target date a number of days corresponding to (dayOfWeek - 1)
+            '$subtract': [
+                {'$subtract': [f'${step.column}', 7 * 24 * 60 * 60 * 1000]},
+                {
+                    '$multiply': [
+                        {'$subtract': [{'$dayOfWeek': f'${step.column}'}, 1]},
+                        24 * 60 * 60 * 1000,
+                    ],
+                },
+            ],
+        }
+    )
+
+
+def _extract_first_day_of_previous_quarter(step: DateExtractStep) -> MongoStep:
+    return {
+        '$dateFromParts': {
+            'year': {
+                '$cond': [
+                    {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 1]},
+                    {'$subtract': [{'$year': f'${step.column}'}, 1]},
+                    {'$year': f'${step.column}'},
+                ],
+            },
+            'month': {
+                '$switch': {
+                    'branches': [
+                        {
+                            'case': {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 1]},
+                            'then': 10,
+                        },
+                        {
+                            'case': {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 2]},
+                            'then': 1,
+                        },
+                        {
+                            'case': {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 3]},
+                            'then': 4,
+                        },
+                    ],
+                    'default': 7,
+                },
+            },
+            'day': 1,
+        },
+    }
+
+
+def _extract_first_day_of_previous_iso_week(step: DateExtractStep) -> MongoStep:
+    return _truncate_date_to_day(
+        {
+            # We subtract to the target date a number of days corresponding to (isoDayOfWeek - 1)
+            '$subtract': [
+                {'$subtract': [f'${step.column}', 7 * 24 * 60 * 60 * 1000]},
+                {
+                    '$multiply': [
+                        {'$subtract': [{'$isoDayOfWeek': f'${step.column}'}, 1]},
+                        24 * 60 * 60 * 1000,
+                    ],
+                },
+            ],
+        }
+    )
+
+
+def _extract_previous_year(step: DateExtractStep) -> MongoStep:
+    return {
+        '$subtract': [{'$year': f'${step.column}'}, 1],
+    }
+
+
+def _extract_previous_month(step: DateExtractStep) -> MongoStep:
+    return {
+        '$cond': [
+            {'$eq': [{'$month': f'${step.column}'}, 1]},
+            12,
+            {'$subtract': [{'$month': f'${step.column}'}, 1]},
+        ],
+    }
+
+
+def _extract_previous_week(step: DateExtractStep) -> MongoStep:
+    return {
+        # We subtract to the target date 7 days in milliseconds
+        '$week': {'$subtract': [f'${step.column}', 7 * 24 * 60 * 60 * 1000]},
+    }
+
+
+def _extract_previous_quarter(step: DateExtractStep) -> MongoStep:
+    return {
+        '$switch': {
+            'branches': [
+                {'case': {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 1]}, 'then': 4},
+                {'case': {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 2]}, 'then': 1},
+                {'case': {'$lte': [{'$divide': [{'$month': f'${step.column}'}, 3]}, 3]}, 'then': 2},
+            ],
+            'default': 3,
+        },
+    }
+
+
+def _extract_previous_iso_week(step: DateExtractStep) -> MongoStep:
+    return {
+        # We subtract to the target date 7 days in milliseconds
+        '$isoWeek': {'$subtract': [f'${step.column}', 7 * 24 * 60 * 60 * 1000]},
+    }
+
+
+_ADVANCED_DATE_EXTRACT_MAP = {
+    'quarter': _extract_quarter,
+    'firstDayOfYear': _extract_first_day_of_year,
+    'firstDayOfMonth': _extract_first_day_of_month,
+    'firstDayOfWeek': _extract_first_day_of_week,
+    'firstDayOfQuarter': _extract_first_day_of_quarter,
+    'firstDayOfIsoWeek': _extract_first_day_of_iso_week,
+    'previousDay': _extract_previous_day,
+    'firstDayOfPreviousYear': _extract_first_day_of_previous_year,
+    'firstDayOfPreviousMonth': _extract_first_day_of_previous_month,
+    'firstDayOfPreviousWeek': _extract_first_day_of_previous_week,
+    'firstDayOfPreviousQuarter': _extract_first_day_of_previous_quarter,
+    'firstDayOfPreviousIsoWeek': _extract_first_day_of_previous_iso_week,
+    'previousYear': _extract_previous_year,
+    'previousMonth': _extract_previous_month,
+    'previousWeek': _extract_previous_week,
+    'previousQuarter': _extract_previous_quarter,
+    'previousIsoWeek': _extract_previous_iso_week,
+}
+
+_DATE_EXTRACT_MAP = {
+    'year': '$year',
+    'month': '$month',
+    'day': '$dayOfMonth',
+    'week': '$week',
+    'dayOfYear': '$dayOfYear',
+    'dayOfWeek': '$dayOfWeek',
+    'isoYear': '$isoWeekYear',
+    'isoWeek': '$isoWeek',
+    'isoDayOfWeek': '$isoDayOfWeek',
+    'hour': '$hour',
+    'minutes': '$minute',
+    'seconds': '$second',
+    'milliseconds': '$millisecond',
+}
+
+
+def translate_date_extract(step: DateExtractStep) -> List[MongoStep]:
+    new_columns = []
+    add_fields = {}
+
+    date_info: list
+    # For retrocompatibility
+    if step.operation:
+        date_info = [step.operation] if step.operation else step.date_info
+        new_columns = [
+            step.new_column_name if step.new_column_name else f"{step.column}_{step.operation}"
+        ]
+    else:
+        date_info = step.date_info.copy()
+        new_columns = deepcopy(step.new_columns)
+
+    for i, d in enumerate(date_info):
+        if d in _ADVANCED_DATE_EXTRACT_MAP:
+            add_fields[new_columns[i]] = _ADVANCED_DATE_EXTRACT_MAP[d](step)
+        else:
+            add_fields[new_columns[i]] = {
+                _DATE_EXTRACT_MAP[d]: f"${step.column}",
+            }
+
+    return [{'$addFields': add_fields}]

--- a/server/src/weaverbird/backends/mongo_translator/steps/date_extract.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/date_extract.py
@@ -1,11 +1,10 @@
-from copy import deepcopy
-from typing import List
+from typing import List, Union
 
 from weaverbird.backends.mongo_translator.steps.types import MongoStep
 from weaverbird.pipeline.steps import DateExtractStep
 
 
-def _truncate_date_to_day(expr: dict) -> MongoStep:
+def _truncate_date_to_day(expr: Union[dict, str]) -> MongoStep:
     return {
         '$dateTrunc': {
             'unit': 'day',
@@ -307,7 +306,7 @@ def translate_date_extract(step: DateExtractStep) -> List[MongoStep]:
         ]
     else:
         date_info = step.date_info.copy()
-        new_columns = deepcopy(step.new_columns)
+        new_columns = step.new_columns.copy()
 
     for i, d in enumerate(date_info):
         if d in _ADVANCED_DATE_EXTRACT_MAP:

--- a/server/src/weaverbird/pipeline/steps/addmissingdates.py
+++ b/server/src/weaverbird/pipeline/steps/addmissingdates.py
@@ -6,13 +6,13 @@ from weaverbird.pipeline.steps.utils.base import BaseStep
 from weaverbird.pipeline.steps.utils.render_variables import StepWithVariablesMixin
 from weaverbird.pipeline.types import ColumnName, TemplatedVariable
 
+DatesGranularity = Union[Literal['day'], Literal['week'], Literal['month'], Literal['year']]
+
 
 class AddMissingDatesStep(BaseStep):
     name = Field('addmissingdates', const=True)
     dates_column: ColumnName = Field(alias='datesColumn')
-    dates_granularity: Union[
-        Literal['day'], Literal['week'], Literal['month'], Literal['year']
-    ] = Field(alias='datesGranularity')
+    dates_granularity: DatesGranularity = Field(alias='datesGranularity')
     groups: List[ColumnName] = []
 
 

--- a/server/tests/backends/fixtures/dateextract/after_add_missing_dates_duplicate_values.json
+++ b/server/tests/backends/fixtures/dateextract/after_add_missing_dates_duplicate_values.json
@@ -3,8 +3,7 @@
   "exclude": [
     "snowflake",
     "mysql",
-    "postgres",
-    "mongo"
+    "postgres"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/dateextract/legacy_config.json
+++ b/server/tests/backends/fixtures/dateextract/legacy_config.json
@@ -2,8 +2,7 @@
   "exclude": [
     "snowflake",
     "mysql",
-    "postgres",
-    "mongo"
+    "postgres"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/dateextract/legacy_config_without_column.json
+++ b/server/tests/backends/fixtures/dateextract/legacy_config_without_column.json
@@ -2,8 +2,7 @@
   "exclude": [
     "snowflake",
     "mysql",
-    "postgres",
-    "mongo"
+    "postgres"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/dateextract/mongo_all_cases.json
+++ b/server/tests/backends/fixtures/dateextract/mongo_all_cases.json
@@ -2,7 +2,8 @@
   "exclude": [
     "pandas",
     "mysql",
-    "postgres"
+    "postgres",
+    "snowflake"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/dateextract/mongo_all_cases.json
+++ b/server/tests/backends/fixtures/dateextract/mongo_all_cases.json
@@ -1,0 +1,490 @@
+{
+  "exclude": [
+    "pandas",
+    "mysql",
+    "postgres"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "dateextract",
+        "column": "DATE",
+        "dateInfo": [
+          "year",
+          "month",
+          "day",
+          "week",
+          "quarter",
+          "dayOfWeek",
+          "dayOfYear",
+          "isoYear",
+          "isoWeek",
+          "isoDayOfWeek",
+          "firstDayOfYear",
+          "firstDayOfMonth",
+          "firstDayOfWeek",
+          "firstDayOfQuarter",
+          "firstDayOfIsoWeek",
+          "previousDay",
+          "firstDayOfPreviousYear",
+          "firstDayOfPreviousMonth",
+          "firstDayOfPreviousWeek",
+          "firstDayOfPreviousQuarter",
+          "firstDayOfPreviousIsoWeek",
+          "previousYear",
+          "previousMonth",
+          "previousWeek",
+          "previousQuarter",
+          "previousIsoWeek",
+          "hour",
+          "minutes",
+          "seconds",
+          "milliseconds"
+        ],
+        "newColumns": [
+          "DATE_YEAR",
+          "DATE_MONTH",
+          "DATE_DAY",
+          "DATE_WEEK",
+          "DATE_QUARTER",
+          "DATE_DAYOFWEEK",
+          "DATE_DAYOFYEAR",
+          "DATE_ISOYEAR",
+          "DATE_ISOWEEK",
+          "DATE_ISODAYOFWEEK",
+          "DATE_FIRSTDAYOFYEAR",
+          "DATE_FIRSTDAYOFMONTH",
+          "DATE_FIRSTDAYOFWEEK",
+          "DATE_FIRSTDAYOFQUARTER",
+          "DATE_FIRSTDAYOFISOWEEK",
+          "DATE_PREVIOUSDAY",
+          "DATE_FIRSTDAYOFPREVIOUSYEAR",
+          "DATE_FIRSTDAYOFPREVIOUSMONTH",
+          "DATE_FIRSTDAYOFPREVIOUSWEEK",
+          "DATE_FIRSTDAYOFPREVIOUSQUARTER",
+          "DATE_FIRSTDAYOFPREVIOUSISOWEEK",
+          "DATE_PREVIOUSYEAR",
+          "DATE_PREVIOUSMONTH",
+          "DATE_PREVIOUSWEEK",
+          "DATE_PREVIOUSQUARTER",
+          "DATE_PREVIOUSISOWEEK",
+          "DATE_HOUR",
+          "DATE_MINUTES",
+          "DATE_SECONDS",
+          "DATE_MILLISECONDS"
+        ]
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "DATE",
+          "type": "datetime",
+          "tz": "UTC"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "DATE": "2021-03-29T00:00:00.000Z"
+      },
+      {
+        "DATE": "2020-12-13T00:00:00.000Z"
+      },
+      {
+        "DATE": "2020-07-29T00:00:00.000Z"
+      },
+      {
+        "DATE": "2019-04-09T01:02:03.004Z"
+      },
+      {
+        "DATE": "2017-01-02T00:00:00.000Z"
+      },
+      {
+        "DATE": "2016-01-01T00:00:00.000Z"
+      },
+      {
+        "DATE": null
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "DATE",
+          "type": "datetime",
+          "tz": "UTC"
+        },
+        {
+          "name": "DATE_YEAR",
+          "type": "number"
+        },
+        {
+          "name": "DATE_MONTH",
+          "type": "number"
+        },
+        {
+          "name": "DATE_DAY",
+          "type": "number"
+        },
+        {
+          "name": "DATE_WEEK",
+          "type": "number"
+        },
+        {
+          "name": "DATE_QUARTER",
+          "type": "number"
+        },
+        {
+          "name": "DATE_DAYOFWEEK",
+          "type": "number"
+        },
+        {
+          "name": "DATE_DAYOFYEAR",
+          "type": "number"
+        },
+        {
+          "name": "DATE_ISOYEAR",
+          "type": "number"
+        },
+        {
+          "name": "DATE_ISOWEEK",
+          "type": "number"
+        },
+        {
+          "name": "DATE_ISODAYOFWEEK",
+          "type": "number"
+        },
+        {
+          "name": "DATE_FIRSTDAYOFYEAR",
+          "type": "datetime",
+          "tz": "UTC"
+        },
+        {
+          "name": "DATE_FIRSTDAYOFMONTH",
+          "type": "datetime",
+          "tz": "UTC"
+        },
+        {
+          "name": "DATE_FIRSTDAYOFWEEK",
+          "type": "datetime",
+          "tz": "UTC"
+        },
+        {
+          "name": "DATE_FIRSTDAYOFQUARTER",
+          "type": "datetime",
+          "tz": "UTC"
+        },
+        {
+          "name": "DATE_FIRSTDAYOFISOWEEK",
+          "type": "datetime",
+          "tz": "UTC"
+        },
+        {
+          "name": "DATE_PREVIOUSDAY",
+          "type": "datetime",
+          "tz": "UTC"
+        },
+        {
+          "name": "DATE_FIRSTDAYOFPREVIOUSYEAR",
+          "type": "datetime",
+          "tz": "UTC"
+        },
+        {
+          "name": "DATE_FIRSTDAYOFPREVIOUSMONTH",
+          "type": "datetime",
+          "tz": "UTC"
+        },
+        {
+          "name": "DATE_FIRSTDAYOFPREVIOUSWEEK",
+          "type": "datetime",
+          "tz": "UTC"
+        },
+        {
+          "name": "DATE_FIRSTDAYOFPREVIOUSQUARTER",
+          "type": "datetime",
+          "tz": "UTC"
+        },
+        {
+          "name": "DATE_FIRSTDAYOFPREVIOUSISOWEEK",
+          "type": "datetime",
+          "tz": "UTC"
+        },
+        {
+          "name": "DATE_PREVIOUSYEAR",
+          "type": "number"
+        },
+        {
+          "name": "DATE_PREVIOUSMONTH",
+          "type": "number"
+        },
+        {
+          "name": "DATE_PREVIOUSQUARTER",
+          "type": "number"
+        },
+        {
+          "name": "DATE_PREVIOUSWEEK",
+          "type": "number"
+        },
+        {
+          "name": "DATE_PREVIOUSISOWEEK",
+          "type": "number"
+        },
+        {
+          "name": "DATE_HOUR",
+          "type": "number"
+        },
+        {
+          "name": "DATE_MINUTES",
+          "type": "number"
+        },
+        {
+          "name": "DATE_SECONDS",
+          "type": "number"
+        },
+        {
+          "name": "DATE_MILLISECONDS",
+          "type": "number"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "DATE": "2021-03-29T00:00:00.000Z",
+        "DATE_YEAR": 2021,
+        "DATE_MONTH": 3,
+        "DATE_DAY": 29,
+        "DATE_WEEK": 13,
+        "DATE_QUARTER": 1,
+        "DATE_DAYOFWEEK": 2,
+        "DATE_DAYOFYEAR": 88,
+        "DATE_ISOYEAR": 2021,
+        "DATE_ISOWEEK": 13,
+        "DATE_ISODAYOFWEEK": 1,
+        "DATE_FIRSTDAYOFYEAR": "2021-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFMONTH": "2021-03-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFWEEK": "2021-03-28T00:00:00.000Z",
+        "DATE_FIRSTDAYOFQUARTER": "2021-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFISOWEEK": "2021-03-29T00:00:00.000Z",
+        "DATE_PREVIOUSDAY": "2021-03-28T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSYEAR": "2020-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSMONTH": "2021-02-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSWEEK": "2021-03-21T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSQUARTER": "2020-10-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSISOWEEK": "2021-03-22T00:00:00.000Z",
+        "DATE_PREVIOUSYEAR": 2020,
+        "DATE_PREVIOUSMONTH": 2,
+        "DATE_PREVIOUSQUARTER": 4,
+        "DATE_PREVIOUSWEEK": 12,
+        "DATE_PREVIOUSISOWEEK": 12,
+        "DATE_HOUR": 0,
+        "DATE_MINUTES": 0,
+        "DATE_SECONDS": 0,
+        "DATE_MILLISECONDS": 0
+      },
+      {
+        "DATE": "2020-12-13T00:00:00.000Z",
+        "DATE_YEAR": 2020,
+        "DATE_MONTH": 12,
+        "DATE_DAY": 13,
+        "DATE_WEEK": 50,
+        "DATE_QUARTER": 4,
+        "DATE_DAYOFWEEK": 1,
+        "DATE_DAYOFYEAR": 348,
+        "DATE_ISOYEAR": 2020,
+        "DATE_ISOWEEK": 50,
+        "DATE_ISODAYOFWEEK": 7,
+        "DATE_FIRSTDAYOFYEAR": "2020-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFMONTH": "2020-12-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFWEEK": "2020-12-13T00:00:00.000Z",
+        "DATE_FIRSTDAYOFQUARTER": "2020-10-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFISOWEEK": "2020-12-07T00:00:00.000Z",
+        "DATE_PREVIOUSDAY": "2020-12-12T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSYEAR": "2019-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSMONTH": "2020-11-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSWEEK": "2020-12-06T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSQUARTER": "2020-07-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSISOWEEK": "2020-11-30T00:00:00.000Z",
+        "DATE_PREVIOUSYEAR": 2019,
+        "DATE_PREVIOUSMONTH": 11,
+        "DATE_PREVIOUSQUARTER": 3,
+        "DATE_PREVIOUSWEEK": 49,
+        "DATE_PREVIOUSISOWEEK": 49,
+        "DATE_HOUR": 0,
+        "DATE_MINUTES": 0,
+        "DATE_SECONDS": 0,
+        "DATE_MILLISECONDS": 0
+      },
+      {
+        "DATE": "2020-07-29T00:00:00.000Z",
+        "DATE_YEAR": 2020,
+        "DATE_MONTH": 7,
+        "DATE_DAY": 29,
+        "DATE_WEEK": 30,
+        "DATE_QUARTER": 3,
+        "DATE_DAYOFWEEK": 4,
+        "DATE_DAYOFYEAR": 211,
+        "DATE_ISOYEAR": 2020,
+        "DATE_ISOWEEK": 31,
+        "DATE_ISODAYOFWEEK": 3,
+        "DATE_FIRSTDAYOFYEAR": "2020-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFMONTH": "2020-07-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFWEEK": "2020-07-26T00:00:00.000Z",
+        "DATE_FIRSTDAYOFQUARTER": "2020-07-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFISOWEEK": "2020-07-27T00:00:00.000Z",
+        "DATE_PREVIOUSDAY": "2020-07-28T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSYEAR": "2019-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSMONTH": "2020-06-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSWEEK": "2020-07-19T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSQUARTER": "2020-04-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSISOWEEK": "2020-07-20T00:00:00.000Z",
+        "DATE_PREVIOUSYEAR": 2019,
+        "DATE_PREVIOUSMONTH": 6,
+        "DATE_PREVIOUSQUARTER": 2,
+        "DATE_PREVIOUSWEEK": 29,
+        "DATE_PREVIOUSISOWEEK": 30,
+        "DATE_HOUR": 0,
+        "DATE_MINUTES": 0,
+        "DATE_SECONDS": 0,
+        "DATE_MILLISECONDS": 0
+      },
+      {
+        "DATE": "2019-04-09T01:02:03.004Z",
+        "DATE_YEAR": 2019,
+        "DATE_MONTH": 4,
+        "DATE_DAY": 9,
+        "DATE_WEEK": 14,
+        "DATE_QUARTER": 2,
+        "DATE_DAYOFWEEK": 3,
+        "DATE_DAYOFYEAR": 99,
+        "DATE_ISOYEAR": 2019,
+        "DATE_ISOWEEK": 15,
+        "DATE_ISODAYOFWEEK": 2,
+        "DATE_FIRSTDAYOFYEAR": "2019-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFMONTH": "2019-04-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFWEEK": "2019-04-07T00:00:00.000Z",
+        "DATE_FIRSTDAYOFQUARTER": "2019-04-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFISOWEEK": "2019-04-08T00:00:00.000Z",
+        "DATE_PREVIOUSDAY": "2019-04-08T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSYEAR": "2018-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSMONTH": "2019-03-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSWEEK": "2019-03-31T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSQUARTER": "2019-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSISOWEEK": "2019-04-01T00:00:00.000Z",
+        "DATE_PREVIOUSYEAR": 2018,
+        "DATE_PREVIOUSMONTH": 3,
+        "DATE_PREVIOUSQUARTER": 1,
+        "DATE_PREVIOUSWEEK": 13,
+        "DATE_PREVIOUSISOWEEK": 14,
+        "DATE_HOUR": 1,
+        "DATE_MINUTES": 2,
+        "DATE_SECONDS": 3,
+        "DATE_MILLISECONDS": 4
+      },
+      {
+        "DATE": "2017-01-02T00:00:00.000Z",
+        "DATE_YEAR": 2017,
+        "DATE_MONTH": 1,
+        "DATE_DAY": 2,
+        "DATE_WEEK": 1,
+        "DATE_QUARTER": 1,
+        "DATE_DAYOFWEEK": 2,
+        "DATE_DAYOFYEAR": 2,
+        "DATE_ISOYEAR": 2017,
+        "DATE_ISOWEEK": 1,
+        "DATE_ISODAYOFWEEK": 1,
+        "DATE_FIRSTDAYOFYEAR": "2017-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFMONTH": "2017-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFWEEK": "2017-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFQUARTER": "2017-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFISOWEEK": "2017-01-02T00:00:00.000Z",
+        "DATE_PREVIOUSDAY": "2017-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSYEAR": "2016-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSMONTH": "2016-12-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSWEEK": "2016-12-25T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSQUARTER": "2016-10-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSISOWEEK": "2016-12-26T00:00:00.000Z",
+        "DATE_PREVIOUSYEAR": 2016,
+        "DATE_PREVIOUSMONTH": 12,
+        "DATE_PREVIOUSQUARTER": 4,
+        "DATE_PREVIOUSWEEK": 52,
+        "DATE_PREVIOUSISOWEEK": 52,
+        "DATE_HOUR": 0,
+        "DATE_MINUTES": 0,
+        "DATE_SECONDS": 0,
+        "DATE_MILLISECONDS": 0
+      },
+      {
+        "DATE": "2016-01-01T00:00:00.000Z",
+        "DATE_YEAR": 2016,
+        "DATE_MONTH": 1,
+        "DATE_DAY": 1,
+        "DATE_WEEK": 0,
+        "DATE_QUARTER": 1,
+        "DATE_DAYOFWEEK": 6,
+        "DATE_DAYOFYEAR": 1,
+        "DATE_ISOYEAR": 2015,
+        "DATE_ISOWEEK": 53,
+        "DATE_ISODAYOFWEEK": 5,
+        "DATE_FIRSTDAYOFYEAR": "2016-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFMONTH": "2016-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFWEEK": "2015-12-27T00:00:00.000Z",
+        "DATE_FIRSTDAYOFQUARTER": "2016-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFISOWEEK": "2015-12-28T00:00:00.000Z",
+        "DATE_PREVIOUSDAY": "2015-12-31T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSYEAR": "2015-01-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSMONTH": "2015-12-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSWEEK": "2015-12-20T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSQUARTER": "2015-10-01T00:00:00.000Z",
+        "DATE_FIRSTDAYOFPREVIOUSISOWEEK": "2015-12-21T00:00:00.000Z",
+        "DATE_PREVIOUSYEAR": 2015,
+        "DATE_PREVIOUSMONTH": 12,
+        "DATE_PREVIOUSQUARTER": 4,
+        "DATE_PREVIOUSWEEK": 51,
+        "DATE_PREVIOUSISOWEEK": 52,
+        "DATE_HOUR": 0,
+        "DATE_MINUTES": 0,
+        "DATE_SECONDS": 0,
+        "DATE_MILLISECONDS": 0
+      },
+      {
+        "DATE": null,
+        "DATE_YEAR": null,
+        "DATE_MONTH": null,
+        "DATE_DAY": null,
+        "DATE_WEEK": null,
+        "DATE_QUARTER": 1,
+        "DATE_DAYOFWEEK": null,
+        "DATE_DAYOFYEAR": null,
+        "DATE_ISOYEAR": null,
+        "DATE_ISOWEEK": null,
+        "DATE_ISODAYOFWEEK": null,
+        "DATE_FIRSTDAYOFYEAR": null,
+        "DATE_FIRSTDAYOFMONTH": null,
+        "DATE_FIRSTDAYOFWEEK": null,
+        "DATE_FIRSTDAYOFQUARTER": null,
+        "DATE_FIRSTDAYOFISOWEEK": null,
+        "DATE_PREVIOUSDAY": null,
+        "DATE_FIRSTDAYOFPREVIOUSYEAR": null,
+        "DATE_FIRSTDAYOFPREVIOUSMONTH": null,
+        "DATE_FIRSTDAYOFPREVIOUSWEEK": null,
+        "DATE_FIRSTDAYOFPREVIOUSQUARTER": null,
+        "DATE_FIRSTDAYOFPREVIOUSISOWEEK": null,
+        "DATE_PREVIOUSYEAR": null,
+        "DATE_PREVIOUSMONTH": null,
+        "DATE_PREVIOUSQUARTER": 4,
+        "DATE_PREVIOUSWEEK": null,
+        "DATE_PREVIOUSISOWEEK": null,
+        "DATE_HOUR": null,
+        "DATE_MINUTES": null,
+        "DATE_SECONDS": null,
+        "DATE_MILLISECONDS": null
+      }
+    ]
+  }
+}


### PR DESCRIPTION
`addmissingdates` was required by test fixtures.

Note that this only targets mongo 5.

Note that the behvaiour here is ISO with the mongo translator, BUT there are few issues/inconsistencies that would need to be adressed imo:

-  mongo's `$week` operator returns the week of the year for a date, starting at 0 (ending at 52, included). Other backends (and the commonly used form) start at 1 and end at 53. Maybe this should be adressed later on to be consistent throughout all backends ?
- Several steps using mongo's `$switch` statements have a weird behaviour with null values: Since `{$lte:  [null, anyPositiveInteger]}` is `true` in mongo 5, we get `1` for `quarter` with `null`, `4` for `previousQuarter` and so on... This could probably easily be fixed by checking first if the value is not null