### PR TITLE
feat(backend-service): retrieve translator from execute pipeline meta [TCTC-3370]

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -245,7 +245,7 @@ class MongoService {
         dataset = annotateDataset(dataset, types[0]);
         dataset = autocastDataset(dataset);
       }
-      return { data: dataset };
+      return { data: dataset, translator: 'mongo50' };
     } else {
       return {
         error: [{ type: 'error', message: responseContent.errmsg }],
@@ -316,7 +316,7 @@ class PandasService {
         pageno: Math.floor(offset / limit) + 1,
       };
       dataset = autocastDataset(dataset);
-      return { data: dataset };
+      return { data: dataset, translator: 'pandas' };
     } else {
       let error = { type: 'error' };
       if (typeof result === 'string') {
@@ -373,7 +373,7 @@ class SnowflakeService {
       };
       dataset = autocastDataset(dataset);
       updateLastExecutedQuery(result.query);
-      return { data: dataset };
+      return { data: dataset, translator: 'snowflake' };
     } else {
       updateLastExecutedQuery(null);
       return {
@@ -425,7 +425,7 @@ class AthenaService {
       };
       dataset = autocastDataset(dataset);
       updateLastExecutedQuery(result.query);
-      return { data: dataset };
+      return { data: dataset, translator: 'athena' };
     } else {
       updateLastExecutedQuery(null);
       return {
@@ -477,7 +477,7 @@ class GoogleBigQueryService {
       };
       dataset = autocastDataset(dataset);
       updateLastExecutedQuery(result.query);
-      return { data: dataset };
+      return { data: dataset, translator: 'google-big-query' };
     } else {
       updateLastExecutedQuery(null);
       return {
@@ -529,7 +529,7 @@ class MySqlService {
       };
       dataset = autocastDataset(dataset);
       updateLastExecutedQuery(result.query);
-      return { data: dataset };
+      return { data: dataset, translator: 'mysql' };
     } else {
       updateLastExecutedQuery(null);
       return {
@@ -581,7 +581,7 @@ class PostgresqlService {
       };
       // dataset = autocastDataset(dataset);
       updateLastExecutedQuery(result.query);
-      return { data: dataset };
+      return { data: dataset, translator: 'postgresql' };
     } else {
       updateLastExecutedQuery(null);
       return {
@@ -633,7 +633,7 @@ class RedshiftService {
       };
       dataset = autocastDataset(dataset);
       updateLastExecutedQuery(result.query);
-      return { data: dataset };
+      return { data: dataset, translator: 'redshift' };
     } else {
       updateLastExecutedQuery(null);
       return {

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -14,8 +14,8 @@ export type BackendWarning = {
 };
 
 export type BackendResponse<T> =
-  | Promise<{ data: T; error?: never; warning?: BackendWarning[] }>
-  | Promise<{ data?: never; error: BackendError[] }>;
+  | Promise<{ data: T; translator?: string; error?: never; warning?: BackendWarning[] }>
+  | Promise<{ data?: never; translator?: string; error: BackendError[] }>;
 
 export interface BackendService {
   /**

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -72,6 +72,9 @@ class Actions {
         pageOffset(state.pagesize, getters.pageno),
         getters.previewSourceRowsSubset,
       );
+      if (response.translator) {
+        commit('setTranslator', { translator: response.translator });
+      }
       const backendMessages = response.error || response.warning || [];
       commit('logBackendMessages', { backendMessages });
       if (response.data) {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,7 +1,7 @@
 import { ActionContext, ActionTree } from 'vuex';
 
 import { BackendError } from '@/lib/backend';
-import { addLocalUniquesToDataset, updateLocalUniquesFromDatabase } from '@/lib/dataset/helpers.ts';
+import { addLocalUniquesToDataset, updateLocalUniquesFromDatabase } from '@/lib/dataset/helpers';
 import { pageOffset } from '@/lib/dataset/pagination';
 import { Pipeline, PipelineStep } from '@/lib/steps';
 
@@ -72,9 +72,8 @@ class Actions {
         pageOffset(state.pagesize, getters.pageno),
         getters.previewSourceRowsSubset,
       );
-      if (response.translator) {
-        commit('setTranslator', { translator: response.translator });
-      }
+      const translator = response.translator ?? 'mongo50'; // mongo50 is not send by backend
+      commit('setTranslator', { translator });
       const backendMessages = response.error || response.warning || [];
       commit('logBackendMessages', { backendMessages });
       if (response.data) {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -95,7 +95,7 @@ export function emptyState(): VQBState {
     isLoading: { dataset: false, uniqueValues: false },
     isRequestOnGoing: false,
     variables: {},
-    translator: 'mongo40',
+    translator: 'mongo50',
     backendService: UnsetBackendService,
     interpolateFunc: (x: string | any[], _context: ScopeContext) => x,
     featureFlags: undefined,

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -759,7 +759,7 @@ describe('action tests', () => {
     let instantiateDummyService: Function;
     beforeEach(() => {
       instantiateDummyService = (): BackendService => ({
-        executePipeline: jest.fn().mockResolvedValue({ data: dummyDataset }),
+        executePipeline: jest.fn().mockResolvedValue({ data: dummyDataset, translator: 'pandas' }),
       });
     });
     it('should reset the preview if the pipeline is empty', async () => {
@@ -793,7 +793,7 @@ describe('action tests', () => {
       const commitSpy = jest.spyOn(store, 'commit');
 
       await store.dispatch(VQBnamespace('updateDataset'));
-      expect(commitSpy).toHaveBeenCalledTimes(7);
+      expect(commitSpy).toHaveBeenCalledTimes(8);
       // call 1 (clear backend messages) :
       expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('logBackendMessages'));
       expect(commitSpy.mock.calls[0][1]).toEqual({ backendMessages: [] });
@@ -803,18 +803,21 @@ describe('action tests', () => {
       // call 3 :
       expect(commitSpy.mock.calls[2][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
       expect(commitSpy.mock.calls[2][1]).toEqual({ isRequestOnGoing: true });
-      // call 4 :
-      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('logBackendMessages'));
-      expect(commitSpy.mock.calls[3][1]).toEqual({ backendMessages: [] });
+      // call 4 (set the translator provided by backend meta) :
+      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('setTranslator'));
+      expect(commitSpy.mock.calls[3][1]).toEqual({ translator: 'pandas' });
       // call 5 :
-      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('setDataset'));
-      expect(commitSpy.mock.calls[4][1]).toEqual({ dataset: dummyDatasetWithUniqueComputed });
+      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('logBackendMessages'));
+      expect(commitSpy.mock.calls[4][1]).toEqual({ backendMessages: [] });
       // call 6 :
-      expect(commitSpy.mock.calls[5][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
-      expect(commitSpy.mock.calls[5][1]).toEqual({ isRequestOnGoing: false });
+      expect(commitSpy.mock.calls[5][0]).toEqual(VQBnamespace('setDataset'));
+      expect(commitSpy.mock.calls[5][1]).toEqual({ dataset: dummyDatasetWithUniqueComputed });
       // call 7 :
-      expect(commitSpy.mock.calls[6][0]).toEqual(VQBnamespace('setLoading'));
-      expect(commitSpy.mock.calls[6][1]).toEqual({ type: 'dataset', isLoading: false });
+      expect(commitSpy.mock.calls[6][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[6][1]).toEqual({ isRequestOnGoing: false });
+      // call 8 :
+      expect(commitSpy.mock.calls[7][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[7][1]).toEqual({ type: 'dataset', isLoading: false });
     });
 
     it('updateDataset with error from service', async () => {

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -837,7 +837,7 @@ describe('action tests', () => {
       const commitSpy = jest.spyOn(store, 'commit');
 
       await store.dispatch(VQBnamespace('updateDataset'));
-      expect(commitSpy).toHaveBeenCalledTimes(6);
+      expect(commitSpy).toHaveBeenCalledTimes(7);
       // call 1 (clear backend messages) :
       expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('logBackendMessages'));
       expect(commitSpy.mock.calls[0][1]).toEqual({ backendMessages: [] });
@@ -847,17 +847,20 @@ describe('action tests', () => {
       // call 3 :
       expect(commitSpy.mock.calls[2][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
       expect(commitSpy.mock.calls[2][1]).toEqual({ isRequestOnGoing: true });
-      // call 4 :
-      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('logBackendMessages'));
-      expect(commitSpy.mock.calls[3][1]).toEqual({
+      // call 4 (set the translator provided by backend meta) :
+      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('setTranslator'));
+      expect(commitSpy.mock.calls[3][1]).toEqual({ translator: 'mongo50' });
+      // call 5 :
+      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('logBackendMessages'));
+      expect(commitSpy.mock.calls[4][1]).toEqual({
         backendMessages: [{ message: 'OMG an error happens', type: 'error' }],
       });
-      // call 5 :
-      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
-      expect(commitSpy.mock.calls[4][1]).toEqual({ isRequestOnGoing: false });
       // call 6 :
-      expect(commitSpy.mock.calls[5][0]).toEqual(VQBnamespace('setLoading'));
-      expect(commitSpy.mock.calls[5][1]).toEqual({ type: 'dataset', isLoading: false });
+      expect(commitSpy.mock.calls[5][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[5][1]).toEqual({ isRequestOnGoing: false });
+      // call 7 :
+      expect(commitSpy.mock.calls[6][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[6][1]).toEqual({ type: 'dataset', isLoading: false });
     });
 
     it('updateDataset with uncaught error from service', async () => {
@@ -920,7 +923,7 @@ describe('action tests', () => {
       const commitSpy = jest.spyOn(store, 'commit');
 
       await store.dispatch(VQBnamespace('updateDataset'));
-      expect(commitSpy).toHaveBeenCalledTimes(6);
+      expect(commitSpy).toHaveBeenCalledTimes(7);
       // call 1 (clear backend messages) :
       expect(commitSpy.mock.calls[0][0]).toEqual(VQBnamespace('logBackendMessages'));
       expect(commitSpy.mock.calls[0][1]).toEqual({ backendMessages: [] });
@@ -930,17 +933,20 @@ describe('action tests', () => {
       // call 3 :
       expect(commitSpy.mock.calls[2][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
       expect(commitSpy.mock.calls[2][1]).toEqual({ isRequestOnGoing: true });
-      // call 4 :
-      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('logBackendMessages'));
-      expect(commitSpy.mock.calls[3][1]).toEqual({
+      // call 4 (set the translator provided by backend meta) :
+      expect(commitSpy.mock.calls[3][0]).toEqual(VQBnamespace('setTranslator'));
+      expect(commitSpy.mock.calls[3][1]).toEqual({ translator: 'mongo50' });
+      // call 5 :
+      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('logBackendMessages'));
+      expect(commitSpy.mock.calls[4][1]).toEqual({
         backendMessages: [{ type: 'error', index: 1, message: 'Specific error for step' }],
       });
-      // call 5 :
-      expect(commitSpy.mock.calls[4][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
-      expect(commitSpy.mock.calls[4][1]).toEqual({ isRequestOnGoing: false });
       // call 6 :
-      expect(commitSpy.mock.calls[5][0]).toEqual(VQBnamespace('setLoading'));
-      expect(commitSpy.mock.calls[5][1]).toEqual({ type: 'dataset', isLoading: false });
+      expect(commitSpy.mock.calls[5][0]).toEqual(VQBnamespace('toggleRequestOnGoing'));
+      expect(commitSpy.mock.calls[5][1]).toEqual({ isRequestOnGoing: false });
+      // call 7 :
+      expect(commitSpy.mock.calls[6][0]).toEqual(VQBnamespace('setLoading'));
+      expect(commitSpy.mock.calls[6][1]).toEqual({ type: 'dataset', isLoading: false });
     });
   });
 


### PR DESCRIPTION
As now translator is retrieved from execute pipeline backendResponse in meta, we can add it to store directly from executePipeline call, no need to retrieve it from Tucana

Tucana PR to clean logic: https://github.com/ToucanToco/tucana/pull/12759
![after](https://user-images.githubusercontent.com/59559689/191797543-2b9cfb94-ea0e-47a3-83be-dfa9fc384573.gif)
