### PR TITLE
feat(sql): add source_rows_subset option on translate sql

### DIFF
--- a/server/src/weaverbird/backends/pypika_translator/translate.py
+++ b/server/src/weaverbird/backends/pypika_translator/translate.py
@@ -11,10 +11,12 @@ def translate_pipeline(
     pipeline: Pipeline,
     tables_columns: Mapping[str, Sequence[str]],
     db_schema: str | None = None,
+    source_rows_subset: int | None = None,
 ) -> str:
     translator_cls = ALL_TRANSLATORS[sql_dialect]
     translator = translator_cls(
         tables_columns=tables_columns,
         db_schema=db_schema,
+        source_rows_subset=source_rows_subset,
     )
     return translator.get_query_str(steps=pipeline.steps)

--- a/server/src/weaverbird/backends/pypika_translator/translators/base.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/base.py
@@ -148,12 +148,14 @@ class SQLTranslator(ABC):
         tables_columns: Mapping[str, Sequence[str]] | None = None,
         db_schema: str | None = None,
         known_instances: dict[int, str] | None = None,
+        source_rows_subset: int | None = None,
     ) -> None:
         self._tables_columns: Mapping[str, Sequence[str]] = tables_columns or {}
         self._db_schema_name = db_schema
         self._db_schema: Schema | None = Schema(db_schema) if db_schema is not None else None
         self._known_instances: dict[int, str] = known_instances or {}
         self._step_count = 0
+        self._source_rows_subset = source_rows_subset
 
     def __init_subclass__(cls) -> None:
         ALL_TRANSLATORS[cls.DIALECT] = cls
@@ -633,6 +635,8 @@ class SQLTranslator(ABC):
         query: "QueryBuilder" = self.QUERY_CLS.from_(
             Table(step.domain, schema=self._db_schema)
         ).select(*selected_cols)
+        if self._source_rows_subset:
+            query = query.limit(self._source_rows_subset)
         return StepContext(query, selected_cols)
 
     def duplicate(

--- a/server/tests/backends/sql_translator_unit_tests/test_base_translator.py
+++ b/server/tests/backends/sql_translator_unit_tests/test_base_translator.py
@@ -296,6 +296,20 @@ def test_domain(base_translator: BaseTranslator):
     assert ctx.selectable.get_sql() == expected_query.get_sql()
 
 
+def test_domain_with_source_rows_subset(base_translator: BaseTranslator, mocker):
+    mocker.patch.object(base_translator, "_source_rows_subset", new=42)
+
+    domain = "users"
+    step = steps.DomainStep(domain=domain)
+    ctx = base_translator._domain(step=step)
+
+    schema = Schema(DB_SCHEMA)
+    users = Table(domain, schema)
+    expected_query = Query.from_(users).select(*ALL_TABLES["users"]).limit(42)
+
+    assert ctx.selectable.get_sql() == expected_query.get_sql()
+
+
 # this seems wrong for me...
 def test_domain_with_wrong_domain_name(base_translator: BaseTranslator):
     domain = "people"


### PR DESCRIPTION
## What

This option will be useful to preview the result of complex queries on a subset of the source dataset (e.g when a table has 10M rows and you want to preview your transformations on 10k rows).