### PR TITLE
feat(data-viewer): use map icon when column type is geometry [TCTC-4376]

### DIFF
--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -237,6 +237,8 @@ export default class DataViewer extends Vue {
         return 'check';
       case 'object':
         return '{ }';
+      case 'geometry':
+        return 'map-marked-alt';
       default:
         return '???';
     }
@@ -247,6 +249,8 @@ export default class DataViewer extends Vue {
       case 'date':
         return true;
       case 'boolean':
+        return true;
+      case 'geometry':
         return true;
       default:
         return false;

--- a/src/lib/dataset/index.ts
+++ b/src/lib/dataset/index.ts
@@ -11,7 +11,8 @@ export type DataSetColumnType =
   | 'boolean'
   | 'string'
   | 'date'
-  | 'object';
+  | 'object'
+  | 'geometry';
 export type ColumnTypeMapping = {
   [col: string]: DataSetColumnType | undefined;
 };

--- a/src/lib/dataset/pandas.ts
+++ b/src/lib/dataset/pandas.ts
@@ -13,7 +13,8 @@ type TableSchemaType =
   | 'datetime'
   | 'duration'
   | 'any'
-  | 'string';
+  | 'string'
+  | 'geometry';
 
 export interface PandasDataTable {
   schema: {
@@ -33,6 +34,7 @@ const COL_TYPE_MAPPING: Record<TableSchemaType, DataSetColumnType> = {
   duration: 'date',
   any: 'object',
   string: 'string',
+  geometry: 'geometry',
 };
 
 function tableSchemaTypeToDataSetColumnType(tableSchemaType: TableSchemaType): DataSetColumnType {

--- a/tests/unit/data-viewer.spec.ts
+++ b/tests/unit/data-viewer.spec.ts
@@ -215,7 +215,8 @@ describe('Data Viewer', () => {
               { name: 'columnE', type: 'date' },
               { name: 'columnF', type: 'object' },
               { name: 'columnG', type: 'boolean' },
-              { name: 'columnH', type: undefined },
+              { name: 'columnH', type: 'geometry' },
+              { name: 'columnI', type: undefined },
             ],
             data: [['value1', 42, 3.14, date, { obj: 'value' }, true]],
             paginationContext: {
@@ -246,7 +247,13 @@ describe('Data Viewer', () => {
           .find('FAIcon-stub')
           .props().icon,
       ).toEqual('check');
-      expect(headerIconsWrapper.at(7).text()).toEqual('???');
+      expect(
+        headerIconsWrapper
+          .at(7)
+          .find('FAIcon-stub')
+          .props().icon,
+      ).toEqual('map-marked-alt');
+      expect(headerIconsWrapper.at(8).text()).toEqual('???');
     });
 
     it('should have a action menu for each column', async () => {


### PR DESCRIPTION
Use map icon when column type is geometry

Before
<img width="543" alt="Screenshot 2022-11-08 at 12 07 44" src="https://user-images.githubusercontent.com/18734475/200551093-37d999d9-40d2-4aec-bdf1-5314a6c6c2a2.png">

After
<img width="550" alt="Screenshot 2022-11-08 at 12 08 26" src="https://user-images.githubusercontent.com/18734475/200551097-5acdc8e6-662f-4de0-997d-b9a61b665d2d.png">
