### PR TITLE
fix(tests/mongo_translator): Sanitize pandas dataframes before inserting them into mongo TCTC-2688

### DIFF
--- a/server/tests/backends/fixtures/convert/to_bool.json
+++ b/server/tests/backends/fixtures/convert/to_bool.json
@@ -101,7 +101,7 @@
         "value": true
       },
       {
-        "value": true
+        "value": null
       }
     ]
   },

--- a/server/tests/backends/fixtures/convert/to_text.json
+++ b/server/tests/backends/fixtures/convert/to_text.json
@@ -100,7 +100,7 @@
         "value": "43.6"
       },
       {
-        "value": "NaN"
+        "value": null
       },
       {
         "value": "meh"


### PR DESCRIPTION
This ensures the following:

* null booleans are kept null rather than being converted to False by pandas (allow our tests
  to really check nulls)

* NaTs are converted to None (NaTs make pymongo fail)

* null strings are None rather than NaNs, which get stored in mongo as the litteral "nan" rather than
  null

Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>