### PR TITLE
feat(python-mongo-translator): comparetext step [TCTC-2695]

### DIFF
--- a/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/__init__.py
@@ -5,6 +5,7 @@ from weaverbird.backends.mongo_translator.steps.aggregate import translate_aggre
 from weaverbird.backends.mongo_translator.steps.append import translate_append
 from weaverbird.backends.mongo_translator.steps.argmax import translate_argmax
 from weaverbird.backends.mongo_translator.steps.argmin import translate_argmin
+from weaverbird.backends.mongo_translator.steps.comparetext import translate_comparetext
 from weaverbird.backends.mongo_translator.steps.concatenate import translate_concatenate
 from weaverbird.backends.mongo_translator.steps.convert import translate_convert
 from weaverbird.backends.mongo_translator.steps.cumsum import translate_cumsum
@@ -51,6 +52,7 @@ mongo_step_translator: Dict[str, Callable[[Any], list]] = {
     'append': translate_append,
     'argmax': translate_argmax,
     'argmin': translate_argmin,
+    'comparetext': translate_comparetext,
     'concatenate': translate_concatenate,
     'convert': translate_convert,
     'cumsum': translate_cumsum,

--- a/server/src/weaverbird/backends/mongo_translator/steps/comparetext.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/comparetext.py
@@ -1,0 +1,16 @@
+from typing import List
+
+from weaverbird.backends.mongo_translator.steps.types import MongoStep
+from weaverbird.pipeline.steps import CompareTextStep
+
+
+def translate_comparetext(step: CompareTextStep) -> List[MongoStep]:
+    return [
+        {
+            '$addFields': {
+                (step.new_column_name): {
+                    '$cond': [{'$eq': [f'${step.str_col_1}', f'${step.str_col_2}']}, True, False],
+                }
+            }
+        }
+    ]

--- a/server/tests/backends/fixtures/comparetext/simple.json
+++ b/server/tests/backends/fixtures/comparetext/simple.json
@@ -2,8 +2,7 @@
   "exclude": [
     "mysql",
     "snowflake",
-    "postgres",
-    "mongo"
+    "postgres"
   ],
   "step": {
     "pipeline": [


### PR DESCRIPTION
# What
Implemented the comparetext step in python for the mongo-translator, following the logic from `./src/lib/translators/mongo.ts`