### PR TITLE
refactor(server/pandas/dissolve): Allow to use dissolve without aggregations

### DIFF
--- a/server/src/weaverbird/backends/pandas_executor/steps/dissolve.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/dissolve.py
@@ -29,10 +29,18 @@ def execute_dissolve(
     domain_retriever: DomainRetriever = None,
     execute_pipeline: PipelineExecutor = None,
 ) -> DataFrame:
+    if len(step.aggregations) > 0:
+        aggfunc: dict[str, Any] | str = _translate_agg_func(step.aggregations)
+        geo_df = df_to_geodf(df)
+    else:
+        aggfunc = 'first'  # placeholder, can't be None
+        columns_to_keep = set(step.groups + ['geometry'])
+        geo_df = df_to_geodf(df).drop(list(set(df.columns) - columns_to_keep), axis=1)
+
     return DataFrame(
-        df_to_geodf(df).dissolve(
+        geo_df.dissolve(
             by=step.groups,
-            aggfunc=_translate_agg_func(step.aggregations),
+            aggfunc=aggfunc,
             as_index=False,
             dropna=not step.include_nulls,
         )

--- a/server/src/weaverbird/pipeline/steps/dissolve.py
+++ b/server/src/weaverbird/pipeline/steps/dissolve.py
@@ -12,7 +12,7 @@ from .aggregate import Aggregation
 class DissolveStep(BaseStep):
     name: Literal['dissolve'] = 'dissolve'
     groups: list[ColumnName]
-    aggregations: list[Aggregation]
+    aggregations: list[Aggregation] = []
     include_nulls: bool = False
 
     @staticmethod
@@ -20,13 +20,16 @@ class DissolveStep(BaseStep):
         assert all(len(v) for v in values), f"all values in '{col_name}' must be non-empty"
         assert len(values) == len(set(values)), f"all values in '{col_name}' must be unique"
 
-    @validator('aggregations', 'groups')
+    @validator('groups')
     def _len_validator(cls, values: list) -> list:
         assert len(values) > 0, "list must contain at least one element"
         return values
 
     @validator('aggregations')
     def _validate_aggregations(cls, values: list[Aggregation]) -> list[Aggregation]:
+        if len(values) < 1:
+            return values
+
         for agg in values:
             assert len(agg.columns) == 1, "aggregations can only contain a single column"
             assert len(agg.new_columns) == 1, "aggregations can only contain a single new column"

--- a/server/tests/backends/fixtures/dissolve/pandas_no_aggs.json
+++ b/server/tests/backends/fixtures/dissolve/pandas_no_aggs.json
@@ -1,0 +1,247 @@
+{
+  "exclude": [
+    "mysql",
+    "postgres",
+    "snowflake",
+    "mongo"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "dissolve",
+        "groups": [
+          "country"
+        ],
+        "include_nulls": true
+      }
+    ]
+  },
+  "input": {
+    "schema": "geojson",
+    "data": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {
+            "country": "france",
+            "inhabitants": 5000,
+            "region": "occitanie"
+          },
+          "geometry": {
+            "type": "LineString",
+            "coordinates": [
+              [
+                -0.230712890625,
+                42.88401467044253
+              ],
+              [
+                -0.274658203125,
+                43.92163712834673
+              ],
+              [
+                1.549072265625,
+                45.034714778688624
+              ]
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "properties": {
+            "country": "spain",
+            "inhabitants": 15000,
+            "region": "north_east"
+          },
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  -1.571044921875,
+                  42.956422511073335
+                ],
+                [
+                  -3.7353515625,
+                  40.730608477796636
+                ],
+                [
+                  -0.406494140625,
+                  39.59722324495565
+                ]
+              ]
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "properties": {
+            "country": "france",
+            "inhabitants": 500,
+            "region": "monaco"
+          },
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  -5.306396484375,
+                  46.837649560937464
+                ],
+                [
+                  -0.670166015625,
+                  46.837649560937464
+                ],
+                [
+                  -0.670166015625,
+                  49.095452162534826
+                ]
+              ]
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "properties": {
+            "country": null,
+            "inhabitants": 300,
+            "region": "andorre"
+          },
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  42.424242,
+                  46.464646
+                ],
+                [
+                  46.464646,
+                  -0.1337
+                ],
+                [
+                  -0.1337,
+                  42.424242
+                ]
+              ]
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "expected": {
+    "schema": "geojson",
+    "data": {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "properties": {
+            "country": "france"
+          },
+          "geometry": {
+            "type": "GeometryCollection",
+            "geometries": [
+              {
+                "type": "LineString",
+                "coordinates": [
+                  [
+                    -0.230712890625,
+                    42.88401467044253
+                  ],
+                  [
+                    -0.274658203125,
+                    43.92163712834673
+                  ],
+                  [
+                    1.549072265625,
+                    45.034714778688624
+                  ]
+                ]
+              },
+              {
+                "type": "Polygon",
+                "coordinates": [
+                  [
+                    [
+                      -5.306396484375,
+                      46.837649560937464
+                    ],
+                    [
+                      -0.670166015625,
+                      46.837649560937464
+                    ],
+                    [
+                      -0.670166015625,
+                      49.095452162534826
+                    ],
+                    [
+                      -5.306396484375,
+                      46.837649560937464
+                    ]
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "properties": {
+            "country": "spain"
+          },
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  -1.571044921875,
+                  42.956422511073335
+                ],
+                [
+                  -3.7353515625,
+                  40.730608477796636
+                ],
+                [
+                  -0.406494140625,
+                  39.59722324495565
+                ],
+                [
+                  -1.571044921875,
+                  42.956422511073335
+                ]
+              ]
+            ]
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  42.424242,
+                  46.464646
+                ],
+                [
+                  46.464646,
+                  -0.1337
+                ],
+                [
+                  -0.1337,
+                  42.424242
+                ],
+                [
+                  42.424242,
+                  46.464646
+                ]
+              ]
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
In case one want to dissolve without aggregations, all columns which aren't a group nor the 'geometry'
column are dropped.

Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>