### PR TITLE
chore: enable redshift integration tests

### DIFF
--- a/server/tests/backends/sql_translator_integration_tests/test_sql_redshift_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_redshift_translator_steps.py
@@ -1,10 +1,11 @@
 import json
 from os import environ
+from typing import Any
 
 import pandas as pd
 import pytest
-import redshift_connector
-from redshift_connector.core import Connection
+from sqlalchemy import create_engine
+from sqlalchemy.engine.url import URL
 
 from tests.utils import assert_dataframes_equals, get_spec_from_json_fixture, retrieve_case
 from weaverbird.backends.pypika_translator.dialects import SQLDialect
@@ -21,20 +22,18 @@ _PORT = 5439
 
 
 @pytest.fixture
-def redshift_connection() -> Connection:
-    with redshift_connector.connect(
-        user=_USER,
-        database=_DATABASE,
-        host=_HOST,
-        cluster_identifier=_CLUSTER,
-        password=_PASSWORD,
-        region=_REGION,
-        port=_PORT,
-        ssl=False,
-    ) as connection:
-        connection.autocommit = True
-
-    return connection
+def engine():
+    engine = create_engine(
+        url=URL.create(
+            drivername='redshift+redshift_connector',
+            host=_HOST,
+            port=_PORT,
+            database=_DATABASE,
+            username=_USER,
+            password=_PASSWORD,
+        )
+    )
+    return engine
 
 
 _BEERS_TABLE_COLUMNS = [
@@ -49,13 +48,10 @@ _BEERS_TABLE_COLUMNS = [
 ]
 
 
-@pytest.mark.skip(reason='Currently unable to run it on CI :/')
 @pytest.mark.parametrize(
     'case_id, case_spec_file', retrieve_case('sql_translator', 'redshift_pypika')
 )
-def test_redshift_translator_pipeline(
-    redshift_connection: Connection, case_id: str, case_spec_file: str
-):
+def test_redshift_translator_pipeline(engine: Any, case_id: str, case_spec_file: str):
     pipeline_spec = get_spec_from_json_fixture(case_id, case_spec_file)
 
     steps = [{'name': 'domain', 'domain': 'beers_tiny'}] + pipeline_spec['step']['pipeline']
@@ -65,12 +61,8 @@ def test_redshift_translator_pipeline(
         sql_dialect=SQLDialect.REDSHIFT,
         pipeline=pipeline,
         tables_columns={'beers_tiny': _BEERS_TABLE_COLUMNS},
-        db_schema='beers',
+        db_schema=None,
     )
     expected = pd.read_json(json.dumps(pipeline_spec['expected']), orient='table')
-
-    with redshift_connection.cursor() as cursor:
-        cursor.execute(query)
-        result: pd.DataFrame = cursor.fetch_dataframe()
-
+    result: pd.DataFrame = pd.read_sql(query, engine)
     assert_dataframes_equals(expected, result)


### PR DESCRIPTION
a `beers_tiny` dataset was inserted into the redshift test cluster to be used for integration tests.