### PR TITLE
fix(variables): use date with hours in variables label display and titles [TCTC-2718]

### DIFF
--- a/src/components/stepforms/widgets/VariableInputs/VariableListOption.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableListOption.vue
@@ -50,7 +50,7 @@ export default class VariableListOption extends Vue {
   showOnlyLabel!: boolean;
 
   get formattedValue(): string {
-    return this.value instanceof Date ? this.value.toString() : this.value;
+    return this.value instanceof Date ? this.value.toDateString() : this.value;
   }
 
   get readableValue(): string {

--- a/src/components/stepforms/widgets/VariableInputs/VariableTag.vue
+++ b/src/components/stepforms/widgets/VariableInputs/VariableTag.vue
@@ -103,6 +103,7 @@ export default class VariableTag extends Vue {
    */
   get variableValue() {
     const value = this.variable?.value || '';
+    if (value instanceof Date) return value.toDateString();
     return Array.isArray(value) ? value.join(', ') : value;
   }
 

--- a/tests/unit/variable-list-option.spec.ts
+++ b/tests/unit/variable-list-option.spec.ts
@@ -65,7 +65,7 @@ describe('Variable List option', () => {
     });
     it('should display date value with default toString', () => {
       expect(wrapper.find('.widget-variable-option__value').text()).toBe(
-        new Date(1623398957013).toString(),
+        new Date(1623398957013).toDateString(),
       );
     });
   });
@@ -119,7 +119,7 @@ describe('Variable List option', () => {
       {
         type: 'date',
         value: new Date(1623398957013),
-        attendedValue: `"${new Date(1623398957013).toString()}"`,
+        attendedValue: `"${new Date(1623398957013).toDateString()}"`,
       },
     ].forEach(
       ({ type, value, attendedValue }: { type: string; value: any; attendedValue: any }) => {


### PR DESCRIPTION
Display the dates variables without hours (not needed always at 00:00)
Before:
![before](https://user-images.githubusercontent.com/59559689/169492831-64641aa0-9d08-4efe-a7fa-210bd1042d45.png)

After:
![after](https://user-images.githubusercontent.com/59559689/169492847-24dc38de-d94a-4b32-83db-565d4f4066c7.png)