### PR TITLE
chore: rename postgres dialect

### DIFF
--- a/server/src/weaverbird/backends/pypika_translator/dialects.py
+++ b/server/src/weaverbird/backends/pypika_translator/dialects.py
@@ -5,6 +5,6 @@ class SQLDialect(str, Enum):
     ATHENA = "athena"
     GOOGLEBIGQUERY = "googlebigquery"
     MYSQL = "mysql"
-    POSTGRESQL = "postgresql"
+    POSTGRES = "postgres"
     REDSHIFT = "redshift"
     SNOWFLAKE = "snowflake"

--- a/server/src/weaverbird/backends/pypika_translator/translators/postgresql.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/postgresql.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 class PostgreSQLTranslator(SQLTranslator):
-    DIALECT = SQLDialect.POSTGRESQL
+    DIALECT = SQLDialect.POSTGRES
     QUERY_CLS = PostgreSQLQuery
     DATA_TYPE_MAPPING = DataTypeMapping(
         boolean="BOOLEAN",

--- a/server/tests/backends/sql_translator/test_sql_postgres_pypika_translator_steps.py
+++ b/server/tests/backends/sql_translator/test_sql_postgres_pypika_translator_steps.py
@@ -140,7 +140,7 @@ def test_sql_translator_pipeline(case_id, case_spec_file_path, get_engine):
 
     # Convert Pipeline object to Postgres Query
     query = translate_pipeline(
-        sql_dialect=SQLDialect.POSTGRESQL,
+        sql_dialect=SQLDialect.POSTGRES,
         pipeline=pipeline,
         tables_columns={test_table_name: data_to_insert.columns},
         db_schema=None,


### PR DESCRIPTION
use `postgres` instead of `postgresql` to be consistent with backend