### PR TITLE
chore(front): forgot to remove mathjs named export

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -52,7 +52,6 @@ export default {
     // date-fns comes from v-calendar
     commonjs({
       namedExports: {
-        'node_modules/mathjs/index.js': ['parse'],
         'node_modules/date-fns/index.js': ['addDays'],
       },
     }),


### PR DESCRIPTION
I forgot this in #1555!