### PR TITLE
fix(server/pypika/filter): Ensure column to match with a regex is first casted to text

### DIFF
--- a/server/src/weaverbird/backends/pypika_translator/translators/base.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/base.py
@@ -969,7 +969,7 @@ class SQLTranslator(ABC):
                     casted_field = functions.Cast(column_field, self.DATA_TYPE_MAPPING.text)
                     match self.REGEXP_OP:
                         case RegexOp.REGEXP:
-                            return column_field.regexp(compliant_regex).negate()
+                            return casted_field.regexp(compliant_regex).negate()
                         case RegexOp.SIMILAR_TO:
                             return BasicCriterion(
                                 RegexpMatching.not_similar_to,

--- a/server/src/weaverbird/backends/pypika_translator/translators/base.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/base.py
@@ -914,47 +914,49 @@ class SQLTranslator(ABC):
                 compliant_regex = _compliant_regex(condition.value, self.DIALECT)
 
                 if condition.operator == "matches":
+                    # Casting the field to str first as it is the only compatible type for regex
+                    casted_field = functions.Cast(column_field, self.DATA_TYPE_MAPPING.text)
                     match self.REGEXP_OP:
                         case RegexOp.REGEXP:
                             return BasicCriterion(
                                 RegexpMatching.regexp,
-                                column_field,
+                                casted_field,
                                 column_field.wrap_constant(compliant_regex),
                             )
                         case RegexOp.SIMILAR_TO:
                             return BasicCriterion(
                                 RegexpMatching.similar_to,
-                                column_field,
+                                casted_field,
                                 column_field.wrap_constant(compliant_regex),
                             )
                         case RegexOp.CONTAINS:
                             return BasicCriterion(
                                 RegexpMatching.contains,
-                                column_field,
+                                casted_field,
                                 column_field.wrap_constant(compliant_regex),
                             )
                         case RegexOp.REGEXP_CONTAINS:
                             return functions.Function(
                                 RegexOp.REGEXP_CONTAINS,
-                                column_field,
+                                casted_field,
                                 column_field.wrap_constant(compliant_regex),
                             )
                         case RegexOp.REGEXP_LIKE:
                             return functions.Function(
                                 RegexOp.REGEXP_LIKE,
-                                column_field,
+                                casted_field,
                                 column_field.wrap_constant(compliant_regex),
                             )
                         case RegexOp.REGEXP_CONTAINS:
                             return functions.Function(
                                 RegexOp.NOT_REGEXP_CONTAINS,
-                                column_field,
+                                casted_field,
                                 column_field.wrap_constant(compliant_regex),
                             )
                         case RegexOp.REGEXP_LIKE:
                             return functions.Function(
                                 RegexOp.NOT_REGEXP_LIKE,
-                                column_field,
+                                casted_field,
                                 column_field.wrap_constant(compliant_regex),
                             )
                         case _:
@@ -963,31 +965,33 @@ class SQLTranslator(ABC):
                             )
 
                 elif condition.operator == "notmatches":
+                    # Casting the field to str first as it is the only compatible type for regex
+                    casted_field = functions.Cast(column_field, self.DATA_TYPE_MAPPING.text)
                     match self.REGEXP_OP:
                         case RegexOp.REGEXP:
                             return column_field.regexp(compliant_regex).negate()
                         case RegexOp.SIMILAR_TO:
                             return BasicCriterion(
                                 RegexpMatching.not_similar_to,
-                                column_field,
+                                casted_field,
                                 column_field.wrap_constant(compliant_regex),
                             )
                         case RegexOp.CONTAINS:
                             return BasicCriterion(
                                 RegexpMatching.not_contains,
-                                column_field,
+                                casted_field,
                                 column_field.wrap_constant(compliant_regex),
                             )
                         case RegexOp.REGEXP_CONTAINS:
                             return functions.Function(
                                 RegexOp.NOT_REGEXP_CONTAINS,
-                                column_field,
+                                casted_field,
                                 column_field.wrap_constant(compliant_regex),
                             )
                         case RegexOp.REGEXP_LIKE:
                             return functions.Function(
                                 RegexOp.NOT_REGEXP_LIKE,
-                                column_field,
+                                casted_field,
                                 column_field.wrap_constant(compliant_regex),
                             )
                         case _:

--- a/server/tests/backends/fixtures/filter/matches_with_float_pypika.yaml
+++ b/server/tests/backends/fixtures/filter/matches_with_float_pypika.yaml
@@ -1,0 +1,24 @@
+exclude:
+- mongo
+- pandas
+- snowflake
+expected:
+  data:
+  - name: Superstrong beer
+  schema:
+    fields:
+    - name: name
+      type: string
+    pandas_version: 1.4.0
+step:
+  pipeline:
+  - condition:
+      and:
+      - or:
+        - column: alcohol_degree
+          operator: matches
+          value: 13.5
+    name: filter
+  - columns:
+    - name
+    name: select

--- a/server/tests/backends/fixtures/filter/notmatches_with_float_pypika.yaml
+++ b/server/tests/backends/fixtures/filter/notmatches_with_float_pypika.yaml
@@ -1,0 +1,32 @@
+exclude:
+- mongo
+- pandas
+- snowflake
+expected:
+  data:
+  - name: Ninkasi Ploploplop
+  - name: Brewdog Nanny State Alcoholvrij
+  - name: Ardwen Blonde
+  - name: Cuvée des Trolls
+  - name: Weihenstephan Hefe Weizen Alcoholarm
+  - name: Bellfield Lawless Village IPA
+  - name: Pauwel Kwak
+  - name: Brasserie De Sutter Brin de Folie
+  - name: Brugse Zot blonde
+  schema:
+    fields:
+    - name: name
+      type: string
+    pandas_version: 1.4.0
+step:
+  pipeline:
+  - condition:
+      and:
+      - or:
+        - column: alcohol_degree
+          operator: notmatches
+          value: 13.5
+    name: filter
+  - columns:
+    - name
+    name: select


### PR DESCRIPTION


Without this, it is not possible to use the matches/notmatches operator on non-text columns

Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>