### PR TITLE
feat(pandas): delete step should not fail on non-existing cols

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog (weaverbird python package)
 
+## Unreleased
+
+- Fix: stop failing when deleting a non-existing columns
+
 ## [0.13.0] - 2022-06-13
 
 - Move to poetry for dependency management

--- a/server/src/weaverbird/backends/pandas_executor/steps/delete.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/delete.py
@@ -10,4 +10,4 @@ def execute_delete(
     domain_retriever: DomainRetriever = None,
     execute_pipeline: PipelineExecutor = None,
 ) -> DataFrame:
-    return df.drop([c for c in step.columns if c in df.column.names], axis=1)
+    return df.drop(step.columns, axis=1, errors='ignore')

--- a/server/src/weaverbird/backends/pandas_executor/steps/delete.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/delete.py
@@ -10,4 +10,4 @@ def execute_delete(
     domain_retriever: DomainRetriever = None,
     execute_pipeline: PipelineExecutor = None,
 ) -> DataFrame:
-    return df.drop(step.columns, axis=1)
+    return df.drop([c for c in step.columns if c in df.column.names], axis=1)

--- a/server/src/weaverbird/backends/sql_translator/metadata.py
+++ b/server/src/weaverbird/backends/sql_translator/metadata.py
@@ -164,9 +164,9 @@ class TableMetadata(BaseModel):
 
     def remove_column(self, column_name: str) -> None:
         c_name = column_name.upper()
-        if c_name not in self.columns:
-            raise MetadataError(f'Error to delete column {c_name}({column_name}), column not exist')
-        self.columns[c_name].remove()
+        if c_name in self.columns:
+            self.columns[c_name].remove()
+        # else warn that column does not exist
 
     def remove_columns(self, columns_name: List[str]) -> int:
         i = 0

--- a/server/tests/backends/fixtures/delete/non_existing_column.json
+++ b/server/tests/backends/fixtures/delete/non_existing_column.json
@@ -1,0 +1,55 @@
+{
+  "description": "it should not fail when deleting a column that does not exist in the dataset",
+  "exclude": [
+    "mysql"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "delete",
+        "columns": [
+          "NAME",
+          "SCORE"
+        ]
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "VALUE",
+          "type": "integer"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "VALUE": 42
+      },
+      {
+        "VALUE": 43
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "VALUE",
+          "type": "integer"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "VALUE": 42
+      },
+      {
+        "VALUE": 43
+      }
+    ]
+  }
+}

--- a/server/tests/backends/sql_translator/test_metadata.py
+++ b/server/tests/backends/sql_translator/test_metadata.py
@@ -91,8 +91,8 @@ def test_remove_column_table_not_exist(sql_query_metadata):
 
 
 def test_remove_column_column_not_exist(sql_query_metadata):
-    with pytest.raises(MetadataError):
-        sql_query_metadata.remove_table_column('table_1', 'column_not_exist')
+    # Should not raise
+    sql_query_metadata.remove_table_column('table_1', 'column_not_exist')
 
 
 def test_remove_column(sql_query_metadata):

--- a/server/tests/steps/sql_translator/test_delete.py
+++ b/server/tests/steps/sql_translator/test_delete.py
@@ -1,6 +1,3 @@
-import pytest
-
-from weaverbird.backends.sql_translator.metadata import MetadataError
 from weaverbird.backends.sql_translator.steps import translate_delete
 from weaverbird.pipeline.steps import DeleteStep
 
@@ -21,12 +18,16 @@ def test_translate_select(query):
     assert query.query_name == 'DELETE_STEP_1'
 
 
-def test_translate_select_error(query, mocker):
+def test_translate_select_invalid_column(query, mocker):
+    """
+    It should not fail if a column does not exist
+    """
     step = DeleteStep(name='delete', columns=['RAICHU', 'BIDULE'])
 
-    with pytest.raises(MetadataError):
-        translate_delete(
-            step,
-            query,
-            index=1,
-        )
+    query = translate_delete(
+        step,
+        query,
+        index=1,
+    )
+    assert 'BIDULE' not in query.selection_query
+    assert 'RAICHU' not in query.selection_query

--- a/server/tests/test_pipeline_executor.py
+++ b/server/tests/test_pipeline_executor.py
@@ -143,16 +143,15 @@ def test_errors(pipeline_executor):
                 steps=[
                     {'name': 'domain', 'domain': 'domain_a'},
                     {
-                        'name': 'delete',
-                        'columns': ['columnThatDoesNotExist', 'whatever'],
+                        'name': 'sort',
+                        'columns': [{'column': 'whatever', 'order': 'asc'}],
                     },
                 ]
             )
         )
     exception_message = excinfo.value.message
     assert 'Step #2' in exception_message
-    assert 'delete' in exception_message
-    assert 'columnThatDoesNotExist' in exception_message
+    assert 'sort' in exception_message
     assert 'whatever' in exception_message
     assert excinfo.value.details['index'] == 1
     assert excinfo.value.details['message'] == exception_message


### PR DESCRIPTION
To prevent getting errors in pipelines executed with the pandas backend when unused columns have been deleted.

This should already be the case for mongo and SQL backends. 