### PR TITLE
chore(front): upgrade node to LTS (v18)

### DIFF
--- a/.github/workflows/ci-ui.yml
+++ b/.github/workflows/ci-ui.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '18'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
           scope: '@toucantoco'
       - run: yarn install --non-interactive --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # $ docker run -p 5000:5000 --rm -d weaverbird-playground
 # and then access http://localhost:5000/?backend=pandas
 
-FROM node:14 AS ui-builder
+FROM node:18 AS ui-builder
 
 WORKDIR /weaverbird
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Last but not least, you can **play with Weaverbird on our [online playground](ht
 yarn install
 ```
 
-**Requirement: node > v11**
+> See Dockerfile for supported node version
 
 ### Compiles target library
 


### PR DESCRIPTION
The CI/CD is blocked by the version of node it uses (too old for dependencies that we just upgraded).
https://github.com/ToucanToco/weaverbird/actions/runs/3384849837/jobs/5622306593