### PR TITLE
fix(resizable-columns): disable directive when columns count is too big [TCTC-3887]

### DIFF
--- a/src/directives/resizable/ResizableTable.ts
+++ b/src/directives/resizable/ResizableTable.ts
@@ -12,6 +12,7 @@ export const DEFAULT_OPTIONS: ResizableTableOptions = {
     handler: 'table__handler',
   },
   columns: [],
+  maxHandleableColumns: 100,
   firstDisplayCharsPerCol: 7.5,
   maxCharsPerCol: 20,
   labelTargetClass: '',
@@ -23,6 +24,7 @@ export interface ResizableTableOptions {
     handler: string; // class applied to col handler
   };
   columns: string[] | number[]; // the columns associated to cols handlers
+  maxHandleableColumns: number; // the number of columns directive can handle without being disabled
   firstDisplayCharsPerCol: number; // The number of chars per col display on first render
   maxCharsPerCol: number; // The max number of chars to display per col
   labelTargetClass: string; // DOM class to select label in col

--- a/src/directives/resizable/resizable.ts
+++ b/src/directives/resizable/resizable.ts
@@ -22,7 +22,7 @@
 import { DirectiveOptions } from 'vue';
 import { DirectiveBinding } from 'vue/types/options';
 
-import ResizableTable, { ResizableTableOptions } from './ResizableTable';
+import ResizableTable, { DEFAULT_OPTIONS, ResizableTableOptions } from './ResizableTable';
 
 // stock table to destroy referent listeners when component is destroyed
 export let resizableTable: ResizableTable | null;
@@ -33,7 +33,17 @@ export const resizable: DirectiveOptions = {
     if (el.nodeName != 'TABLE') return;
     // instantiate resizable table
     const options: ResizableTableOptions = node.value;
-    resizableTable = new ResizableTable(el, options);
+    const maxColumns = options.maxHandleableColumns ?? DEFAULT_OPTIONS.maxHandleableColumns;
+    const isDisabled = options.columns.length > maxColumns;
+    if (isDisabled) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Resizable feature is disabled because of columns count (${options.columns.length} > ${maxColumns})`,
+      );
+      resizableTable = null;
+    } else {
+      resizableTable = new ResizableTable(el, options);
+    }
   },
   async componentUpdated(_, node: DirectiveBinding) {
     const options: ResizableTableOptions = node.value;

--- a/tests/unit/resizable.spec.ts
+++ b/tests/unit/resizable.spec.ts
@@ -30,6 +30,10 @@ describe('Resizable directive', () => {
       shallowMount(FakeOtherComponent);
       expect(ResizableTableStub).not.toHaveBeenCalled();
     });
+    it('should not create a resizable table when columns count is higher than max handleable columns', () => {
+      shallowMount(FakeOtherComponent, { propsData: { maxHandleableColumns: 1 } });
+      expect(ResizableTableStub).not.toHaveBeenCalled();
+    });
   });
 
   describe('default', () => {


### PR DESCRIPTION
Quickfix to add a new maxHandleableColumns to v-resizable directive to be able to disable it with large amount of columns.
Do not merge until we know if merge on master or not: (this branch is plugged on v0.89.0 release for now) in order to be able to create a v0.89.1 if we need to target monthly directly