### PR TITLE
fix(ui): fa- classes are not added in FA 6

### DIFF
--- a/ui/src/components/Pipeline.vue
+++ b/ui/src/components/Pipeline.vue
@@ -38,7 +38,7 @@
       <div class="query-pipeline__tips">
         Interact with the widgets and table on the right to add steps
       </div>
-      <FAIcon icon="wand-magic-sparkles" />
+      <FAIcon icon="wand-magic-sparkles" class="query-pipeline__tips-icon" />
     </div>
     <DeleteConfirmationModal
       v-if="deleteConfirmationModalIsOpened"
@@ -250,11 +250,7 @@ export default class PipelineComponent extends Vue {
   border-radius: 2px;
 }
 
-::v-deep .fa-code {
-  color: rgb(239, 239, 239);
-}
-
-::v-deep .fa-magic {
+.query-pipeline__tips-icon {
   color: rgb(239, 239, 239);
   font-size: 64px;
 }

--- a/ui/src/components/QueryBuilder.vue
+++ b/ui/src/components/QueryBuilder.vue
@@ -23,7 +23,7 @@
             class="documentation-help__content"
             :data-version="version"
           >
-            <FAIcon icon="question-circle" />
+            <FAIcon icon="question-circle" />&nbsp;
             <p>Need help?</p>
           </a>
         </div>
@@ -170,10 +170,6 @@ export default class QueryBuilder extends Vue {
 
   p {
     text-decoration: underline;
-  }
-
-  ::v-deep .fa-question-circle {
-    margin-right: 5px;
   }
 }
 </style>

--- a/ui/src/components/Step.vue
+++ b/ui/src/components/Step.vue
@@ -4,7 +4,7 @@
       <div :class="firstStrokeClass" />
       <div class="query-pipeline-queue__dot" data-cy="weaverbird-step-dot" @click="toggleDelete">
         <div class="query-pipeline-queue__dot-ink">
-          <FAIcon icon="check" />
+          <FAIcon class="query-pipeline-queue__dot-check" icon="check" />
         </div>
       </div>
       <div :class="lastStrokeClass" />
@@ -37,7 +37,7 @@
             data-cy="weaverbird-edit-step"
             @click.stop="editStep()"
           >
-            <FAIcon icon="cog" />
+            <FAIcon class="query-pipeline-step__action-icon" icon="cog" />
           </div>
           <div
             class="query-pipeline-step__action query-pipeline-step__action--handle"
@@ -257,7 +257,7 @@ export default class Step extends Vue {
   color: white;
   transform: width 0.2s, height 0.2s;
 
-  ::v-deep .fa-check {
+  .query-pipeline-queue__dot-check {
     visibility: hidden;
   }
 }
@@ -342,7 +342,7 @@ export default class Step extends Vue {
   cursor: move;
 }
 
-.query-pipeline-step__action ::v-deep .fa-cog {
+.query-pipeline-step__action-icon {
   transition: color 0.3s ease;
 }
 
@@ -387,7 +387,7 @@ export default class Step extends Vue {
   .query-pipeline-queue__dot-ink {
     background-color: $active-color-faded;
     border-color: $active-color-faded;
-    ::v-deep .fa-check {
+    .query-pipeline-queue__dot-check {
       visibility: visible;
     }
   }

--- a/ui/src/components/stepforms/widgets/InputDate.vue
+++ b/ui/src/components/stepforms/widgets/InputDate.vue
@@ -3,7 +3,7 @@
     <div class="widget-input-date__label">
       <label v-if="name" @click="$refs.input.focus()">{{ name }}</label>
       <a v-if="docUrl" :href="docUrl" target="_blank" rel="noopener">
-        <FAIcon icon="question-circle" />
+        <FAIcon class="widget-input-date__doc-icon" icon="question-circle" />
       </a>
     </div>
     <VariableInput
@@ -109,7 +109,7 @@ export default class InputDateWidget extends FormWidget {
   @extend %form-widget__label;
 }
 
-::v-deep .fa-question-circle {
+.widget-input-date__doc-icon {
   margin-left: 5px;
   color: $base-color;
   font-size: 14px;

--- a/ui/src/components/stepforms/widgets/InputNumber.vue
+++ b/ui/src/components/stepforms/widgets/InputNumber.vue
@@ -3,7 +3,7 @@
     <div class="widget-input-number__container">
       <label v-if="name" @click="$refs.input.focus()">{{ name }}</label>
       <a v-if="docUrl" :href="docUrl" target="_blank" rel="noopener">
-        <FAIcon icon="question-circle" />
+        <FAIcon class="widget-input-number__doc-icon" icon="question-circle" />
       </a>
     </div>
     <VariableInput
@@ -128,7 +128,7 @@ export default class InputNumberWidget extends FormWidget {
   @extend %form-widget__label;
 }
 
-::v-deep .fa-question-circle {
+.widget-input-number__doc-icon {
   margin-left: 5px;
   color: $base-color;
   font-size: 14px;

--- a/ui/src/components/stepforms/widgets/InputText.vue
+++ b/ui/src/components/stepforms/widgets/InputText.vue
@@ -3,7 +3,7 @@
     <div class="widget-input-text__label">
       <label v-if="name" @click="$refs.input.focus()">{{ name }}</label>
       <a v-if="docUrl" :href="docUrl" target="_blank" rel="noopener">
-        <FAIcon icon="question-circle" />
+        <FAIcon class="widget-input-text__doc-icon" icon="question-circle" />
       </a>
     </div>
 
@@ -103,7 +103,7 @@ export default class InputTextWidget extends FormWidget {
   @extend %form-widget__label;
 }
 
-::v-deep .fa-question-circle {
+.widget-input-text__doc-icon {
   margin-left: 5px;
   color: $base-color;
   font-size: 14px;

--- a/ui/src/components/stepforms/widgets/List.vue
+++ b/ui/src/components/stepforms/widgets/List.vue
@@ -31,7 +31,7 @@
         {{ messageError }}
       </div>
       <button v-if="!automaticNewField" class="widget-list__add-fieldset" @click="addFieldSet">
-        <FAIcon icon="plus-circle" />
+        <FAIcon class="widget-list__add-fieldset-icon" icon="plus-circle" />
         {{ addFieldName }}
       </button>
     </div>
@@ -161,7 +161,7 @@ export default class ListWidget extends FormWidget {
 </script>
 <style lang="scss" scoped>
 @import '../../../styles/_variables';
-::v-deep .fa-plus-circle {
+.widget-list__add-fieldset-icon {
   color: $active-color;
 }
 

--- a/ui/src/components/stepforms/widgets/VariableInputs/AdvancedVariableModal.vue
+++ b/ui/src/components/stepforms/widgets/VariableInputs/AdvancedVariableModal.vue
@@ -133,9 +133,6 @@ export default class AdvancedVariableModal extends Vue {
   position: absolute;
   top: 15px;
   right: 30px;
-}
-
-::v-deep.fa-times {
   cursor: pointer;
 }
 


### PR DESCRIPTION
Some icons relying on the fa- classes have lost their style with the migration to Font Awesome 6.

Before:
![image](https://user-images.githubusercontent.com/932583/201970454-c4d31a6c-1b83-496e-ab72-0a35a3e0a170.png)
After:
![image](https://user-images.githubusercontent.com/932583/201970427-f8b28f14-0e78-4e37-9852-9b73db00051b.png)

Also takes the opportunity to not rely on v-deep.