### PR TITLE
ci(front): check that build types complete

### DIFF
--- a/.github/workflows/ci-ui.yml
+++ b/.github/workflows/ci-ui.yml
@@ -69,4 +69,4 @@ jobs:
         if: ${{ always() }}
 
       - name: Check that build completes as expected
-        run: yarn build-bundle
+        run: yarn build


### PR DESCRIPTION
The new update of ajv seems to block the build of types. However, this was not detected by the CI! :scream: 
Let's fix this