### PR TITLE
feat(python-mongo-translator): new dataset to test the waterfall step on the playground [TCTC-2695]

### DIFF
--- a/playground/datastore/revenue-product-dataset.json
+++ b/playground/datastore/revenue-product-dataset.json
@@ -1,0 +1,141 @@
+{
+    "schema": {
+      "fields": [
+        {
+          "name": "CITY",
+          "type": "string"
+        },
+        {
+          "name": "COUNTRY",
+          "type": "string"
+        },
+        {
+          "name": "PRODUCT",
+          "type": "string"
+        },
+        {
+          "name": "YEAR",
+          "type": "integer"
+        },
+        {
+          "name": "REVENUE",
+          "type": "integer"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "CITY": "Bordeaux",
+        "COUNTRY": "France",
+        "PRODUCT": "product1",
+        "YEAR": 2019,
+        "REVENUE": 65
+      },
+      {
+        "CITY": "Bordeaux",
+        "COUNTRY": "France",
+        "PRODUCT": "product2",
+        "YEAR": 2019,
+        "REVENUE": 70
+      },
+      {
+        "CITY": "Paris",
+        "COUNTRY": "France",
+        "PRODUCT": "product1",
+        "YEAR": 2019,
+        "REVENUE": 210
+      },
+      {
+        "CITY": "Paris",
+        "COUNTRY": "France",
+        "PRODUCT": "product2",
+        "YEAR": 2019,
+        "REVENUE": 240
+      },
+      {
+        "CITY": "Boston",
+        "COUNTRY": "USA",
+        "PRODUCT": "product1",
+        "YEAR": 2019,
+        "REVENUE": 130
+      },
+      {
+        "CITY": "Boston",
+        "COUNTRY": "USA",
+        "PRODUCT": "product2",
+        "YEAR": 2019,
+        "REVENUE": 145
+      },
+      {
+        "CITY": "New-York",
+        "COUNTRY": "USA",
+        "PRODUCT": "product1",
+        "YEAR": 2019,
+        "REVENUE": 55
+      },
+      {
+        "CITY": "New-York",
+        "COUNTRY": "USA",
+        "PRODUCT": "product2",
+        "YEAR": 2019,
+        "REVENUE": 60
+      },
+      {
+        "CITY": "Bordeaux",
+        "COUNTRY": "France",
+        "PRODUCT": "product1",
+        "YEAR": 2018,
+        "REVENUE": 38
+      },
+      {
+        "CITY": "Bordeaux",
+        "COUNTRY": "France",
+        "PRODUCT": "product2",
+        "YEAR": 2018,
+        "REVENUE": 60
+      },
+      {
+        "CITY": "Paris",
+        "COUNTRY": "France",
+        "PRODUCT": "product1",
+        "YEAR": 2018,
+        "REVENUE": 175
+      },
+      {
+        "CITY": "Paris",
+        "COUNTRY": "France",
+        "PRODUCT": "product2",
+        "YEAR": 2018,
+        "REVENUE": 210
+      },
+      {
+        "CITY": "Boston",
+        "COUNTRY": "USA",
+        "PRODUCT": "product1",
+        "YEAR": 2018,
+        "REVENUE": 95
+      },
+      {
+        "CITY": "Boston",
+        "COUNTRY": "USA",
+        "PRODUCT": "product2",
+        "YEAR": 2018,
+        "REVENUE": 150
+      },
+      {
+        "CITY": "New-York",
+        "COUNTRY": "USA",
+        "PRODUCT": "product1",
+        "YEAR": 2018,
+        "REVENUE": 50
+      },
+      {
+        "CITY": "New-York",
+        "COUNTRY": "USA",
+        "PRODUCT": "product2",
+        "YEAR": 2018,
+        "REVENUE": 53
+      }
+    ]
+}

--- a/playground/init-mongo/01-import-files.sh
+++ b/playground/init-mongo/01-import-files.sh
@@ -10,3 +10,5 @@ mongoimport --db playground_data --collection sin-from-2019-to-2022 --drop \
 mongoimport --db playground_data --collection november-2021-hours --drop \
     --type=json --file /datasources/november-2021-hours.json
 
+mongoimport --db playground_data --collection revenue-product-dataset --drop \
+    --type=json --file /datasources/revenue-product-dataset.json

--- a/playground/init-mongo/02-adjust-types.js
+++ b/playground/init-mongo/02-adjust-types.js
@@ -35,3 +35,15 @@ db['november-2021-hours'].find().forEach(function(d) {
     }
   })
 });
+
+
+const revenueProductDatasetTableSchema = db['revenue-product-dataset'].find()[0];
+db['revenue-product-dataset'].insert(revenueProductDatasetTableSchema.data);
+db['revenue-product-dataset'].remove({_id: revenueProductDatasetTableSchema._id});
+db['revenue-product-dataset'].find().forEach(function(d) {
+  db['revenue-product-dataset'].update({_id: d._id}, {
+    $set: {
+      date: new Date(d.date),
+    }
+  })
+});


### PR DESCRIPTION
# WHAT
Just added a good dataset to be able to well test the waterfall Step on python mongo translator

![Screenshot from 2022-05-09 17-02-14](https://user-images.githubusercontent.com/22576758/167439534-71add7ff-a316-4e30-a96b-2008cc7e129f.png)
![Screenshot from 2022-05-09 17-04-57](https://user-images.githubusercontent.com/22576758/167439527-1717df3a-bfbd-4f9b-9bdb-ee9530e9f84c.png)


PS: this new dataset is comming from a fixture `waterfall/with_groups.json` **AND**, i converted the YEAR column to text first for the waterfall to work !
