### PR TITLE
feat(mongo-translator): added split step [TCTC-2657]

### DIFF
--- a/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
@@ -22,6 +22,7 @@ from weaverbird.backends.mongo_translator.steps.rename import translate_rename
 from weaverbird.backends.mongo_translator.steps.replace import translate_replace
 from weaverbird.backends.mongo_translator.steps.select import translate_select
 from weaverbird.backends.mongo_translator.steps.sort import translate_sort
+from weaverbird.backends.mongo_translator.steps.split import translate_split
 from weaverbird.backends.mongo_translator.steps.substring import translate_substring
 from weaverbird.backends.mongo_translator.steps.text import translate_text
 from weaverbird.backends.mongo_translator.steps.todate import translate_todate
@@ -56,6 +57,7 @@ mongo_step_translator: Dict[str, Callable[[Any], list]] = {
     'replace': translate_replace,
     'select': translate_select,
     'sort': translate_sort,
+    'split': translate_split,
     'substring': translate_substring,
     'text': translate_text,
     'todate': translate_todate,

--- a/server/src/weaverbird/backends/mongo_translator/steps/split.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/split.py
@@ -1,0 +1,16 @@
+from typing import List
+
+from weaverbird.backends.mongo_translator.steps.types import MongoStep
+from weaverbird.pipeline.steps import SplitStep
+
+
+def translate_split(step: SplitStep) -> List[MongoStep]:
+    add_fields_step = {}
+    for i in range(1, step.number_cols_to_keep + 1):
+        add_fields_step[f'{step.column}_{i}'] = {'$arrayElemAt': ['$_vqbTmp', i - 1]}
+
+    return [
+        {'$addFields': {'_vqbTmp': {'$split': [f'${step.column}', step.delimiter]}}},
+        {'$addFields': add_fields_step},
+        {'$project': {'_vqbTmp': 0}},
+    ]

--- a/server/tests/backends/fixtures/split/simple.json
+++ b/server/tests/backends/fixtures/split/simple.json
@@ -1,7 +1,6 @@
 {
   "exclude": [
-    "mysql",
-    "mongo"
+    "mysql"
   ],
   "step": {
     "pipeline": [


### PR DESCRIPTION
# What
Implemented the split step in python for the mongo-translator, following the logic from `./src/lib/translators/mongo.ts`