### PR TITLE
chore: build and export types [TCTC-3320]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Changelog (weaverbird npm package)
 
+## [0.89.0] - 2022-08-19
+
+- Export type definitions
+
 ## [0.88.0] - 2022-08-18
+
 - Translators: enable unpivot step for pypika translator
 
 ## [0.87.0] - 2022-08-05
+
 - Translators: enable todate steps for pypika translator
 
 ## [0.86.0] - 2022-07-28
+
 - Domain step: retrieve name as label for external query domain
 - Steps: add dissolve step
 - Translators: enable join and append steps for pypika translator
@@ -23,24 +30,29 @@
 ## [0.83.1] - 2022-05-27
 
 ### Fixed
+
 - Fix ifthenelse step with date conditions
 
 ## [0.83.0] - 2022-05-24
 
 ### Changed
+
 - Use 'desc' order by default for top step
 
 ### Feat
+
 - Add top step in other options
 
 ## [0.82.3] - 2022-03-23
 
 ### Fixed
+
 - Mongo translator: handle years and timestamps correctly
 
 ## [0.82.2] - 2022-02-03
 
 ### Changed
+
 - Dataviewer: add data cy element for e2e tests
 
 ## [0.82.1] - 2022-02-02
@@ -62,9 +74,11 @@
 ## [0.81.0] - 2022-01-24
 
 ### Added
+
 - Query: domains can be replaced by references to other queries
 
 ### Fixed
+
 - Step: Hide previous step error when creating a new step
 
 ## [0.80.0] - 2022-01-19
@@ -105,11 +119,13 @@
 ## [0.79.1] - 2021-12-16
 
 ### Added
+
 - DateRangeToString: export method to use it outside of app
 
 ## [0.79.0] - 2021-12-16
 
 ### Added
+
 Preview source subset: improve design and move component under domain step
 
 ## [0.78.1] - 2021-12-10
@@ -137,11 +153,13 @@ Preview source subset: improve design and move component under domain step
 ## [0.76.2] - 2021-11-22
 
 ### Fixed
+
 - Variable input: don't clear field when selecting variables in multiple mode
 
 ## [0.76.1] - 2021-11-17
 
 ### Fixed
+
 - Calendars: reset value and update nav position when selected value is outside of updated bounds
 
 ## [0.76.0] - 2021-11-16
@@ -157,6 +175,7 @@ Preview source subset: improve design and move component under domain step
 ## [0.75.0] - 2021-11-09
 
 ### Changed
+
 - UI: DateRangeInput: remove background of the reset button
 - UI: Relative date selection: rename before/after to from/until
 
@@ -182,34 +201,41 @@ Preview source subset: improve design and move component under domain step
 ## [0.72.1] - 2021-10-29
 
 ### Fixed
+
 TabbedRangeCalendars: keep selected tab unchanged when updated enabled calendars contains selected tab
 
 ## [0.72.0] - 2021-10-28
 
 ### Added
+
 - DateRangeInput: ability to customize the format of the date range
 
 ## [0.71.0] - 2021-10-27
 
 ### Added
+
 - DateRangeInput: enable to use custom css variables to stylize component colors
 
 ## [0.70.0] - 2021-10-27
 
 ### Added
+
 - DateRangeInput: internationalization for fixed periods (English and French)
 
 ### Fixed
+
 - DateRangeInput: better preview with new system to keep popovers always opened
 
 ## [0.69.2] - 2021-10-26
 
 ## Fix
+
 - Multiselect: restore display of text in variables tags
 
 ## [0.69.1] - 2021-10-21
 
 ### Fix
+
 - DateRangeInput: display tabs header correctly
 - DateRangeInput: display date separator correctly and clean unecessary html tag
 - Calendar: use correct post css
@@ -217,9 +243,11 @@ TabbedRangeCalendars: keep selected tab unchanged when updated enabled calendars
 ## [0.69.0] - 2021-10-20
 
 ### Added
+
 - Dates input components: friendlier labels for calendar ranges
 
 ### Fix
+
 - WidgetList: display trash icon
 - Store: avoid console error messages due to state mutation
 - DateRangeInput: make all input clickable
@@ -231,14 +259,17 @@ TabbedRangeCalendars: keep selected tab unchanged when updated enabled calendars
 ## [0.68.0] - 2021-10-19
 
 ### Added
+
 - DateRangeInput: implement bounds in custom granularity calendars (years, quarters, months, weeks)
 
 ### Fix
+
 - DateRangeInput: force popover to update position when clicking on `custom` option
 
 ## [0.67.1] - 2021-10-19
 
 ### Fix
+
 - DateRangeInput: remove `daterangeUpdated` emitter and export method directly from main file
 - Date components: rename `Dynamic` tab to `Relative`
 - CustomVariableList: show only the label of options
@@ -269,9 +300,11 @@ TabbedRangeCalendars: keep selected tab unchanged when updated enabled calendars
 ## [0.65.0] - 2021-10-13
 
 ### Added
+
 - DateRangeInput: hide 'unactive' variables needed for computations from UI
 
 ### Fix
+
 - Calendar: use UTC timezone
 
 ## [0.64.1] - 2021-10-12
@@ -285,6 +318,7 @@ TabbedRangeCalendars: keep selected tab unchanged when updated enabled calendars
 ## [0.64.0] - 2021-10-12
 
 ### Changed
+
 - DateRangeInput: enable to use relative date as bounds
 
 ## [0.63.0] - 2021-10-12
@@ -297,6 +331,7 @@ TabbedRangeCalendars: keep selected tab unchanged when updated enabled calendars
 - DateRangeInput: hide/show custom editor depding on `enableCustom` variable
 
 ### Changed
+
 - DateRangeInput: replace range-calendar with a simple calendar using a range
 - DateRangeInput: Disable save custom date button if value is incomplete
 
@@ -311,7 +346,6 @@ TabbedRangeCalendars: keep selected tab unchanged when updated enabled calendars
 ### Added
 
 - Export for dates components
-
 
 ## [0.60.9] - 2021-09-30
 

--- a/build-types.sh
+++ b/build-types.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+rm -rf dist/types
+npx tsc -p tsconfig.types.json
+for file in dist/types/**/*.*
+do
+  if [ $file = dist/types/main.d.ts ]
+  then
+    path_to_src=./
+  else
+    path_to_src=$(echo $file | tr -dc '/' | colrm 1 2 | sed "s#/#../#g")
+  fi
+  sed -i -r "s#((import|export) .* from ')@/(.*)#\1$path_to_src\3#g" $file
+done

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,13 @@ module.exports = {
   transformIgnorePatterns: ['/node_modules/(?!v-calendar)', 'tests/*.js', 'playground/*'],
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.{vue,ts,js}'],
-  coveragePathIgnorePatterns: ['/node_modules/', 'playground/', 'tests/', 'src/typings/', 'src/main.ts'],
+  coveragePathIgnorePatterns: [
+    '/node_modules/',
+    'playground/',
+    'tests/',
+    'src/typings/',
+    'src/main.ts',
+    'src/types.ts',
+  ],
   coverageDirectory: 'coverage',
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "types": "./dist/types/main.d.ts",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "weaverbird",
   "version": "0.88.0",
+  "types": "./dist/types/main.d.ts",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
     "url": "https://github.com/ToucanToco/weaverbird/issues",
@@ -19,8 +20,9 @@
     "lint": "eslint --no-error-on-unmatched-pattern \"src/{components,lib,store}/**/*.{ts,vue}\" \"tests/**/*.ts\"",
     "lint:fix": "eslint --fix --no-error-on-unmatched-pattern \"src/{components,lib,store}/**/*.{ts,vue}\" \"tests/**/*.ts\"",
     "lint:ci": "yarn lint --output-file lint-report.json --format json",
-    "build": "yarn build-bundle",
+    "build": "yarn run build-bundle && yarn run build-types",
     "build-bundle": "rollup -c",
+    "build-types": ". ./build-types.sh",
     "build-doc": "typedoc --tsconfig tsconfig.json --readme README.md --out dist/docs src/",
     "storybook": "concurrently \"yarn storybook:bundle --watch\" \"start-storybook -p 9001 -c .storybook\"",
     "storybook:build": "build-storybook -o .storybook/dist -c .storybook",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weaverbird",
   "version": "0.89.0",
-  "types": "./dist/types/main.d.ts",
+  "types": "./dist/types/types.d.ts",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
     "url": "https://github.com/ToucanToco/weaverbird/issues",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,17 +1,16 @@
+import autoprefixer from 'autoprefixer';
 import fs from 'fs';
 import path from 'path';
-
+import postcssPresetEnv from 'postcss-preset-env';
 import alias from 'rollup-plugin-alias';
-import autoprefixer from "autoprefixer";
 import commonjs from 'rollup-plugin-commonjs';
 import json from 'rollup-plugin-json';
-import postcss from 'rollup-plugin-postcss'
-import postcssPresetEnv from 'postcss-preset-env';
-import replace from 'rollup-plugin-replace';
 import resolve from 'rollup-plugin-node-resolve';
+import postcss from 'rollup-plugin-postcss';
+import replace from 'rollup-plugin-replace';
+import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript';
 import vue from 'rollup-plugin-vue';
-import { terser } from 'rollup-plugin-terser';
 
 const production = process.env.NODE_ENV === 'production' || !process.env.ROLLUP_WATCH;
 /**
@@ -44,14 +43,19 @@ export default {
       // Default extensions ['.mjs', '.js', '.json', '.node']
       // We need to add the '.vue' extension because of the import of the component from v-calendar
       // which contains relative paths without extensions.
-      extensions: ['.mjs', '.js', '.ts', '.json', '.node', '.vue']
+      extensions: ['.mjs', '.js', '.ts', '.json', '.node', '.vue'],
     }),
     alias({
       resolve: ['.vue', '.json'],
       '@': path.join(packageDir(), '/src'),
     }),
     // date-fns comes from v-calendar
-    commonjs({ namedExports: { 'node_modules/mathjs/index.js': ['parse'], 'node_modules/date-fns/index.js': ['addDays'] } }),
+    commonjs({
+      namedExports: {
+        'node_modules/mathjs/index.js': ['parse'],
+        'node_modules/date-fns/index.js': ['addDays'],
+      },
+    }),
     // since we are using a v-calendar component directly we need to use postcss and apply the same config
     postcss({
       plugins: [
@@ -61,11 +65,10 @@ export default {
             'nesting-rules': true,
           },
         }),
-        autoprefixer()
+        autoprefixer(),
       ],
       // extract option break CSS live reload in Storybook, comment it to get it back
-      extract: true,
-      extract: 'weaverbird.css'
+      extract: 'weaverbird.css',
     }),
     replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
     vue({ css: false }),

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 # sonar.projectName=weaverbird
-sonar.projectVersion=0.88.0
+sonar.projectVersion=0.89.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./src

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.projectVersion=0.89.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./src
-sonar.coverage.exclusions=./src/typings,./src/main.ts
+sonar.coverage.exclusions=./src/typings,./src/main.ts,./src/types.ts
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ export { setAvailableCodeEditors } from './components/code-editor';
 export { defineSendAnalytics } from './lib/send-analytics';
 
 // export store entrypoints
-export { dereferencePipelines, getPipelineNamesReferencing } from '@/lib/dereference-pipeline';
+export { dereferencePipelines, getPipelineNamesReferencing } from './lib/dereference-pipeline';
 export {
   setupStore,
   registerModule,
@@ -15,19 +15,19 @@ export {
   VQBModule,
   VQBnamespace,
   VQB_MODULE_NAME,
-} from '@/store';
+} from './store';
 
-import '@/lib/icons';
+import './lib/icons';
 
 // export Vue components
-import DataViewer from '@/components/DataViewer.vue';
-import FilterEditor from '@/components/FilterEditor.vue';
-import Pagination from '@/components/Pagination.vue';
-import PipelineSelector from '@/components/PipelineSelector.vue';
-import QueryBuilder from '@/components/QueryBuilder.vue';
-import DateRangeInput from '@/components/stepforms/widgets/DateComponents/DateRangeInput.vue';
-import NewDateInput from '@/components/stepforms/widgets/DateComponents/NewDateInput.vue';
-import Vqb from '@/components/Vqb.vue';
+import DataViewer from './components/DataViewer.vue';
+import FilterEditor from './components/FilterEditor.vue';
+import Pagination from './components/Pagination.vue';
+import PipelineSelector from './components/PipelineSelector.vue';
+import QueryBuilder from './components/QueryBuilder.vue';
+import DateRangeInput from './components/stepforms/widgets/DateComponents/DateRangeInput.vue';
+import NewDateInput from './components/stepforms/widgets/DateComponents/NewDateInput.vue';
+import Vqb from './components/Vqb.vue';
 
 export {
   // All-in-one component
@@ -44,9 +44,9 @@ export {
 };
 
 // export helpers/utils
-export { exampleInterpolateFunc } from '@/lib/templating';
-export { transformValueToDateRange } from '@/components/DatePicker/transform-value-to-date-or-range';
-export { dateRangeToString } from '@/lib/dates';
+export { exampleInterpolateFunc } from './lib/templating';
+export { transformValueToDateRange } from './components/DatePicker/transform-value-to-date-or-range';
+export { dateRangeToString } from './lib/dates';
 
 // export directives
-export { resizable } from '@/directives/resizable/resizable';
+export { resizable } from './directives/resizable/resizable';

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,11 +50,3 @@ export { dateRangeToString } from './lib/dates';
 
 // export directives
 export { resizable } from './directives/resizable/resizable';
-
-// export types
-export { PipelineStep, Pipeline } from './lib/steps';
-export { VariableDelimiters, VariablesBucket } from './lib/variables';
-export { ColumnValueStat } from './lib/dataset/helpers';
-export { PaginationContext } from './lib/dataset/pagination';
-export { DataSetColumnType, DataSetColumn, DataSet } from './lib/dataset';
-export { BackendError, BackendWarning, BackendResponse, BackendService } from './lib/backend';

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,3 +50,11 @@ export { dateRangeToString } from './lib/dates';
 
 // export directives
 export { resizable } from './directives/resizable/resizable';
+
+// export types
+export { PipelineStep, Pipeline } from './lib/steps';
+export { VariableDelimiters, VariablesBucket } from './lib/variables';
+export { ColumnValueStat } from './lib/dataset/helpers';
+export { PaginationContext } from './lib/dataset/pagination';
+export { DataSetColumnType, DataSetColumn, DataSet } from './lib/dataset';
+export { BackendError, BackendWarning, BackendResponse, BackendService } from './lib/backend';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,8 @@
+export * from './main';
+
+export { PipelineStep, Pipeline } from './lib/steps';
+export { VariableDelimiters, VariablesBucket } from './lib/variables';
+export { ColumnValueStat } from './lib/dataset/helpers';
+export { PaginationContext } from './lib/dataset/pagination';
+export { DataSetColumnType, DataSetColumn, DataSet } from './lib/dataset';
+export { BackendError, BackendWarning, BackendResponse, BackendService } from './lib/backend';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "lib": ["es5", "esnext", "dom", "dom.iterable", "scripthost"],
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "tests/**/*.ts", "tests/**/*.tsx"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "tests/**/*.ts", "tests/**/*.tsx", "rollup.config.js"],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false,
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "emitDeclarationOnly": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
# TL;DR

https://toucantoco.atlassian.net/browse/TCTC-3320
https://github.com/ToucanToco/tucana/pull/12553

Weaverbird is fully written in TS but didn't export type definitions, which frequently broke Tucana and other dependent packages. This PR adds a build script to generate type definitions to resolve this.

Before:

:x: no type defs, usual workaround in Tucana was to ts-ignore imports

![image](https://user-images.githubusercontent.com/29477588/185648952-94865d05-40f6-4061-ae02-bac39145ab80.png)

:x: type errors not prevented

![image](https://user-images.githubusercontent.com/29477588/185649146-cbc9ab86-454e-4aee-b5eb-71332b27e7bb.png)

After:

:heavy_check_mark: type defs of imports

![image](https://user-images.githubusercontent.com/29477588/185647631-ae7e7275-6537-4b25-b096-ec867cf2c5b5.png)

:heavy_check_mark: error prevention

![image](https://user-images.githubusercontent.com/29477588/185647930-6d366fff-f550-4be5-9a60-459cd1c3340f.png)

# How

I first wanted to use rollup-plugin-dts, but it turned out that it required the latest rollup, the latest version of rollup plugins, the latest typescript, and after all these updates and many fixes in the code itself, the build was broken, likely due to a rollup error

```console
nino@dell~/tc/weaverbirdchore/dts$ yarn run build
yarn run v1.22.19
$ yarn build-bundle
$ rollup -c
clean: postcss.plugin was deprecated. Migration guide:
https://evilmartians.com/chronicles/postcss-8-plugin-migration

src/main.ts → dist/weaverbird.common.js, dist/weaverbird.esm.js, dist/weaverbird.browser.js...
(!) Plugin commonjs: The namedExports option from "@rollup/plugin-commonjs" is deprecated. Named exports are now handled automatically.
(!) Plugin replace: @rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
[!] Error: Unexpected character '@' (Note that you need plugins to import files that are not JavaScript)
src/components/Pagination.vue?rollup-plugin-vue=script.ts (29:0)
27: import { numberOfPages, pageMinMax, PaginationContext } from '@/lib/dataset/pagination';
28: 
29: @Component({
    ^
30:   name: 'pagination',
31:   components: {
Error: Unexpected character '@' (Note that you need plugins to import files that are not JavaScript)
    at error (/home/nino/tc/weaverbird/node_modules/rollup/dist/shared/rollup.js:198:30)
    at Module.error (/home/nino/tc/weaverbird/node_modules/rollup/dist/shared/rollup.js:12559:16)
    at Module.tryParse (/home/nino/tc/weaverbird/node_modules/rollup/dist/shared/rollup.js:12936:25)
    at Module.setSource (/home/nino/tc/weaverbird/node_modules/rollup/dist/shared/rollup.js:12841:24)
    at ModuleLoader.addModuleSource (/home/nino/tc/weaverbird/node_modules/rollup/dist/shared/rollup.js:22283:20)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I tried to fix this error but it looked like a messy thing to fix because things were supposed to work already: this is rollup failing to transpile a typescript file with decorators, eventhough decorator transpilation worked before all the updates, and went until page 5 of google to find answers and none worked.

I also tried to update plugin versions not to their latest, but I either got the error above or heap overflow errors. At this point I abandonned.

All wasn't lost tho, the build broke only on the last commit, so there's this free work available if we want weaverbird to be built with the latest typescript and rollup version (but not with the latest plugin versions apparently).

The branch is [chore/dts](https://github.com/ToucanToco/weaverbird/compare/06dc57800d703a0113afeca3d2b6e28eced2876d...chore/dts) if you wanna take a look.

# Why the build script? Why not use TSC directly to generate types?

If we generate types they'll still have path aliases in them. Stuff that looks like:

```ts
// /dist/types/main.d.ts
import foo from '@/bar/baz/foo';
```

and these path won't resolve when being used in dependent modules. Everybody wants TSC to natively resolve paths aliases when building declaration files https://github.com/microsoft/TypeScript/issues/15479 https://github.com/microsoft/TypeScript/issues/5039 but it has been refused several times so I figured that having a dirty but simple sed-based script to replace '@' by the path to src in declaration files was the simplest workaround.

# Should we worry about the impact of this?

Probably not.

Build time time only lasts 7% longer.

```console
nino@dell~/tc/weaverbirdmaster$ time npx rollup -c
[...]
real	0m56.346s
user	1m25.636s
sys	0m4.164s
nino@dell~/tc/weaverbirdchore/dts2$ time . build-types.sh 
real    0m3.966s
user	0m7.545s
sys	0m0.278s
```

The only thing I'd probably worry a tiny bit about would be the use of the [dot command](https://en.wikipedia.org/wiki/Dot_(command)) but it's a POSIX standard so should work on mac on unix, and also [works in powershell](https://devblogs.microsoft.com/powershell/powershell-constrained-language-mode-and-the-dot-source-operator/#:~:text=The%20PowerShell%20dot%2Dsource%20operator,file%20directly%20into%20your%20script).