### PR TITLE
fix(mongo): remove $expr wrapping for ifthenelse condtions  TCTC-2118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog (weaverbird npm package)
 
+## [0.83.1] - 2022-05-27
+
+### Fixed
+- Fix ifthenelse step with date conditions
+
 ## [0.83.0] - 2022-05-24
 
 ### Changed
@@ -1236,6 +1241,7 @@ TabbedRangeCalendars: keep selected tab unchanged when updated enabled calendars
 
 ## Unreleased
 
+[0.83.1]: https://github.com/ToucanToco/weaverbird/compare/v0.83.1...v0.83.0
 [0.83.0]: https://github.com/ToucanToco/weaverbird/compare/v0.83.0...v0.82.3
 [0.82.3]: https://github.com/ToucanToco/weaverbird/compare/v0.82.3...v0.82.2
 [0.82.2]: https://github.com/ToucanToco/weaverbird/compare/v0.82.1...v0.82.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.83.0",
+  "version": "0.83.1",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
     "url": "https://github.com/ToucanToco/weaverbird/issues",

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog (weaverbird python package)
 
+## [0.12.2] - 2022-05-27
+
+- Fix ifthenelse step with date conditions
+
 ## [0.12.1] - 2022-05-24
 
 - Fix: handle cumsum legacy syntax aliases

--- a/server/setup.cfg
+++ b/server/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = weaverbird
-version = 0.12.1
+version = 0.12.2
 
 [options]
 package_dir =

--- a/server/src/weaverbird/backends/mongo_translator/utils.py
+++ b/server/src/weaverbird/backends/mongo_translator/utils.py
@@ -83,16 +83,14 @@ def build_dates_expressions(
             ]
     if cond.operator == 'from' or cond.operator == 'until':
         cond_expression = {
-            '$expr': {
-                operator_mapping[cond.operator]: [
-                    truncate_to_day(f'${cond.column}'),
-                    truncate_to_day(
-                        translate_relative_date(cond.value)
-                        if isinstance(cond.value, RelativeDate)
-                        else cond.value
-                    ),
-                ]
-            }
+            operator_mapping[cond.operator]: [
+                truncate_to_day(f'${cond.column}'),
+                truncate_to_day(
+                    translate_relative_date(cond.value)
+                    if isinstance(cond.value, RelativeDate)
+                    else cond.value
+                ),
+            ]
         }
     return cond_expression
 

--- a/server/tests/backends/fixtures/ifthenelse/dates-conditions.json
+++ b/server/tests/backends/fixtures/ifthenelse/dates-conditions.json
@@ -1,0 +1,78 @@
+{
+  "exclude": [
+    "mysql",
+    "postgres",
+    "snowflake"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "ifthenelse",
+        "newColumn": "BEFOREMARCH",
+        "if": {
+          "column": "DATE",
+          "operator": "until",
+          "value": "date: 2022-03-01 00:00:00"
+        },
+        "then": "True",
+        "else": "False"
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "NAME",
+          "type": "string"
+        },
+        {
+          "name": "DATE",
+          "type": "datetime"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "NAME": "foo",
+        "DATE": "2022-05-27 00:00:00"
+      },
+      {
+        "NAME": "bar",
+        "DATE": "2022-01-01 00:00:00"
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "NAME",
+          "type": "string"
+        },
+        {
+          "name": "DATE",
+          "type": "datetime"
+        },
+        {
+          "name": "BEFOREMARCH",
+          "type": "boolean"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "NAME": "foo",
+        "DATE": "2022-05-27 00:00:00",
+        "BEFOREMARCH": false
+      },
+      {
+        "NAME": "bar",
+        "DATE": "2022-01-01 00:00:00",
+        "BEFOREMARCH": true
+      }
+    ]
+  }
+}

--- a/server/tests/utils.py
+++ b/server/tests/utils.py
@@ -91,7 +91,7 @@ def get_spec_from_json_fixture(case_id: str, case_spec_file_path: str) -> dict:
     spec_file = open(case_spec_file_path, 'r')
 
     # if it's a date type step like the filter on date
-    if 'filter_' in case_id and 'date' in case_id:
+    if 'date' in case_id:
 
         def _datetime_parser(dct):
             for k, v in dct.items():

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 # sonar.projectName=weaverbird
-sonar.projectVersion=0.83.0
+sonar.projectVersion=0.83.1
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./src

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -2188,18 +2188,14 @@ export class Mongo36Translator extends BaseTranslator {
           }
         }
 
-        // $dateAdd operators are aggregation operators, so they can't be used directly in $match steps
-        // They need to be used with $expr
         if (cond.operator === 'from' || cond.operator === 'until') {
           return {
-            $expr: {
-              [operatorMapping[cond.operator]]: [
-                this.truncateDateToDay($$(cond.column)),
-                this.truncateDateToDay(
-                  isRelativeDate(cond.value) ? this.translateRelativeDate(cond.value) : cond.value,
-                ),
-              ],
-            },
+            [operatorMapping[cond.operator]]: [
+              this.truncateDateToDay($$(cond.column)),
+              this.truncateDateToDay(
+                isRelativeDate(cond.value) ? this.translateRelativeDate(cond.value) : cond.value,
+              ),
+            ],
           };
         }
 

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -4579,46 +4579,42 @@ describe.each(['36', '40', '42', '50'])(`Mongo %s translator`, version => {
               if: {
                 $and: [
                   {
-                    $expr: {
-                      $gte:
-                        version >= '5'
-                          ? [
-                              {
-                                $dateTrunc: {
-                                  date: '$DATE_FROM',
-                                  unit: 'day',
-                                },
+                    $gte:
+                      version >= '5'
+                        ? [
+                            {
+                              $dateTrunc: {
+                                date: '$DATE_FROM',
+                                unit: 'day',
                               },
-                              {
-                                $dateTrunc: {
-                                  date: new Date('2021-08-08T00:00:00.000Z'),
-                                  unit: 'day',
-                                },
+                            },
+                            {
+                              $dateTrunc: {
+                                date: new Date('2021-08-08T00:00:00.000Z'),
+                                unit: 'day',
                               },
-                            ]
-                          : ['$DATE_FROM', new Date('2021-08-08T00:00:00.000Z')],
-                    },
+                            },
+                          ]
+                        : ['$DATE_FROM', new Date('2021-08-08T00:00:00.000Z')],
                   },
                   {
-                    $expr: {
-                      $lte:
-                        version >= '5'
-                          ? [
-                              {
-                                $dateTrunc: {
-                                  date: '$DATE_UNTIL',
-                                  unit: 'day',
-                                },
+                    $lte:
+                      version >= '5'
+                        ? [
+                            {
+                              $dateTrunc: {
+                                date: '$DATE_UNTIL',
+                                unit: 'day',
                               },
-                              {
-                                $dateTrunc: {
-                                  date: new Date('2021-11-24T23:59:59.999Z'),
-                                  unit: 'day',
-                                },
+                            },
+                            {
+                              $dateTrunc: {
+                                date: new Date('2021-11-24T23:59:59.999Z'),
+                                unit: 'day',
                               },
-                            ]
-                          : ['$DATE_UNTIL', new Date('2021-11-24T23:59:59.999Z')],
-                    },
+                            },
+                          ]
+                        : ['$DATE_UNTIL', new Date('2021-11-24T23:59:59.999Z')],
                   },
                 ],
               },


### PR DESCRIPTION
$match and $cond doesn't function extacly the same way: $cond takes an
expression while $match only a filter. Therefore, in $match, we need to
wrap some stuff with $expr, but not with $cond.

Added a fixture to test this behavior for mongo and pandas backends