### PR TITLE
chore(server): handle cumsum legacy syntax aliases

### DIFF
--- a/server/setup.cfg
+++ b/server/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = weaverbird
-version = 0.12.0
+version = 0.12.1
 
 [options]
 package_dir =

--- a/server/src/weaverbird/pipeline/steps/cumsum.py
+++ b/server/src/weaverbird/pipeline/steps/cumsum.py
@@ -15,6 +15,11 @@ class CumSumStep(BaseStep):
 
     @root_validator(pre=True)
     def handle_legacy_syntax(cls, values):
+        if 'valueColumn' in values:
+            values['value_column'] = values.pop('valueColumn')
+        if 'newColumn' in values:
+            values['new_column'] = values.pop('newColumn')
+
         if 'value_column' in values:
             values['to_cumsum'] = [(values.pop('value_column'), values.pop('new_column', None))]
         return values

--- a/server/tests/steps/test_cumsum.py
+++ b/server/tests/steps/test_cumsum.py
@@ -1,7 +1,17 @@
 from pandas import DataFrame
 
+from tests.utils import assert_dataframes_equals
 from weaverbird.backends.pandas_executor.steps.cumsum import execute_cumsum
 from weaverbird.pipeline.steps import CumSumStep
+
+
+def test_cumsum_legacy_syntax():
+    df = DataFrame({'x': [1, 2, 3], 'date': ['2020', '2021', '2022']})
+    step = CumSumStep(name='cumsum', referenceColumn='date', valueColumn='x', newColumn='y')  # type: ignore
+    df_result = execute_cumsum(step, df)
+
+    expected_result = DataFrame({'x': [1, 2, 3], 'y': [1, 3, 6], 'date': ['2020', '2021', '2022']})
+    assert_dataframes_equals(df_result, expected_result)
 
 
 def test_benchmark_cumsum_legacy_syntax(benchmark):


### PR DESCRIPTION
We need to handle `valueColumn` as well as `value_column` for cumsum step.