### PR TITLE
feat(python-mongo-translator): delete step [TCTC-2656]

### DIFF
--- a/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
@@ -6,6 +6,7 @@ from weaverbird.backends.mongo_translator.steps.argmax import translate_argmax
 from weaverbird.backends.mongo_translator.steps.argmin import translate_argmin
 from weaverbird.backends.mongo_translator.steps.concatenate import translate_concatenate
 from weaverbird.backends.mongo_translator.steps.convert import translate_convert
+from weaverbird.backends.mongo_translator.steps.delete import translate_delete
 from weaverbird.backends.mongo_translator.steps.domain import translate_domain
 from weaverbird.backends.mongo_translator.steps.filter import translate_filter
 from weaverbird.backends.mongo_translator.steps.formula import translate_formula
@@ -36,6 +37,7 @@ mongo_step_translator: Dict[str, Callable[[Any], list]] = {
     'argmin': translate_argmin,
     'concatenate': translate_concatenate,
     'convert': translate_convert,
+    'delete': translate_delete,
     'domain': translate_domain,
     'filter': translate_filter,
     'formula': translate_formula,

--- a/server/src/weaverbird/backends/mongo_translator/steps/delete.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/delete.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from weaverbird.backends.mongo_translator.steps.types import MongoStep
+from weaverbird.pipeline.steps import DeleteStep
+
+
+def translate_delete(step: DeleteStep) -> List[MongoStep]:
+    return [{'$project': {c: 0 for c in step.columns}}]

--- a/server/tests/backends/fixtures/delete/simple.json
+++ b/server/tests/backends/fixtures/delete/simple.json
@@ -1,7 +1,6 @@
 {
   "exclude": [
-    "mysql",
-    "mongo"
+    "mysql"
   ],
   "step": {
     "pipeline": [


### PR DESCRIPTION
# What
Implemented the delete step in python for the mongo-translator, following the logic from `./src/lib/translators/mongo.ts`