### PR TITLE
chore: pypika translate typing

### DIFF
--- a/server/src/weaverbird/backends/pypika_translator/translate.py
+++ b/server/src/weaverbird/backends/pypika_translator/translate.py
@@ -2,7 +2,7 @@ from typing import Mapping, Sequence
 
 from weaverbird.backends.pypika_translator.dialects import SQLDialect
 from weaverbird.backends.pypika_translator.translators import ALL_TRANSLATORS
-from weaverbird.pipeline import PipelineWithVariables
+from weaverbird.pipeline import Pipeline
 
 
 def translate_pipeline(

--- a/server/src/weaverbird/backends/pypika_translator/translate.py
+++ b/server/src/weaverbird/backends/pypika_translator/translate.py
@@ -8,7 +8,7 @@ from weaverbird.pipeline import PipelineWithVariables
 def translate_pipeline(
     *,
     sql_dialect: SQLDialect,
-    pipeline: PipelineWithVariables,
+    pipeline: Pipeline,
     tables_columns: Mapping[str, Sequence[str]],
     db_schema: str | None = None,
 ) -> str:


### PR DESCRIPTION
I think we should have a `Pipeline` type instead of `PipelineWithVariables` in `pypika_translator`'s `translate_pipeline` method as we expect the `pipeline` to be rendered when translating the query. 