### PR TITLE
[cherry-pick] fix(backend/pandas/addmissingdates): Ensure we always insert pd.Timestamp objects (#1644)

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Pandas: Ensure the `addmissingdates` step always inserts Timestamp objects rather than integers
+
 - MongoTranslator : We make sure the `$switch` aggregation should always have a `default` key
   field set from the mongo query to prevent "PlanExecutor error".
 

--- a/server/src/weaverbird/backends/pandas_executor/steps/addmissingdates.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/addmissingdates.py
@@ -10,7 +10,12 @@ _FREQUENCIES = {"day": "D", "week": "W", "month": "M", "year": "Y"}
 
 
 def at_begin_period(timestamps: Series, dates_granularity: str):
-    return timestamps.dt.to_period(_FREQUENCIES[dates_granularity]).dt.start_time
+    # Returns the timezone of the Series, or None in case all objects is naive. In case of mixed
+    # objects or non-datetime series, raises an exception
+    tz = timestamps.dt.tz
+    naive_start_times = timestamps.dt.to_period(_FREQUENCIES[dates_granularity]).dt.start_time
+    # Setting the right TZ for all objects
+    return naive_start_times.dt.tz_localize(tz)
 
 
 def execute_addmissingdates(

--- a/server/tests/backends/fixtures/addmissingdates/simple.json
+++ b/server/tests/backends/fixtures/addmissingdates/simple.json
@@ -1,0 +1,87 @@
+{
+    "exclude": [
+        "athena_pypika",
+        "bigquery_pypika",
+        "mysql_pypika",
+        "postgres_pypika",
+        "redshift_pypika",
+        "snowflake_pypika"
+    ],
+    "step": {
+        "pipeline": [
+            {
+                "name": "addmissingdates",
+                "dates_column": "DATE",
+                "dates_granularity": "day",
+                "groups": []
+            }
+        ]
+    },
+    "input": {
+        "schema": {
+            "fields": [
+                {
+                    "name": "DATE",
+                    "type": "datetime"
+                },
+                {
+                    "name": "AGE",
+                    "type": "integer"
+                },
+                {
+                    "name": "SCORE",
+                    "type": "number"
+                }
+            ],
+            "pandas_version": "0.20.0"
+        },
+        "data": [
+            {
+                "DATE": "2022-12-07T00:00:00",
+                "AGE": 42,
+                "SCORE": 12.34
+            },
+            {
+                "DATE": "2022-12-09T00:00:00",
+                "AGE": 21,
+                "SCORE": 43.32
+            }
+        ]
+    },
+    "expected": {
+        "schema": {
+            "fields": [
+                {
+                    "name": "DATE",
+                    "type": "datetime"
+                },
+                {
+                    "name": "AGE",
+                    "type": "number"
+                },
+                {
+                    "name": "SCORE",
+                    "type": "number"
+                }
+            ],
+            "pandas_version": "0.20.0"
+        },
+        "data": [
+            {
+                "DATE": "2022-12-07T00:00:00",
+                "AGE": 42,
+                "SCORE": 12.34
+            },
+            {
+                "DATE": "2022-12-08T00:00:00",
+                "AGE": "nan",
+                "SCORE": "nan"
+            },
+            {
+                "DATE": "2022-12-09T00:00:00",
+                "AGE": 21,
+                "SCORE": 43.32
+            }
+        ]
+    }
+}

--- a/server/tests/backends/fixtures/addmissingdates/simple_with_tz.yaml
+++ b/server/tests/backends/fixtures/addmissingdates/simple_with_tz.yaml
@@ -1,0 +1,53 @@
+exclude:
+- athena_pypika
+- bigquery_pypika
+- mysql_pypika
+- postgres_pypika
+- redshift_pypika
+- snowflake_pypika
+input:
+  data:
+  - AGE: 42
+    # Equivalent to '2022-12-09T00:00:00+00:00'. This format is used so that pandas loads this as a timezone-aware
+    # timestamp object
+    DATE: 1670371200000000000
+    SCORE: 12.34
+  - AGE: 21
+    # '2022-12-09T00:00:00+00:00'
+    DATE: 1670544000000000000
+    SCORE: 43.32
+  schema:
+    fields:
+    - name: DATE
+      type: datetime
+    - name: AGE
+      type: integer
+    - name: SCORE
+      type: number
+    pandas_version: 0.20.0
+expected:
+  data:
+  - AGE: 42
+    DATE: '2022-12-07T00:00:00+00:00'
+    SCORE: 12.34
+  - AGE: nan
+    DATE: '2022-12-08T00:00:00+00:00'
+    SCORE: nan
+  - AGE: 21
+    DATE: '2022-12-09T00:00:00+00:00'
+    SCORE: 43.32
+  schema:
+    fields:
+    - name: DATE
+      type: datetime
+    - name: AGE
+      type: number
+    - name: SCORE
+      type: number
+    pandas_version: 0.20.0
+step:
+  pipeline:
+  - dates_column: DATE
+    dates_granularity: day
+    groups: []
+    name: addmissingdates


### PR DESCRIPTION
Before this change, in case we had timezone-aware series, inserting the start of a period (naive) would result in an integer (representing a unix timestamp in nanoseconds). The resulting series would end up being a mix of tz-aware timestamp objects and integers (for naive inserted dates).

This ensures that inserted objects are properly localized if required.

closes TCTC-4429