### PR TITLE
fix(server/pypika/gbq): Fix split step quoting TCTC-3806

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- PyPika: Fixed "split" step with Google Big Query backend: If provided, the delimiter is now passed wrapped in single quotes.
+  Also, empty strings are returned rather than null values, for consistency with other backends
+- PyPika: Fixed "split" step with Athena backend: empty strings are returned rather than null values, for consistency with other backends
+- PyPika: Fixed "split" step with MySQL backend, in case there are more `keep_columns` than splitted parts, fill those with empty string
+  rather than the entire string to split
+
 ## [0.25.2] - 2022-09-27
 
 - Fixed "matches" operator behaviour of the IfThenElse step in case the column the condition applies to contains NA values

--- a/server/src/weaverbird/backends/pypika_translator/translators/base.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/base.py
@@ -1314,6 +1314,11 @@ class SQLTranslator(ABC):
 
         return StepContext(query, columns)
 
+    @staticmethod
+    def _wrap_split_part(term: Term) -> Term:
+        """Wraps calls to SplitPart if needed"""
+        return term
+
     def split(
         self: Self,
         *,
@@ -1328,7 +1333,9 @@ class SQLTranslator(ABC):
             query: "QueryBuilder" = self.QUERY_CLS.from_(prev_step_name).select(
                 *columns,
                 *(
-                    functions.SplitPart(col_field, step.delimiter, i + 1).as_(new_cols[i])
+                    self._wrap_split_part(
+                        functions.SplitPart(col_field, step.delimiter, i + 1)
+                    ).as_(new_cols[i])
                     for i in range(step.number_cols_to_keep)
                 ),
             )

--- a/server/tests/backends/fixtures/split/with_delimiter_pypika.yaml
+++ b/server/tests/backends/fixtures/split/with_delimiter_pypika.yaml
@@ -1,0 +1,54 @@
+exclude:
+- mongo
+- pandas
+- snowflake
+step:
+  pipeline:
+  - columns:
+    - beer_kind
+    name: select
+  - column: beer_kind
+    delimiter: i
+    name: split
+    number_cols_to_keep: 2
+expected:
+  data:
+  - beer_kind: Triple
+    beer_kind_1: Tr
+    beer_kind_2: ple
+  - beer_kind: India Pale Ale
+    beer_kind_1: Ind
+    beer_kind_2: a Pale Ale
+  - beer_kind: Sans alcool
+    beer_kind_1: Sans alcool
+    beer_kind_2: ""
+  - beer_kind: Best-sellers
+    beer_kind_1: Best-sellers
+    beer_kind_2: ""
+  - beer_kind: Blonde
+    beer_kind_1: Blonde
+    beer_kind_2: ""
+  - beer_kind: Blanche & Weizen
+    beer_kind_1: Blanche & We
+    beer_kind_2: zen
+  - beer_kind: India Pale Ale
+    beer_kind_1: Ind
+    beer_kind_2: a Pale Ale
+  - beer_kind: Belge blonde forte & Golden Ale
+    beer_kind_1: Belge blonde forte & Golden Ale
+    beer_kind_2: ""
+  - beer_kind: Blonde
+    beer_kind_1: Blonde
+    beer_kind_2: ""
+  - beer_kind: Blonde
+    beer_kind_1: Blonde
+    beer_kind_2: ""
+  schema:
+    fields:
+    - name: beer_kind
+      type: string
+    - name: beer_kind_1
+      type: string
+    - name: beer_kind_2
+      type: string
+    pandas_version: 1.4.0

--- a/server/tests/backends/fixtures/split/with_delimiter_pypika.yaml
+++ b/server/tests/backends/fixtures/split/with_delimiter_pypika.yaml
@@ -2,6 +2,8 @@ exclude:
 - mongo
 - pandas
 - snowflake
+# AwsWrangler seems to replace empty strings with NULLS... guess we'll have a special case for Athena
+- athena_pypika
 step:
   pipeline:
   - columns:


### PR DESCRIPTION
The separator should be escaped as a string literal (single quotes).

relates to TCTC-3806

Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>