### PR TITLE
fix(ui): types defintions were not in the correct folder

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog (weaverbird npm package)
 
+## [0.94.1] - 2022-11-10
+
+### Fixed
+
+- Types definitions (.d.ts) files were not in the correct folder
+
 ## [0.94.0] - 2022-11-10
 
 ### Added
@@ -1353,6 +1359,7 @@ TabbedRangeCalendars: keep selected tab unchanged when updated enabled calendars
 - Initial version, showtime!
 
 
+[0.94.1]: https://github.com/ToucanToco/weaverbird/compare/v0.94.1...v0.94.0
 [0.94.0]: https://github.com/ToucanToco/weaverbird/compare/v0.94.0...v0.93.0
 [0.93.0]: https://github.com/ToucanToco/weaverbird/compare/v0.93.0...v0.92.0
 [0.92.0]: https://github.com/ToucanToco/weaverbird/compare/v0.92.0...v0.91.3

--- a/ui/build-types.sh
+++ b/ui/build-types.sh
@@ -11,3 +11,5 @@ do
   fi
   sed -i -r "s#((import|export) .* from ')@/(.*)#\1$path_to_src\3#g" $file
 done
+mv dist/types/src/* dist/types
+rm -r dist/types/src

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "types": "./dist/types/types.d.ts",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {

--- a/ui/sonar-project.properties
+++ b/ui/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 # sonar.projectName=weaverbird UI
-sonar.projectVersion=0.94.0
+sonar.projectVersion=0.94.1
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./src


### PR DESCRIPTION
There were in dist/types/src instead of dist dist/types
Consumers of weaverbird were not able to resolve its types in v0.94.0