### PR TITLE
feat(domain-step): enable to label domain step with query name when query is referenced behind an uid [TCTC-3100]

### DIFF
--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -130,14 +130,10 @@ export default class Step extends Vue {
     | undefined;
 
   get stepName(): string {
-    if (this.step.name === 'domain') {
-      // enable to retrieve the related name of a query referenced behind an uid
-      return humanReadableLabel(this.step, (domain: string | ReferenceToExternalQuery) =>
-        retrieveDomainName(domain, this.queries),
-      );
-    } else {
-      return humanReadableLabel(this.step);
-    }
+    // enable to retrieve the related name of a query referenced behind an uid
+    return humanReadableLabel(this.step, (domain: string | ReferenceToExternalQuery) =>
+      retrieveDomainName(domain, this.queries),
+    );
   }
 
   get canConfigurePreviewSourceSubset(): boolean {

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -67,8 +67,12 @@ import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 
 import FAIcon from '@/components/FAIcon.vue';
-import { humanReadableLabel, labelWithReadeableVariables } from '@/lib/labeller';
-import { PipelineStep } from '@/lib/steps';
+import {
+  humanReadableLabel,
+  labelWithReadeableVariables,
+  retrieveDomainName,
+} from '@/lib/labeller';
+import { PipelineStep, ReferenceToExternalQuery } from '@/lib/steps';
 import { VariableDelimiters } from '@/lib/variables';
 import { VQBModule } from '@/store';
 
@@ -82,6 +86,8 @@ import PreviewSourceSubset from './PreviewSourceSubset.vue';
   },
 })
 export default class Step extends Vue {
+  @VQBModule.State queries!: { name: string; uid: string }[];
+
   @Prop(Boolean)
   readonly isFirst!: boolean;
 
@@ -124,7 +130,14 @@ export default class Step extends Vue {
     | undefined;
 
   get stepName(): string {
-    return humanReadableLabel(this.step);
+    if (this.step.name === 'domain') {
+      // enable to retrieve the related name of a query referenced behind an uid
+      return humanReadableLabel(this.step, (domain: string | ReferenceToExternalQuery) =>
+        retrieveDomainName(domain, this.queries),
+      );
+    } else {
+      return humanReadableLabel(this.step);
+    }
   }
 
   get canConfigurePreviewSourceSubset(): boolean {

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -210,9 +210,8 @@ class StepLabeller implements StepMatcher<string> {
     return `Dissolve geographical data grouped by ${formatMulticol(step.groups)}`;
   }
 
-  domain(step: Readonly<S.DomainStep>, nameForUid?: Function) {
-    const sourceLabel = nameForUid ? nameForUid(step.domain) : step.domain;
-    return `Source: "${sourceLabel}"`;
+  domain(step: Readonly<S.DomainStep>, retrieveDomainName: Function) {
+    return `Source: "${retrieveDomainName(step.domain)}"`;
   }
 
   duplicate(step: Readonly<S.DuplicateColumnStep>) {
@@ -366,9 +365,12 @@ const LABELLER = new StepLabeller();
  * @param step the step we want to compute a label for
  * @return the human-readable label.
  */
-export function humanReadableLabel(step: S.PipelineStep, nameForUid?: Function) {
-  const transform = LABELLER[step.name] as (step: S.PipelineStep, nameForUid?: Function) => string;
-  return transform(step, nameForUid);
+export function humanReadableLabel(step: S.PipelineStep, retrieveDomainName: Function) {
+  const transform = LABELLER[step.name] as (
+    step: S.PipelineStep,
+    retrieveDomainName: Function,
+  ) => string;
+  return transform(step, retrieveDomainName);
 }
 
 function _replaceAll(str: string, search: string, replace: string) {

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -365,10 +365,10 @@ const LABELLER = new StepLabeller();
  * @param step the step we want to compute a label for
  * @return the human-readable label.
  */
-export function humanReadableLabel(step: S.PipelineStep, retrieveDomainName: Function) {
+export function humanReadableLabel(step: S.PipelineStep, retrieveDomainName?: Function) {
   const transform = LABELLER[step.name] as (
     step: S.PipelineStep,
-    retrieveDomainName: Function,
+    retrieveDomainName?: Function,
   ) => string;
   return transform(step, retrieveDomainName);
 }

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -210,8 +210,8 @@ class StepLabeller implements StepMatcher<string> {
     return `Dissolve geographical data grouped by ${formatMulticol(step.groups)}`;
   }
 
-  domain(step: Readonly<S.DomainStep>, retrieveDomainName: Function) {
-    return `Source: "${retrieveDomainName(step.domain)}"`;
+  domain(step: Readonly<S.DomainStep>, retrieveDomainName?: Function) {
+    return `Source: "${retrieveDomainName!(step.domain)}"`;
   }
 
   duplicate(step: Readonly<S.DuplicateColumnStep>) {

--- a/src/lib/matcher.ts
+++ b/src/lib/matcher.ts
@@ -33,10 +33,7 @@ export type StepByType<A, T> = A extends { name: T } ? A : never;
  * translation function at compile time.
  */
 export type StepMatcher<T> = {
-  [K in PipelineStepName]: (
-    step: Readonly<StepByType<PipelineStep, K>>,
-    retrieveDomainName: Function,
-  ) => T;
+  [K in PipelineStepName]: (step: Readonly<StepByType<PipelineStep, K>>) => T;
 };
 export type TransformStep = (step: Readonly<PipelineStep>) => void;
 

--- a/src/lib/matcher.ts
+++ b/src/lib/matcher.ts
@@ -33,7 +33,10 @@ export type StepByType<A, T> = A extends { name: T } ? A : never;
  * translation function at compile time.
  */
 export type StepMatcher<T> = {
-  [K in PipelineStepName]: (step: Readonly<StepByType<PipelineStep, K>>) => T;
+  [K in PipelineStepName]: (
+    step: Readonly<StepByType<PipelineStep, K>>,
+    retrieveDomainName: Function,
+  ) => T;
 };
 export type TransformStep = (step: Readonly<PipelineStep>) => void;
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -32,6 +32,11 @@ type DomainsMutation = {
   payload: Pick<VQBState, 'domains'>;
 };
 
+type QueriesMutation = {
+  type: 'setQueries';
+  payload: Pick<VQBState, 'queries'>;
+};
+
 type PipelineMutation = {
   type: 'setPipeline';
   payload: { pipeline: Pipeline };
@@ -96,7 +101,8 @@ export type StateMutation =
   | SetPreviewSourceRowsSubset
   | ToggleColumnSelectionMutation
   | ToggleRequestOnGoing
-  | VariableDelimitersMutation;
+  | VariableDelimitersMutation
+  | QueriesMutation;
 
 type MutationByType<M, MT> = M extends { type: MT } ? M : never;
 export type MutationCallbacks = {
@@ -201,6 +207,10 @@ class Mutations {
 
   setDomains(state: VQBState, { domains }: Pick<VQBState, 'domains'>) {
     state.domains = domains;
+  }
+
+  setQueries(state: VQBState, { queries }: Pick<VQBState, 'queries'>) {
+    state.queries = queries;
   }
 
   @resetPagination

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -26,6 +26,7 @@ export interface VQBState {
   interpolateFunc?: InterpolateFunction;
 
   domains: string[];
+  queries: { name: string; uid: string }[];
   pipelines: { [name: string]: Pipeline };
 
   dataset: DataSet; // currently preview one
@@ -81,6 +82,7 @@ export function emptyState(): VQBState {
     },
     rightColumnNames: [],
     domains: [],
+    queries: [],
     currentStepFormName: undefined,
     stepFormInitialValue: undefined,
     stepFormDefaults: undefined,

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -142,17 +142,6 @@ describe('Labeller', () => {
     expect(hrl(step)).toEqual('Source: "the-domain"');
   });
 
-  it('generates label for domain steps that reference other queries', () => {
-    const step: S.DomainStep = {
-      name: 'domain',
-      domain: {
-        type: 'ref',
-        uid: 'xxx-yyy-zzz',
-      },
-    };
-    expect(hrl(step)).toEqual('Source: query xxx-yyy-zzz');
-  });
-
   it('generates label for duplicate steps', () => {
     const step: S.DuplicateColumnStep = {
       name: 'duplicate',

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -1,4 +1,8 @@
-import { humanReadableLabel as hrl, labelWithReadeableVariables as lwv } from '@/lib/labeller';
+import {
+  humanReadableLabel as hrl,
+  labelWithReadeableVariables as lwv,
+  retrieveDomainName,
+} from '@/lib/labeller';
 import * as S from '@/lib/steps';
 import { VariableDelimiters } from '@/lib/variables';
 
@@ -848,6 +852,20 @@ describe('Labeller', () => {
         aggregations: [],
       };
       expect(hrl(step)).toEqual('Dissolve geographical data grouped by "foo", "bar"');
+    });
+  });
+
+  describe('retrieveDomainName', () => {
+    it('return string if domain is a string', () => {
+      expect(retrieveDomainName('plop', [])).toBe('plop');
+    });
+    it('return query name if domain is a reference to an external query', () => {
+      expect(retrieveDomainName({ uid: '2', type: 'ref' }, [{ uid: '2', name: 'Query 2' }])).toBe(
+        'Query 2',
+      );
+    });
+    it('return query id if domain is a reference to an external query unfound', () => {
+      expect(retrieveDomainName({ uid: '2', type: 'ref' }, [])).toBe('2');
     });
   });
 });

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -139,7 +139,7 @@ describe('Labeller', () => {
       name: 'domain',
       domain: 'the-domain',
     };
-    expect(hrl(step)).toEqual('Source: "the-domain"');
+    expect(hrl(step, retrieveDomainName)).toEqual('Source: "the-domain"');
   });
 
   it('generates label for duplicate steps', () => {

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -138,7 +138,7 @@ describe('Step.vue', () => {
     expect(wrapper.find('.query-pipeline-step__name').text()).toBe('Source: "user.username"');
   });
 
-  it('should retrieveDomainName for domain step label', () => {
+  it('should retrieveDomainName for step label', () => {
     createStepWrapper({
       propsData: {
         key: 0,

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -548,6 +548,13 @@ describe('mutation tests', () => {
     expect(state.domains).toEqual(['foo', 'bar']);
   });
 
+  it('sets queries list', () => {
+    const state = buildState({});
+    expect(state.queries).toEqual([]);
+    mutations.setQueries(state, { queries: [{ uid: '1', name: 'Query 1' }] });
+    expect(state.queries).toEqual([{ uid: '1', name: 'Query 1' }]);
+  });
+
   it('sets currentPipelineName', () => {
     const state = buildState({
       dataset: {


### PR DESCRIPTION
Retrieve the name of the query referenced behind uid in domain step label

Before:
![before](https://user-images.githubusercontent.com/59559689/181291723-f0e09f31-ba4d-4e09-9352-8477427469cc.png)

After:
![after](https://user-images.githubusercontent.com/59559689/181291743-86029c96-beb9-4952-a7ab-093f275ca2fb.png)

