### PR TITLE
chore: bump weaverbird from 0.12.2 to 0.12.3

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog (weaverbird python package)
 
+## [0.12.3] - 2022-06-02
+
+- Added logs for each step under pandas executor
+
 ## [0.12.2] - 2022-05-27
 
 - Fix ifthenelse step with date conditions

--- a/server/setup.cfg
+++ b/server/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = weaverbird
-version = 0.12.2
+version = 0.12.3
 
 [options]
 package_dir =


### PR DESCRIPTION
## WHAT

- minor bump for logs on each pandas step 