### PR TITLE
feat(python-mongo-translator): evolution step [TCTC-2657]

### DIFF
--- a/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
@@ -14,6 +14,7 @@ from weaverbird.backends.mongo_translator.steps.delete import translate_delete
 from weaverbird.backends.mongo_translator.steps.domain import translate_domain
 from weaverbird.backends.mongo_translator.steps.duplicate import translate_duplicate
 from weaverbird.backends.mongo_translator.steps.duration import translate_duration
+from weaverbird.backends.mongo_translator.steps.evolution import translate_evolution
 from weaverbird.backends.mongo_translator.steps.fillna import translate_fillna
 from weaverbird.backends.mongo_translator.steps.filter import translate_filter
 from weaverbird.backends.mongo_translator.steps.formula import translate_formula
@@ -58,6 +59,7 @@ mongo_step_translator: Dict[str, Callable[[Any], list]] = {
     'domain': translate_domain,
     'duplicate': translate_duplicate,
     'duration': translate_duration,
+    'evolution': translate_evolution,
     'fillna': translate_fillna,
     'filter': translate_filter,
     'formula': translate_formula,

--- a/server/src/weaverbird/backends/mongo_translator/steps/evolution.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/evolution.py
@@ -1,0 +1,134 @@
+from typing import Any, List
+
+from weaverbird.backends.mongo_translator.steps.types import MongoStep
+from weaverbird.pipeline.steps import EvolutionStep
+
+
+def translate_evolution(step: EvolutionStep) -> List[MongoStep]:
+    new_column = (
+        step.new_column
+        if step.new_column
+        else f'{step.value_col}_EVOL_{step.evolution_format.upper()}'
+    )
+    error_msg = 'Error: More than one previous date found for the specified index columns'
+    add_field_date_prev: dict[str, Any] = {}
+    add_field_result: dict[str, Any] = {}
+
+    if step.evolution_format == 'abs':
+        add_field_result[new_column] = {
+            '$cond': [
+                {'$eq': ['$_VQB_VALUE_PREV', 'Error']},
+                error_msg,
+                {'$subtract': [f'${step.value_col}', '$_VQB_VALUE_PREV']},
+            ],
+        }
+    else:
+        add_field_result[new_column] = {
+            '$switch': {
+                'branches': [
+                    {'case': {'$eq': ['$_VQB_VALUE_PREV', 'Error']}, 'then': error_msg},
+                    {'case': {'$eq': ['$_VQB_VALUE_PREV', 0]}, 'then': None},
+                ],
+                'default': {
+                    '$divide': [
+                        {'$subtract': [f'${step.value_col}', '$_VQB_VALUE_PREV']},
+                        '$_VQB_VALUE_PREV',
+                    ],
+                },
+            },
+        }
+
+    if step.evolution_type == 'vsLastYear':
+        add_field_date_prev['_VQB_DATE_PREV'] = {
+            '$dateFromParts': {
+                'year': {'$subtract': [{'$year': f'${step.date_col}'}, 1]},
+                'month': {'$month': f'${step.date_col}'},
+                'day': {'$dayOfMonth': f'${step.date_col}'},
+            },
+        }
+    elif step.evolution_type == 'vsLastMonth':
+        add_field_date_prev['_VQB_DATE_PREV'] = {
+            '$dateFromParts': {
+                'year': {
+                    '$cond': [
+                        {'$eq': [{'$month': f'${step.date_col}'}, 1]},
+                        {'$subtract': [{'$year': f'${step.date_col}'}, 1]},
+                        {'$year': f'${step.date_col}'},
+                    ],
+                },
+                'month': {
+                    '$cond': [
+                        {'$eq': [{'$month': f'${step.date_col}'}, 1]},
+                        12,
+                        {'$subtract': [{'$month': f'${step.date_col}'}, 1]},
+                    ],
+                },
+                'day': {'$dayOfMonth': f'${step.date_col}'},
+            },
+        }
+    else:
+        add_field_date_prev['_VQB_DATE_PREV'] = {
+            '$subtract': [
+                f'${step.date_col}',
+                60 * 60 * 24 * 1000 * (7 if step.evolution_type == 'vsLastWeek' else 1),
+            ],
+        }
+
+    return [
+        {'$addFields': add_field_date_prev},
+        {
+            '$facet': {
+                '_VQB_ORIGINALS': [{'$project': {'_id': 0}}],
+                '_VQB_COPIES_ARRAY': [
+                    {'$group': {'_id': None, '_VQB_ALL_DOCS': {'$push': '$$ROOT'}}}
+                ],
+            },
+        },
+        {'$unwind': '$_VQB_ORIGINALS'},
+        {
+            '$project': {
+                '_VQB_ORIGINALS': {
+                    '$mergeObjects': [
+                        '$_VQB_ORIGINALS',
+                        {'$arrayElemAt': ['$_VQB_COPIES_ARRAY', 0]},
+                    ],
+                },
+            },
+        },
+        {'$replaceRoot': {'newRoot': '$_VQB_ORIGINALS'}},
+        {
+            '$addFields': {
+                '_VQB_ALL_DOCS': {
+                    '$filter': {
+                        'input': '$_VQB_ALL_DOCS',
+                        'as': 'item',
+                        'cond': {
+                            '$and': [
+                                {'$eq': ['$_VQB_DATE_PREV', f'$$item.{step.date_col}']},
+                                {'$eq': [f'${col}', f'$$item.{col}'] for col in step.index_columns},
+                            ],
+                        },
+                    },
+                },
+            },
+        },
+        {
+            '$addFields': {
+                '_VQB_VALUE_PREV': {
+                    '$cond': [
+                        {'$gt': [{'$size': f'$_VQB_ALL_DOCS.{step.value_col}'}, 1]},
+                        'Error',
+                        {'$arrayElemAt': [f'$_VQB_ALL_DOCS.{step.value_col}', 0]},
+                    ],
+                },
+            },
+        },
+        {'$addFields': add_field_result},
+        {
+            '$project': {
+                '_VQB_ALL_DOCS': 0,
+                '_VQB_DATE_PREV': 0,
+                '_VQB_VALUE_PREV': 0,
+            },
+        },
+    ]

--- a/server/tests/backends/fixtures/evolution/abs_nogroups.json
+++ b/server/tests/backends/fixtures/evolution/abs_nogroups.json
@@ -1,8 +1,7 @@
 {
   "exclude": [
     "mysql",
-    "postgres",
-    "mongo"
+    "postgres"
   ],
   "step": {
     "pipeline": [

--- a/server/tests/backends/fixtures/evolution/perc_groups_mongo.json
+++ b/server/tests/backends/fixtures/evolution/perc_groups_mongo.json
@@ -1,0 +1,113 @@
+{
+  "exclude": [
+    "mysql",
+    "postgres",
+    "snowflake",
+    "pandas"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "evolution",
+        "date_col": "DATE",
+        "value_col": "VALUE",
+        "evolution_type": "vsLastYear",
+        "evolution_format": "pct",
+        "index_columns": [
+          "COUNTRY"
+        ],
+        "new_column": "POUET"
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "DATE",
+          "type": "datetime"
+        },
+        {
+          "name": "VALUE",
+          "type": "number"
+        },
+        {
+          "name": "COUNTRY",
+          "type": "string"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "DATE": "2019-01-01 00:00:01",
+        "VALUE": 2,
+        "COUNTRY": "France"
+      },
+      {
+        "DATE": "2019-01-01 00:00:02",
+        "VALUE": 1,
+        "COUNTRY": "Italy"
+      },
+      {
+        "DATE": "2020-01-01 00:00:01",
+        "VALUE": 4,
+        "COUNTRY": "France"
+      },
+      {
+        "DATE": "2020-01-01 00:00:02",
+        "VALUE": 0.5,
+        "COUNTRY": "Italy"
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "DATE",
+          "type": "datetime"
+        },
+        {
+          "name": "VALUE",
+          "type": "number"
+        },
+        {
+          "name": "COUNTRY",
+          "type": "string"
+        },
+        {
+          "name": "POUET",
+          "type": "number"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "DATE": "2019-01-01 00:00:01",
+        "VALUE": 2,
+        "COUNTRY": "France",
+        "POUET": null
+      },
+      {
+        "DATE": "2019-01-01 00:00:02",
+        "VALUE": 1,
+        "COUNTRY": "Italy",
+        "POUET": null
+      },
+      {
+        "DATE": "2020-01-01 00:00:01",
+        "VALUE": 4,
+        "COUNTRY": "France",
+        "POUET": null
+      },
+      {
+        "DATE": "2020-01-01 00:00:02",
+        "VALUE": 0.5,
+        "COUNTRY": "Italy",
+        "POUET": null
+      }
+    ]
+  }
+}

--- a/server/tests/backends/fixtures/evolution/perc_groups_mongo.json
+++ b/server/tests/backends/fixtures/evolution/perc_groups_mongo.json
@@ -40,22 +40,22 @@
     },
     "data": [
       {
-        "DATE": "2019-01-01 00:00:01",
+        "DATE": "2019-01-01 00:00:00",
         "VALUE": 2,
         "COUNTRY": "France"
       },
       {
-        "DATE": "2019-01-01 00:00:02",
+        "DATE": "2019-01-01 00:00:00",
         "VALUE": 1,
         "COUNTRY": "Italy"
       },
       {
-        "DATE": "2020-01-01 00:00:01",
+        "DATE": "2020-01-01 00:00:00",
         "VALUE": 4,
         "COUNTRY": "France"
       },
       {
-        "DATE": "2020-01-01 00:00:02",
+        "DATE": "2020-01-01 00:00:00",
         "VALUE": 0.5,
         "COUNTRY": "Italy"
       }
@@ -85,28 +85,28 @@
     },
     "data": [
       {
-        "DATE": "2019-01-01 00:00:01",
+        "DATE": "2019-01-01 00:00:00",
         "VALUE": 2,
         "COUNTRY": "France",
         "POUET": null
       },
       {
-        "DATE": "2019-01-01 00:00:02",
+        "DATE": "2019-01-01 00:00:00",
         "VALUE": 1,
         "COUNTRY": "Italy",
         "POUET": null
       },
       {
-        "DATE": "2020-01-01 00:00:01",
+        "DATE": "2020-01-01 00:00:00",
         "VALUE": 4,
         "COUNTRY": "France",
-        "POUET": null
+        "POUET": 1
       },
       {
-        "DATE": "2020-01-01 00:00:02",
+        "DATE": "2020-01-01 00:00:00",
         "VALUE": 0.5,
         "COUNTRY": "Italy",
-        "POUET": null
+        "POUET": -0.5
       }
     ]
   }

--- a/server/tests/backends/fixtures/evolution/perc_nogroups.json
+++ b/server/tests/backends/fixtures/evolution/perc_nogroups.json
@@ -1,8 +1,7 @@
 {
   "exclude": [
     "mysql",
-    "postgres",
-    "mongo"
+    "postgres"
   ],
   "step": {
     "pipeline": [


### PR DESCRIPTION
# What
Implemented the evolution step in python for the mongo-translator, following the logic from `./src/lib/translators/mongo.ts`

⚠️ However am facing a difference behaviour between results from pandas <> mongo when it comes to group, that's why i added a new group fixture only reserved to mongo, not sure if am missing something somewhere or it should behave like that 🤔 .