### PR TITLE
feat(python-mongo-translator): added duplicate step [TCTC-2657]

### DIFF
--- a/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
@@ -9,6 +9,7 @@ from weaverbird.backends.mongo_translator.steps.convert import translate_convert
 from weaverbird.backends.mongo_translator.steps.custom import translate_custom
 from weaverbird.backends.mongo_translator.steps.delete import translate_delete
 from weaverbird.backends.mongo_translator.steps.domain import translate_domain
+from weaverbird.backends.mongo_translator.steps.duplicate import translate_duplicate
 from weaverbird.backends.mongo_translator.steps.fillna import translate_fillna
 from weaverbird.backends.mongo_translator.steps.filter import translate_filter
 from weaverbird.backends.mongo_translator.steps.formula import translate_formula
@@ -45,6 +46,7 @@ mongo_step_translator: Dict[str, Callable[[Any], list]] = {
     'custom': translate_custom,
     'delete': translate_delete,
     'domain': translate_domain,
+    'duplicate': translate_duplicate,
     'fillna': translate_fillna,
     'filter': translate_filter,
     'formula': translate_formula,

--- a/server/src/weaverbird/backends/mongo_translator/steps/duplicate.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/duplicate.py
@@ -1,0 +1,12 @@
+from typing import List
+
+from weaverbird.backends.mongo_translator.steps.types import MongoStep
+from weaverbird.pipeline.steps import DuplicateStep
+
+
+def translate_duplicate(step: DuplicateStep) -> List[MongoStep]:
+    return [
+        {
+            '$addFields': {(step.new_column_name): f'${step.column}'},
+        }
+    ]

--- a/server/tests/backends/fixtures/duplicate/simple.json
+++ b/server/tests/backends/fixtures/duplicate/simple.json
@@ -1,7 +1,6 @@
 {
   "exclude": [
-    "mysql",
-    "mongo"
+    "mysql"
   ],
   "step": {
     "pipeline": [


### PR DESCRIPTION
# What
Implemented the duplicate step in python for the mongo-translator, following the logic from `./src/lib/translators/mongo.ts`