### PR TITLE
fix(new-date-input): popover position [TCTC-4324]

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## [0.98.2] - 2022-12-13
+
+### Fixed
+
+- Avoid date picker popover to overflow the window
+- Allow to remove any aggregation in rollup step form
+
 ## [0.98.1] - 2022-12-07
 
 ### Changed
@@ -1409,7 +1416,7 @@ TabbedRangeCalendars: keep selected tab unchanged when updated enabled calendars
 
 - Initial version, showtime!
 
-
+[0.98.2]: https://github.com/ToucanToco/weaverbird/compare/v0.98.2...v0.98.1
 [0.98.1]: https://github.com/ToucanToco/weaverbird/compare/v0.98.1...v0.98.0
 [0.98.0]: https://github.com/ToucanToco/weaverbird/compare/v0.98.0...v0.97.0
 [0.97.0]: https://github.com/ToucanToco/weaverbird/compare/v0.97.0...v0.96.0

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.98.1",
+  "version": "0.98.2",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
     "url": "https://github.com/ToucanToco/weaverbird/issues",

--- a/ui/sonar-project.properties
+++ b/ui/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 # sonar.projectName=weaverbird UI
-sonar.projectVersion=0.98.1
+sonar.projectVersion=0.98.2
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./src

--- a/ui/src/components/Popover.vue
+++ b/ui/src/components/Popover.vue
@@ -1,7 +1,10 @@
 <template>
   <div
     class="weaverbird-popover"
-    :class="{ 'weaverbird-popover--always-opened': alwaysOpened }"
+    :class="{
+      'weaverbird-popover--always-opened': alwaysOpened,
+      'weaverbird-popover--calculated-height': shouldCalculateHeight,
+    }"
     data-cy="weaverbird-popover"
     :style="elementStyle"
     @click.stop
@@ -223,5 +226,8 @@ export default class Popover extends Vue {
   position: absolute;
   visibility: visible;
   z-index: 2;
+}
+.weaverbird-popover--calculated-height {
+  // Don't remove me, i'm used as wrapper in child components
 }
 </style>

--- a/ui/src/components/Popover.vue
+++ b/ui/src/components/Popover.vue
@@ -26,6 +26,7 @@ interface ElementPosition {
   bottom?: string | number;
   left?: string | number;
   right?: string | number;
+  height?: string | number;
 }
 
 /**
@@ -81,6 +82,12 @@ export default class Popover extends Vue {
     default: false,
   })
   alwaysOpened!: boolean;
+
+  @Prop({
+    type: Boolean,
+    default: false,
+  })
+  shouldCalculateHeight!: boolean;
 
   // Inject any element as `weaverbirdPopoverContainer` in any parent component
   @Inject({ default: document.body }) weaverbirdPopoverContainer!: Element;
@@ -199,6 +206,9 @@ export default class Popover extends Vue {
       // Set alignment
       const elementStyle: ElementPosition = DOMUtil.align(this.align, positionContext);
       elementStyle.top = DOMUtil.computeTop(this.bottom, positionContext);
+      if (this.shouldCalculateHeight) {
+        elementStyle.height = DOMUtil.computeHeight(this.bottom, positionContext);
+      }
       // make sure to use `px` unit explicitly
       this.elementStyle = _.fromPairs(Object.entries(elementStyle).map(([k, v]) => [k, `${v}px`]));
     },

--- a/ui/src/components/Popover.vue
+++ b/ui/src/components/Popover.vue
@@ -227,7 +227,4 @@ export default class Popover extends Vue {
   visibility: visible;
   z-index: 2;
 }
-.weaverbird-popover--calculated-height {
-  // Don't remove me, i'm used as wrapper in child components
-}
 </style>

--- a/ui/src/components/domutil.ts
+++ b/ui/src/components/domutil.ts
@@ -258,3 +258,30 @@ export function computeTop(fromBottom = false, ctx: PartialPositionContext) {
 
   return top;
 }
+
+/**
+ * Compute the "height" property for `ctx.element`.
+ *
+ * @param fromBottom whether or not the element should be "bottom" or "top" aligned
+ * @param ctx the position context used to make positioning computations
+ */
+export function computeHeight(fromBottom = false, ctx: PartialPositionContext) {
+  let height;
+  const top = computeTop(fromBottom, ctx);
+  const { body } = completePositionContext(ctx);
+  const bodyHeight = body.height;
+
+  /**
+   * Restrict the height when necessary
+   * We assume that if the top of the element is above the middle of the page,
+   * we will have enough space to let it grow.
+   */
+  if (top < bodyHeight / 2) {
+    // leave the default height
+    height = undefined;
+  } else {
+    // avoid the element to overflow the body
+    height = bodyHeight - top;
+  }
+  return height;
+}

--- a/ui/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -33,6 +33,7 @@
       :visible="isEditorOpened"
       :align="alignLeft"
       @closed="closeEditor"
+      :shouldCalculateHeight="true"
       bottom
     >
       <div class="widget-date-input__editor-container">
@@ -402,7 +403,6 @@ export default class NewDateInput extends Vue {
 }
 .widget-date-input__editor-body {
   flex: 1;
-  height: 280px;
   min-height: 280px;
   width: 280px;
   .vc-container {
@@ -447,5 +447,16 @@ export default class NewDateInput extends Vue {
   opacity: 0.5;
   pointer-events: none;
   cursor: not-allowed;
+}
+
+// specifics styles when Popover has the prop shouldCalculateHeight
+.weaverbird-popover--calculated-height {
+  .widget-date-input__editor-content {
+    overflow: hidden;
+  }
+  .widget-date-input__editor-body {
+    min-height: 0;
+    overflow: auto;
+  }
 }
 </style>

--- a/ui/tests/unit/domutil.spec.ts
+++ b/ui/tests/unit/domutil.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeHeight } from '@/components/domutil';
+
+describe('domutil', () => {
+  describe('computeHeight', () => {
+    it('should return undefined when there is enough space to display', () => {
+      const ctx = {
+        body: { height: 500, top: 0 },
+        parent: { height: 40, top: 200 },
+        element: { offsetHeight: 400 },
+        window: { innerHeight: 500 },
+      };
+      expect(computeHeight(true, ctx)).toBe(undefined);
+    });
+
+    it('should return 200 when there is not enough space to display', () => {
+      const ctx = {
+        body: { height: 500, top: 0 },
+        parent: { height: 40, top: 300 },
+        element: { offsetHeight: 400 },
+        window: { innerHeight: 500 },
+      };
+      expect(computeHeight(true, ctx)).toBe(160);
+    });
+  });
+});


### PR DESCRIPTION
The Popover was overflowing the window, so we couldn't click on the bottom buttons

Before
https://user-images.githubusercontent.com/18734475/207180976-41706956-b73e-41d9-a576-898c13accadd.mp4

After
https://user-images.githubusercontent.com/18734475/207180990-b5657c32-b5f4-409d-b423-848d13fe1045.mp4

ℹ️ I add a prop `shouldCalculateHeight` prop set to false by default to prevent to break other components that are using Popover.