### PR TITLE
feat: optimize regex on formula step for edge cases

### DIFF
--- a/server/src/weaverbird/backends/pypika_translator/translators/base.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/base.py
@@ -805,8 +805,8 @@ class SQLTranslator(ABC):
         # TODO : an AST should be implemented here to sanitize the formula
         def _sanitize_formula(formula: str) -> str:
             """
-            This combined regex will :
-                - remove and replace quotes & brackets to the one
+            These combined regexes will :
+                - remove and replace quotes & brackets with the ones
                   corresponding to the translator.
                 - prevent division by zero by adding NULLIF on all division
                   expression.
@@ -822,7 +822,7 @@ class SQLTranslator(ABC):
                 formula,
             )
             # detect and encapsulate / and %
-            if '/' in step.formula:
+            if '/' in formula:
                 formula = re.sub(
                     '((?<=/)\{}?\w+\{}?)|((?<=/)\d+)|((?<=/)\(?.*\)?)'.format(
                         self.QUOTE_CHAR, self.QUOTE_CHAR
@@ -830,7 +830,7 @@ class SQLTranslator(ABC):
                     r' NULLIF(\1\2\3, 0)',
                     formula.replace('/ ', '/'),
                 )
-            if '%' in step.formula:
+            if '%' in formula:
                 formula = re.sub(
                     '((?<=%)\{}?\w+\{}?)|((?<=/)\d+)|((?<=/)\(?.*\)?)'.format(
                         self.QUOTE_CHAR, self.QUOTE_CHAR

--- a/server/tests/backends/fixtures/formula/special_brackets_pypika.json
+++ b/server/tests/backends/fixtures/formula/special_brackets_pypika.json
@@ -11,7 +11,7 @@
       {
         "name": "formula",
         "new_column": "foobar",
-        "formula": " (\"price_per_l\" + [volume_ml]) / 0 "
+        "formula": " 'cost' - (price_per_l / [ cost]) + (`price_per_l` / 0) / (\"price_per_l\" + [ volume_ml  ])"
       },
       {
         "name": "select",


### PR DESCRIPTION
## WHAT

fix the regex on formula step for weird edge cases such as : 
```
 'cost' - (price_per_l / [ cost]) + (`price_per_l` / 0) / ("price_per_l" + [ volume_ml  ])
```

PS :  a work on AST for our formulas is ongoing and this sanitizer may be removed, but for now we need it !