### PR TITLE
fix(playground): mongo dockerfile was removed

### DIFF
--- a/playground/Dockerfile-mongo
+++ b/playground/Dockerfile-mongo
@@ -1,0 +1,8 @@
+FROM mongo:5
+
+ADD ./datastore /datasources
+
+# Import data from datastore/ into the database
+ENV MONGO_INITDB_DATABASE=playground_data
+ADD ./init-mongo/01-import-files.sh /docker-entrypoint-initdb.d/01-import-files.sh
+ADD ./init-mongo/02-adjust-types.js /docker-entrypoint-initdb.d/02-adjust-types.js


### PR DESCRIPTION
## What
Fix weaverbird render for the mongo-playground
![Screenshot from 2022-05-09 17-59-13](https://user-images.githubusercontent.com/22576758/167450170-1bbce6fc-d18e-4c79-befb-4538c52754af.png)
![Screenshot from 2022-05-09 17-59-49](https://user-images.githubusercontent.com/22576758/167450195-fb2ab6fb-7c20-4001-b6a2-01d7b2089ade.png)

Failing history on deployment...
![Screenshot from 2022-05-09 18-03-29](https://user-images.githubusercontent.com/22576758/167450690-64f1b27b-681c-49b2-bbf9-c1a8758b7390.png)

⚠️ Due to the workflow, it will be deployed after a merge on master !