### PR TITLE
chore: bump weaverbird ui from 0.92.1 to 0.92.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1348,6 +1348,9 @@ TabbedRangeCalendars: keep selected tab unchanged when updated enabled calendars
 
 ## Unreleased
 
+[0.92.2]: https://github.com/ToucanToco/weaverbird/compare/v0.92.2...v0.92.1
+[0.92.1]: https://github.com/ToucanToco/weaverbird/compare/v0.92.1...v0.92.0
+[0.92.0]: https://github.com/ToucanToco/weaverbird/compare/v0.92.0...v0.91.3
 [0.91.3]: https://github.com/ToucanToco/weaverbird/compare/v0.91.3...v0.91.2
 [0.91.2]: https://github.com/ToucanToco/weaverbird/compare/v0.91.2...v0.91.1
 [0.91.1]: https://github.com/ToucanToco/weaverbird/compare/v0.91.1...v0.91.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.92.2] - 2022-12-06
+
 ### Fixed
 
 - We make sure the `$switch` aggregation should always have a `default` key

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.92.1",
+  "version": "0.92.2",
   "types": "./dist/types/types.d.ts",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 # sonar.projectName=weaverbird
-sonar.projectVersion=0.92.1
+sonar.projectVersion=0.92.2
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./src


### PR DESCRIPTION
## WHAT

Fix comming from : https://github.com/ToucanToco/weaverbird/pull/1633
