### PR TITLE
fix(server): date as null default on switch to prevent PlanExecutor error [TCTC-4622] (#1632)

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- MongoTranslator : We make sure the `$switch` aggregation should always have a `default` key
+  field set from the mongo query to prevent "PlanExecutor error".
+
 ## [0.27.2] - 2022-11-24
 
 - PyPika: Cast columns before applying a regex operation to them when using the `matches` or `notmatches` operator.

--- a/server/src/weaverbird/backends/mongo_translator/steps/fromdate.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/fromdate.py
@@ -21,6 +21,7 @@ _SMALL_MONTH_REPLACE = {
             {"case": {"$eq": ["$_vqbTempMonth", "11"]}, "then": "Nov"},
             {"case": {"$eq": ["$_vqbTempMonth", "12"]}, "then": "Dec"},
         ],
+        "default": None,
     },
 }
 
@@ -40,6 +41,7 @@ _FULL_MONTH_REPLACE = {
             {"case": {"$eq": ["$_vqbTempMonth", "11"]}, "then": "November"},
             {"case": {"$eq": ["$_vqbTempMonth", "12"]}, "then": "December"},
         ],
+        "default": None,
     },
 }
 

--- a/server/src/weaverbird/backends/mongo_translator/steps/todate.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/todate.py
@@ -193,7 +193,8 @@ MONTH_REPLACEMENT_STEP: MongoStep = {
                     "then": month_number,
                 }
                 for month_number, month_names in MONTH_NUMBER_TO_NAMES.items()
-            ]
+            ],
+            "default": None,
         }
     }
 }

--- a/server/tests/backends/fixtures/fromdate/simple_with_null.json
+++ b/server/tests/backends/fixtures/fromdate/simple_with_null.json
@@ -13,7 +13,7 @@
       {
         "name": "fromdate",
         "column": "CREATED_DATE",
-        "format": "%Y-%m-%d"
+        "format": "%d %b %Y"
       }
     ]
   },
@@ -36,6 +36,11 @@
       "pandas_version": "0.20.0"
     },
     "data": [
+      {
+        "NAME": "foo",
+        "AGE": 30,
+        "CREATED_DATE": null
+      },
       {
         "NAME": "foo",
         "AGE": 42,
@@ -64,8 +69,13 @@
     "data": [
       {
         "NAME": "foo",
+        "AGE": 30,
+        "CREATED_DATE": null
+      },
+      {
+        "NAME": "foo",
         "AGE": 42,
-        "CREATED_DATE": "2020-03-09"
+        "CREATED_DATE": "09 Mar 2020"
       }
     ]
   }


### PR DESCRIPTION
## WHAT 

* fix: added a default on switch
* chore: added a entry to the changelog
* test: some fixtures with null in dataset
* feat: restore the old fixture
* feat: added a new fixture for the fix that handle nulls on weird formats
