### PR TITLE
fix(server/tests/athena): Disable CTAS for athena

### DIFF
--- a/server/tests/backends/sql_translator_integration_tests/test_sql_athena_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_athena_translator_steps.py
@@ -56,6 +56,6 @@ def test_athena_translator_pipeline(boto_session: Session, case_id: str, case_sp
     )
     expected = pd.read_json(json.dumps(pipeline_spec['expected']), orient='table')
     result = wr.athena.read_sql_query(
-        query, database=_DB, boto3_session=boto_session, s3_output=_OUTPUT
+        query, database=_DB, boto3_session=boto_session, s3_output=_OUTPUT, ctas_approach=False
     )
     assert_dataframes_equals(expected, result)


### PR DESCRIPTION
This doubles the speed of tests (CTAS is recommended for big results only)

Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>