### PR TITLE
chore: prevent CustomSqlStepWithVariables

### DIFF
--- a/server/src/weaverbird/pipeline/steps/__init__.py
+++ b/server/src/weaverbird/pipeline/steps/__init__.py
@@ -11,7 +11,7 @@ from .concatenate import ConcatenateStep, ConcatenateStepWithVariable
 from .convert import ConvertStep
 from .cumsum import CumSumStep, CumSumStepWithVariable
 from .custom import CustomStep
-from .customsql import CustomSqlStep, CustomSqlStepWithVariables
+from .customsql import CustomSqlStep
 from .date_extract import DateExtractStep, DateExtractStepWithVariable
 from .delete import DeleteStep
 from .dissolve import DissolveStep

--- a/server/src/weaverbird/pipeline/steps/customsql.py
+++ b/server/src/weaverbird/pipeline/steps/customsql.py
@@ -3,7 +3,6 @@ from typing import Literal
 from pydantic import validator
 
 from weaverbird.pipeline.steps.utils.base import BaseStep
-from weaverbird.pipeline.steps.utils.render_variables import StepWithVariablesMixin
 
 
 class CustomSqlStep(BaseStep):
@@ -22,5 +21,5 @@ class CustomSqlStep(BaseStep):
         return stripped
 
 
-class CustomSqlStepWithVariables(CustomSqlStep, StepWithVariablesMixin):
-    ...
+# /!\ Do not create CustomSqlStepWithVariables
+# (variables should not be rendered using nosql_apply_parameters_to_query)

--- a/server/tests/test_pipeline.py
+++ b/server/tests/test_pipeline.py
@@ -45,6 +45,17 @@ def test_step_with_variables(case: Case):
     assert pipeline == expected_result
 
 
+def test_custom_sql_step_with_variables():
+    steps = [{"name": "customsql", "query": "{{ __front_var_0__ }}"}]
+    variables = {"__front_var_0__": "-- DROP TABLE users;"}
+
+    pipeline_with_variables = PipelineWithVariables(steps=steps)
+    pipeline = pipeline_with_variables.render(variables, renderer=nosql_apply_parameters_to_query)
+
+    # It should not have been rendered:
+    assert pipeline.steps[0].query == "{{ __front_var_0__ }}"
+
+
 def test_to_dict():
     pipeline = Pipeline(
         steps=[


### PR DESCRIPTION
This PR doesnt change existing behaviour since CustomSqlStepWithVariables was not part of the union PipelineStepWithVariables ; but we want to make sure this is done on purpose.