### PR TITLE
feat(textstep): allow to create columns of other types [TCTC-4365]

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Pypika: Snowflake translator now has a custom queryBuilder class to force the `QUOTE_CHAR` to `"`
 - Feat: Added `replacetext` step for all backends
-- Feat: `text` step now allows to create other types of column (when used in conjunctions with variables)
+- Feat: `text` step now allows to create other types of column (when used in conjunction with variables)
 
 ### Breaking
 * Dropped support for the old snowflake  SQL translator

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Pypika: Snowflake translator now has a custom queryBuilder class to force the `QUOTE_CHAR` to `"`
 - Feat: Added `replacetext` step for all backends
+- Feat: `text` step now allows to create other types of column (when used in conjunctions with variables)
 
 ### Breaking
 * Dropped support for the old snowflake  SQL translator

--- a/server/src/weaverbird/backends/pypika_translator/translators/mysql.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/mysql.py
@@ -33,7 +33,7 @@ class MySQLTranslator(SQLTranslator):
         float="DOUBLE",
         integer="UNSIGNED",
         text="CHAR",
-        datetime="TIMESTAMP",
+        datetime="DATETIME",
         timestamp="TIMESTAMP",
     )
     # Requires MySQL>=8

--- a/server/src/weaverbird/pipeline/steps/text.py
+++ b/server/src/weaverbird/pipeline/steps/text.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Literal
 
 from weaverbird.pipeline.steps.utils.base import BaseStep
@@ -5,9 +6,9 @@ from weaverbird.pipeline.steps.utils.render_variables import StepWithVariablesMi
 from weaverbird.pipeline.types import ColumnName
 
 
-class TextStep(BaseStep):
+class TextStep(BaseStep, smart_union=True):
     name: Literal["text"] = "text"
-    text: str
+    text: datetime | int | float | bool | str
     new_column: ColumnName
 
 

--- a/server/src/weaverbird/pipeline/steps/text.py
+++ b/server/src/weaverbird/pipeline/steps/text.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 from typing import Literal
+from zoneinfo import ZoneInfo
+
+from pydantic import validator
 
 from weaverbird.pipeline.steps.utils.base import BaseStep
 from weaverbird.pipeline.steps.utils.render_variables import StepWithVariablesMixin
@@ -10,6 +13,12 @@ class TextStep(BaseStep, smart_union=True):
     name: Literal["text"] = "text"
     text: datetime | int | float | bool | str
     new_column: ColumnName
+
+    @validator("text")
+    def _text_validator(cls, value):
+        if isinstance(value, datetime) and value.tzinfo is not None:
+            return value.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+        return value
 
 
 class TextStepWithVariable(TextStep, StepWithVariablesMixin):

--- a/server/tests/backends/fixtures/text/simple.json
+++ b/server/tests/backends/fixtures/text/simple.json
@@ -13,6 +13,26 @@
         "name": "text",
         "new_column": "BEST_SINGER_EVER",
         "text": "jean-jacques-goldman"
+      },
+      {
+        "name": "text",
+        "new_column": "ONE",
+        "text": "{{ ONE }}"
+      },
+      {
+        "name": "text",
+        "new_column": "ONE_POINT_ONE",
+        "text": "{{ ONE_POINT_ONE }}"
+      },
+      {
+        "name": "text",
+        "new_column": "TODAY",
+        "text": "{{ TODAY }}"
+      },
+      {
+        "name": "text",
+        "new_column": "TRUE",
+        "text": "{{ TRUE }}"
       }
     ]
   },
@@ -65,6 +85,22 @@
         {
           "name": "BEST_SINGER_EVER",
           "type": "string"
+        },
+        {
+          "name": "ONE",
+          "type": "integer"
+        },
+        {
+          "name": "ONE_POINT_ONE",
+          "type": "number"
+        },
+        {
+          "name": "TODAY",
+          "type": "datetime"
+        },
+        {
+          "name": "TRUE",
+          "type": "boolean"
         }
       ],
       "pandas_version": "0.20.0"
@@ -74,13 +110,21 @@
         "NAME": "foo",
         "AGE": 42.0,
         "SCORE": 100,
-        "BEST_SINGER_EVER": "jean-jacques-goldman"
+        "BEST_SINGER_EVER": "jean-jacques-goldman",
+        "ONE": 1,
+        "ONE_POINT_ONE": 1.1,
+        "TODAY": "2022-10-17 17:30:12",
+        "TRUE": true
       },
       {
         "NAME": "bar",
         "AGE": 43,
         "SCORE": 200,
-        "BEST_SINGER_EVER": "jean-jacques-goldman"
+        "BEST_SINGER_EVER": "jean-jacques-goldman",
+        "ONE": 1,
+        "ONE_POINT_ONE": 1.1,
+        "TODAY": "2022-10-17 17:30:12",
+        "TRUE": true
       }
     ]
   }

--- a/server/tests/backends/fixtures/text/simple_pypika.json
+++ b/server/tests/backends/fixtures/text/simple_pypika.json
@@ -10,6 +10,26 @@
         "name": "text",
         "new_column": "best_singer_ever",
         "text": "jean-jacques-goldman"
+      },
+      {
+        "name": "text",
+        "new_column": "one",
+        "text": "{{ ONE }}"
+      },
+      {
+        "name": "text",
+        "new_column": "one_point_one",
+        "text": "{{ ONE_POINT_ONE }}"
+      },
+      {
+        "name": "text",
+        "new_column": "today",
+        "text": "{{ TODAY }}"
+      },
+      {
+        "name": "text",
+        "new_column": "true",
+        "text": "{{ TRUE }}"
       }
     ]
   },
@@ -51,6 +71,22 @@
         {
           "name": "best_singer_ever",
           "type": "string"
+        },
+        {
+          "name": "one",
+          "type": "integer"
+        },
+        {
+          "name": "one_point_one",
+          "type": "number"
+        },
+        {
+          "name": "today",
+          "type": "datetime"
+        },
+        {
+          "name": "true",
+          "type": "boolean"
         }
       ],
       "pandas_version": "1.4.0"
@@ -65,7 +101,11 @@
         "volume_ml": 330.0,
         "brewing_date": "2022-01-01",
         "nullable_name": null,
-        "best_singer_ever": "jean-jacques-goldman"
+        "best_singer_ever": "jean-jacques-goldman",
+        "one": 1,
+        "one_point_one": 1.1,
+        "today": "2022-10-17 17:30:12",
+        "true": true
       },
       {
         "price_per_l": 0.0540000014,
@@ -76,7 +116,11 @@
         "volume_ml": 330.0,
         "brewing_date": "2022-01-02",
         "nullable_name": "Ninkasi Ploploplop",
-        "best_singer_ever": "jean-jacques-goldman"
+        "best_singer_ever": "jean-jacques-goldman",
+        "one": 1,
+        "one_point_one": 1.1,
+        "today": "2022-10-17 17:30:12",
+        "true": true
       },
       {
         "price_per_l": 0.0049999999,
@@ -87,7 +131,11 @@
         "volume_ml": 330.0,
         "brewing_date": "2022-01-03",
         "nullable_name": "Brewdog Nanny State Alcoholvrij",
-        "best_singer_ever": "jean-jacques-goldman"
+        "best_singer_ever": "jean-jacques-goldman",
+        "one": 1,
+        "one_point_one": 1.1,
+        "today": "2022-10-17 17:30:12",
+        "true": true
       },
       {
         "price_per_l": 0.0560000017,
@@ -98,7 +146,11 @@
         "volume_ml": 330.0,
         "brewing_date": "2022-01-04",
         "nullable_name": "Ardwen Blonde",
-        "best_singer_ever": "jean-jacques-goldman"
+        "best_singer_ever": "jean-jacques-goldman",
+        "one": 1,
+        "one_point_one": 1.1,
+        "today": "2022-10-17 17:30:12",
+        "true": true
       },
       {
         "price_per_l": 0.0700000003,
@@ -109,7 +161,11 @@
         "volume_ml": 250.0,
         "brewing_date": "2022-01-05",
         "nullable_name": null,
-        "best_singer_ever": "jean-jacques-goldman"
+        "best_singer_ever": "jean-jacques-goldman",
+        "one": 1,
+        "one_point_one": 1.1,
+        "today": "2022-10-17 17:30:12",
+        "true": true
       },
       {
         "price_per_l": 0.0049999999,
@@ -120,7 +176,11 @@
         "volume_ml": 500.0,
         "brewing_date": "2022-01-06",
         "nullable_name": "Weihenstephan Hefe Weizen Alcoholarm",
-        "best_singer_ever": "jean-jacques-goldman"
+        "best_singer_ever": "jean-jacques-goldman",
+        "one": 1,
+        "one_point_one": 1.1,
+        "today": "2022-10-17 17:30:12",
+        "true": true
       },
       {
         "price_per_l": 0.0450000018,
@@ -131,7 +191,11 @@
         "volume_ml": 330.0,
         "brewing_date": "2022-01-07",
         "nullable_name": "Bellfield Lawless Village IPA",
-        "best_singer_ever": "jean-jacques-goldman"
+        "best_singer_ever": "jean-jacques-goldman",
+        "one": 1,
+        "one_point_one": 1.1,
+        "today": "2022-10-17 17:30:12",
+        "true": true
       },
       {
         "price_per_l": 0.0839999989,
@@ -142,7 +206,11 @@
         "volume_ml": 330.0,
         "brewing_date": "2022-01-08",
         "nullable_name": "Pauwel Kwak",
-        "best_singer_ever": "jean-jacques-goldman"
+        "best_singer_ever": "jean-jacques-goldman",
+        "one": 1,
+        "one_point_one": 1.1,
+        "today": "2022-10-17 17:30:12",
+        "true": true
       },
       {
         "price_per_l": 0.0649999976,
@@ -153,7 +221,11 @@
         "volume_ml": 330.0,
         "brewing_date": "2022-01-09",
         "nullable_name": null,
-        "best_singer_ever": "jean-jacques-goldman"
+        "best_singer_ever": "jean-jacques-goldman",
+        "one": 1,
+        "one_point_one": 1.1,
+        "today": "2022-10-17 17:30:12",
+        "true": true
       },
       {
         "price_per_l": 0.0599999987,
@@ -164,7 +236,11 @@
         "volume_ml": 330.0,
         "brewing_date": "2022-01-10",
         "nullable_name": "Brugse Zot blonde",
-        "best_singer_ever": "jean-jacques-goldman"
+        "best_singer_ever": "jean-jacques-goldman",
+        "one": 1,
+        "one_point_one": 1.1,
+        "today": "2022-10-17 17:30:12",
+        "true": true
       }
     ]
   }

--- a/server/tests/backends/pandas_executor/test_pandas_executor_steps.py
+++ b/server/tests/backends/pandas_executor/test_pandas_executor_steps.py
@@ -3,10 +3,11 @@ import json
 import geopandas as gpd
 import pandas as pd
 import pytest
+from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import assert_dataframes_equals, get_spec_from_json_fixture, retrieve_case
 from weaverbird.backends.pandas_executor import execute_pipeline
-from weaverbird.pipeline import Pipeline
+from weaverbird.pipeline import PipelineWithVariables
 
 test_cases = retrieve_case("pandas_executor", "pandas")
 
@@ -20,7 +21,7 @@ def _load_df(spec: dict) -> pd.DataFrame:
 
 
 @pytest.mark.parametrize("case_id,case_spec_file_path", test_cases)
-def test_pandas_execute_pipeline(case_id, case_spec_file_path):
+def test_pandas_execute_pipeline(case_id, case_spec_file_path, available_variables):
     spec = get_spec_from_json_fixture(case_id, case_spec_file_path)
     df_in = _load_df(spec["input"])
     df_out = _load_df(spec["expected"])
@@ -28,7 +29,9 @@ def test_pandas_execute_pipeline(case_id, case_spec_file_path):
 
     steps = spec["step"]["pipeline"]
     steps.insert(0, {"name": "domain", "domain": "in"})
-    pipeline = Pipeline(steps=steps)
+    pipeline = PipelineWithVariables(steps=steps).render(
+        available_variables, nosql_apply_parameters_to_query
+    )
 
     DOMAINS = {"in": df_in, **dfs_in_others}
     result = execute_pipeline(pipeline, domain_retriever=lambda x: DOMAINS[x])[0]

--- a/server/tests/backends/sql_translator_integration_tests/test_sql_athena_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_athena_translator_steps.py
@@ -5,11 +5,12 @@ import awswrangler as wr
 import pandas as pd
 import pytest
 from boto3 import Session
+from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import assert_dataframes_equals, get_spec_from_json_fixture, retrieve_case
 from weaverbird.backends.pypika_translator.dialects import SQLDialect
 from weaverbird.backends.pypika_translator.translate import translate_pipeline
-from weaverbird.pipeline import Pipeline
+from weaverbird.pipeline import PipelineWithVariables
 
 _REGION = environ["ATHENA_REGION"]
 _DB = environ["ATHENA_DATABASE"]
@@ -42,11 +43,15 @@ _BEERS_TABLE_COLUMNS = [
 @pytest.mark.parametrize(
     "case_id, case_spec_file", retrieve_case("sql_translator", "athena_pypika")
 )
-def test_athena_translator_pipeline(boto_session: Session, case_id: str, case_spec_file: str):
+def test_athena_translator_pipeline(
+    boto_session: Session, case_id: str, case_spec_file: str, available_variables: dict
+):
     pipeline_spec = get_spec_from_json_fixture(case_id, case_spec_file)
 
     steps = [{"name": "domain", "domain": "beers_tiny"}] + pipeline_spec["step"]["pipeline"]
-    pipeline = Pipeline(steps=steps)
+    pipeline = PipelineWithVariables(steps=steps).render(
+        available_variables, nosql_apply_parameters_to_query
+    )
 
     query = translate_pipeline(
         sql_dialect=SQLDialect.ATHENA,

--- a/server/tests/backends/sql_translator_integration_tests/test_sql_postgres_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_postgres_translator_steps.py
@@ -7,6 +7,7 @@ import pandas as pd
 import psycopg2
 import pytest
 from sqlalchemy import create_engine, text
+from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import (
     _BEERS_TABLE_COLUMNS,
@@ -69,12 +70,16 @@ def postgres_container():
 @pytest.mark.parametrize(
     "case_id, case_spec_file_path", retrieve_case("sql_translator", "postgres_pypika")
 )
-def test_sql_translator_pipeline(case_id: str, case_spec_file_path: str, engine: Any):
+def test_sql_translator_pipeline(
+    case_id: str, case_spec_file_path: str, engine: Any, available_variables: dict
+):
     spec = get_spec_from_json_fixture(case_id, case_spec_file_path)
 
     steps = spec["step"]["pipeline"]
     steps.insert(0, {"name": "domain", "domain": "beers_tiny"})
-    pipeline = PipelineWithVariables(steps=steps)
+    pipeline = PipelineWithVariables(steps=steps).render(
+        available_variables, nosql_apply_parameters_to_query
+    )
 
     # Convert Pipeline object to Postgres Query
     query = translate_pipeline(

--- a/server/tests/backends/sql_translator_integration_tests/test_sql_snowflake_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_snowflake_translator_steps.py
@@ -6,11 +6,12 @@ import pandas as pd
 import pytest
 from snowflake.sqlalchemy import URL
 from sqlalchemy import create_engine, text
+from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import assert_dataframes_equals, get_spec_from_json_fixture, retrieve_case
 from weaverbird.backends.pypika_translator.dialects import SQLDialect
 from weaverbird.backends.pypika_translator.translate import translate_pipeline
-from weaverbird.pipeline import Pipeline
+from weaverbird.pipeline import PipelineWithVariables
 
 _ACCOUNT = "toucantocopartner.west-europe.azure"
 _USER = "toucan_test"
@@ -57,11 +58,15 @@ def engine():
 @pytest.mark.parametrize(
     "case_id, case_spec_file", retrieve_case("sql_translator", "snowflake_pypika")
 )
-def test_snowflake_translator_pipeline(engine: Any, case_id: str, case_spec_file: str):
+def test_snowflake_translator_pipeline(
+    engine: Any, case_id: str, case_spec_file: str, available_variables: dict
+):
     pipeline_spec = get_spec_from_json_fixture(case_id, case_spec_file)
 
     steps = [{"name": "domain", "domain": "beers_tiny"}] + pipeline_spec["step"]["pipeline"]
-    pipeline = Pipeline(steps=steps)
+    pipeline = PipelineWithVariables(steps=steps).render(
+        available_variables, nosql_apply_parameters_to_query
+    )
 
     query = translate_pipeline(
         sql_dialect=SQLDialect.SNOWFLAKE,

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,3 +1,13 @@
-import sys
+from datetime import datetime
 
-print(sys.path)
+import pytest
+
+
+@pytest.fixture
+def available_variables():
+    return {
+        "TODAY": datetime(2022, 10, 17, 17, 30, 12),
+        "ONE": 1,
+        "ONE_POINT_ONE": 1.1,
+        "TRUE": True,
+    }

--- a/server/tests/steps/test_text.py
+++ b/server/tests/steps/test_text.py
@@ -1,4 +1,6 @@
 import random
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import pytest
@@ -27,6 +29,13 @@ def test_text(sample_df: DataFrame):
         }
     )
     assert_dataframes_equals(df_result, expected_result)
+
+
+def test_text_datetime_with_tz():
+    now = datetime(2022, 10, 20, 14, 18, 22).replace(tzinfo=ZoneInfo("Europe/Paris"))
+    step = TextStep(name="text", new_column="foo", text=now)
+    assert step.text.tzinfo is None  # it is now tz naive
+    assert step.text.isoformat() == "2022-10-20T12:18:22"
 
 
 def test_benchmark_text(benchmark):


### PR DESCRIPTION
**Before** : textstep can add columns of type string, only
**After** : other types are allowed. Useful when using variables like : 

```
{
  "name": "text",
  "new_column": "current_date",
  "text": "{{ TODAY }}"
},
```

:information_source: since we only deal with `datetime` variables (and not `date`) in laputa, and since mongo doesnt have distinct types, I chose to only handle `datetime` type