### PR TITLE
fix(server/pandas): Fix df_to_geodf

### DIFF
--- a/server/src/weaverbird/backends/pandas_executor/geo_utils.py
+++ b/server/src/weaverbird/backends/pandas_executor/geo_utils.py
@@ -8,8 +8,12 @@ class UnsupportedGeoOperation(Exception):
 
 
 def df_to_geodf(df: pd.DataFrame) -> gpd.GeoDataFrame:
-    if not (isinstance(df, gpd.GeoDataFrame) and hasattr(df, 'geometry')):
-        raise UnsupportedGeoOperation("df must be a GeoDataFrame and 'geometry' must be set")
+    if not (isinstance(df, pd.DataFrame) and hasattr(df, 'geometry')):
+        raise UnsupportedGeoOperation("df must be a DataFrame and 'geometry' must be set")
+
+    # Checking this second because we can have a GeoDataFrame without geometry
+    if isinstance(df, gpd.GeoDataFrame):
+        return df
 
     try:
         return gpd.GeoDataFrame(df)

--- a/server/src/weaverbird/backends/pandas_executor/steps/dissolve.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/dissolve.py
@@ -29,7 +29,6 @@ def execute_dissolve(
     domain_retriever: DomainRetriever = None,
     execute_pipeline: PipelineExecutor = None,
 ) -> DataFrame:
-
     return DataFrame(
         df_to_geodf(df).dissolve(
             by=step.groups,

--- a/server/tests/backends/pandas_executor/test_pandas_executor_steps.py
+++ b/server/tests/backends/pandas_executor/test_pandas_executor_steps.py
@@ -16,8 +16,8 @@ def test_pandas_execute_pipeline(case_id, case_spec_file_path):
     spec = get_spec_from_json_fixture(case_id, case_spec_file_path)
 
     if spec['input'].get('schema') == 'geojson':
-        df_in = gpd.read_file(json.dumps(spec['input']['data']))
-        df_out = gpd.read_file(json.dumps(spec['expected']))
+        df_in = pd.DataFrame(gpd.read_file(json.dumps(spec['input']['data'])))
+        df_out = pd.DataFrame(gpd.read_file(json.dumps(spec['expected'])))
     else:
         df_in = pd.read_json(json.dumps(spec['input']), orient='table')
         df_out = pd.read_json(json.dumps(spec['expected']), orient='table')


### PR DESCRIPTION
Since the contract of steps is to receive and emit DataFrames (and not GeoDataFrames),
fix the df_to_geodf method. Also update the pandas executor tests to provide a DataFrame rather
than a GeoDataFrame in case a geo step is tested.

Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>