### PR TITLE
chore: bump v0.26.0

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog (weaverbird python package)
 
-## Unreleased
+## [0.26.0] - 2022-10-19
 
 - Pypika: Snowflake translator now has a custom queryBuilder class to force the `QUOTE_CHAR` to `"`
 - Feat: Added `replacetext` step for all backends
 - Feat: `text` step now allows to create other types of column (when used in conjunction with variables)
 
 ### Breaking
-* Dropped support for the old snowflake  SQL translator
+* Dropped support for the old snowflake SQL translator
 
 ## [0.25.5] - 2022-10-11
 

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog (weaverbird python package)
 
-## [0.26.0] - 2022-10-19
+## [0.26.0] - 2022-10-20
 
 - Pypika: Snowflake translator now has a custom queryBuilder class to force the `QUOTE_CHAR` to `"`
 - Feat: Added `replacetext` step for all backends

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "weaverbird"
-version = "0.25.5"
+version = "0.26.0"
 description = "A visual data pipeline builder with various backends"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 keywords = ["mongodb", "pandas", "sql", "data", "dataviz", "pipeline", "query", "builder"]


### PR DESCRIPTION
## WHAT

Major bump from 0.25.5 to 0.26.0:
    - Dropped the support of the old sql-translator
    - Added a custom queryBuilder for snowflake for columns having specials characters
    - Added `replacetext` step for all our backends
    - allow to create columns of other types