### PR TITLE
fix(backend/pandas_executor): Do not normalize standard deviation and variance in statistics step TCTC-2701

### DIFF
--- a/server/src/weaverbird/backends/pandas_executor/steps/statistics.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/statistics.py
@@ -1,17 +1,19 @@
+from typing import Callable, Union
+
 import numpy as np
-from pandas import DataFrame
+from pandas import DataFrame, Series
 
 from weaverbird.backends.pandas_executor.types import DomainRetriever, PipelineExecutor
 from weaverbird.pipeline.steps.statistics import DUMB_GROUPBY_COLUMN_NAME, StatisticsStep
 
 
-def statistic_to_pandas_method(s: str) -> str:
+def statistic_to_pandas_method(s: str) -> Union[str, Callable[[Series], float]]:
     if s == 'average':
         return 'mean'
     elif s == 'variance':
-        return 'var'
+        return lambda x: x.var(ddof=0)
     elif s == 'standard deviation':
-        return 'std'
+        return lambda x: x.std(ddof=0)
     return s
 
 

--- a/server/tests/backends/fixtures/statistics/all.json
+++ b/server/tests/backends/fixtures/statistics/all.json
@@ -2,8 +2,7 @@
     "exclude": [
         "snowflake",
         "mysql",
-        "postgres",
-        "pandas"
+        "postgres"
     ],
     "step": {
         "pipeline": [
@@ -76,7 +75,7 @@
             }
         ]
     },
-    "expected": {
+    "expected_mongo": {
         "schema": {
             "fields": [
                 {
@@ -140,6 +139,73 @@
                 "standard deviation": 4.7842333648,
                 "median": 5.5,
                 "2-th 3-quantile": 11.0
+            }
+        ]
+    },
+    "expected": {
+        "schema": {
+            "fields": [
+                {
+                    "name": "count",
+                    "type": "integer"
+                },
+                {
+                    "name": "max",
+                    "type": "number"
+                },
+                {
+                    "name": "min",
+                    "type": "number"
+                },
+                {
+                    "name": "average",
+                    "type": "number"
+                },
+                {
+                    "name": "Group",
+                    "type": "string"
+                },
+                {
+                    "name": "variance",
+                    "type": "number"
+                },
+                {
+                    "name": "standard deviation",
+                    "type": "number"
+                },
+                {
+                    "name": "median",
+                    "type": "number"
+                },
+                {
+                    "name": "2-th 3-quantile",
+                    "type": "number"
+                }
+            ],
+            "pandas_version": "0.20.0"
+        },
+        "data": [
+            {
+                "count": 3,
+                "max": 13.0,
+                "min": 5.0,
+                "average": 8.3333333333,
+                "Group": "Group 1",
+                "variance": 11.5555555556,
+                "standard deviation": 3.3993463424,
+                "median": 7.0,
+                "2-th 3-quantile": 8.999999999999998
+            },
+            {
+                "count": 3,
+                "max": 12.0,
+                "min": 1.0,
+                "average": 7.6666666667,
+                "Group": "Group 2",
+                "variance": 22.8888888889,
+                "standard deviation": 4.7842333648,
+                "median": 10.0,
+                "2-th 3-quantile": 10.666666666666666
             }
         ]
     }


### PR DESCRIPTION
By default, pandas normalizes 'var' and 'std' by 1, which is unexpected behaviour and
inconsistent with mongo. This fixes this behaviour.

closes #1323

Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>