### PR TITLE
chore: bump from 0.25.3 to 0.26.0

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.26.0] - 2022-10-06
+
 - PyPika: Fixed "unpivot" step for mixed column types by adding intermediate convert step
 - PyPika: the float type for MySQL is now DOUBLE
 - PyPika: the float type for Google Big Query is now FLOAT64

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "weaverbird"
-version = "0.25.3"
+version = "0.26.0"
 description = "A visual data pipeline builder with various backends"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 keywords = ["mongodb", "pandas", "sql", "data", "dataviz", "pipeline", "query", "builder"]


### PR DESCRIPTION
## WHAT

Bump from 0.25.3 to 0.26.0 for :
   - PyPika: Fixed "unpivot" step for mixed column types by adding intermediate convert step
   - PyPika: the float type for MySQL is now DOUBLE
   - PyPika: the float type for Google Big Query is now FLOAT64
   - PyPika: the float type for Athena is now DOUBLE
