### PR TITLE
feat(labeller): rename queries to availableDomains [TCTC-4877]

### DIFF
--- a/ui/src/components/Step.vue
+++ b/ui/src/components/Step.vue
@@ -86,7 +86,7 @@ import PreviewSourceSubset from './PreviewSourceSubset.vue';
   },
 })
 export default class Step extends Vue {
-  @VQBModule.State queries!: { name: string; uid: string }[];
+  @VQBModule.State availableDomains!: { name: string; uid: string }[];
 
   @Prop(Boolean)
   readonly isFirst!: boolean;
@@ -132,7 +132,7 @@ export default class Step extends Vue {
   get stepName(): string {
     // enable to retrieve the related name of a query referenced behind an uid
     return humanReadableLabel(this.step, (domain: string | ReferenceToExternalQuery) =>
-      retrieveDomainName(domain, this.queries),
+      retrieveDomainName(domain, this.availableDomains),
     );
   }
 

--- a/ui/src/lib/labeller.ts
+++ b/ui/src/lib/labeller.ts
@@ -146,8 +146,9 @@ class StepLabeller implements StepMatcher<string> {
     }
     if (columns.length === 1) {
       const [aggstep] = step.aggregations;
-      return `${capitalize(AGGFUNCTION_LABELS[aggstep.aggfunction])} of "${columns[0]
-        }" grouped by ${dimensions}`;
+      return `${capitalize(AGGFUNCTION_LABELS[aggstep.aggfunction])} of "${
+        columns[0]
+      }" grouped by ${dimensions}`;
     } else {
       return `Aggregate ${formatMulticol(columns)} grouped by ${dimensions}`;
     }

--- a/ui/src/lib/labeller.ts
+++ b/ui/src/lib/labeller.ts
@@ -146,9 +146,8 @@ class StepLabeller implements StepMatcher<string> {
     }
     if (columns.length === 1) {
       const [aggstep] = step.aggregations;
-      return `${capitalize(AGGFUNCTION_LABELS[aggstep.aggfunction])} of "${
-        columns[0]
-      }" grouped by ${dimensions}`;
+      return `${capitalize(AGGFUNCTION_LABELS[aggstep.aggfunction])} of "${columns[0]
+        }" grouped by ${dimensions}`;
     } else {
       return `Aggregate ${formatMulticol(columns)} grouped by ${dimensions}`;
     }
@@ -411,11 +410,8 @@ export function labelWithReadeableVariables(
 // enable to retrieve the related name of a query referenced behind an uid
 export function retrieveDomainName(
   domain: string | S.ReferenceToExternalQuery,
-  queries: { name: string; uid: string }[],
+  availableDomains: { name: string; uid: string }[],
 ): string {
-  if (S.isReferenceToExternalQuery(domain)) {
-    return queries.find((q) => q.uid === domain.uid)?.name ?? domain.uid;
-  } else {
-    return domain;
-  }
+  const domainOrUid = S.isReferenceToExternalQuery(domain) ? domain.uid : domain;
+  return availableDomains.find((q) => q.uid === domainOrUid)?.name ?? domainOrUid;
 }

--- a/ui/src/store/mutations.ts
+++ b/ui/src/store/mutations.ts
@@ -33,9 +33,9 @@ type DomainsMutation = {
   payload: Pick<VQBState, 'domains'>;
 };
 
-type QueriesMutation = {
-  type: 'setQueries';
-  payload: Pick<VQBState, 'queries'>;
+type AvailableDomainsMutation = {
+  type: 'setAvailableDomains';
+  payload: Pick<VQBState, 'availableDomains'>;
 };
 
 type PipelineMutation = {
@@ -103,7 +103,7 @@ export type StateMutation =
   | ToggleColumnSelectionMutation
   | ToggleRequestOnGoing
   | VariableDelimitersMutation
-  | QueriesMutation;
+  | AvailableDomainsMutation;
 
 type MutationByType<M, MT> = M extends { type: MT } ? M : never;
 export type MutationCallbacks = {
@@ -205,8 +205,8 @@ const mutations: MutationTree<VQBState> = {
     state.domains = domains;
   },
 
-  setQueries(state: VQBState, { queries }: Pick<VQBState, 'queries'>) {
-    state.queries = queries;
+  setAvailableDomains(state: VQBState, { availableDomains }: Pick<VQBState, 'availableDomains'>) {
+    state.availableDomains = availableDomains;
   },
 
   setPipeline(state: VQBState, { pipeline }: { pipeline: Pipeline }) {

--- a/ui/src/store/state.ts
+++ b/ui/src/store/state.ts
@@ -27,7 +27,7 @@ export interface VQBState {
   interpolateFunc?: InterpolateFunction;
 
   domains: string[];
-  queries: { name: string; uid: string }[];
+  availableDomains: { name: string; uid: string }[];
   pipelines: { [name: string]: Pipeline };
 
   dataset: DataSet; // currently preview one
@@ -84,7 +84,7 @@ export function emptyState(): VQBState {
     },
     rightColumnNames: [],
     domains: [],
-    queries: [],
+    availableDomains: [],
     currentStepFormName: undefined,
     stepFormInitialValue: undefined,
     stepFormDefaults: undefined,

--- a/ui/tests/unit/step.spec.ts
+++ b/ui/tests/unit/step.spec.ts
@@ -31,7 +31,7 @@ describe('Step.vue', () => {
       { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
     ];
     const store = setupMockStore(
-      buildStateWithOnePipeline(pipeline, { queries: [{ uid: '1', name: 'Query 1' }] }),
+      buildStateWithOnePipeline(pipeline, { availableDomains: [{ uid: '1', name: 'Query 1' }] }),
     );
     return shallowMount(Step, {
       propsData,

--- a/ui/tests/unit/store.spec.ts
+++ b/ui/tests/unit/store.spec.ts
@@ -581,7 +581,7 @@ describe('mutation tests', () => {
   it('sets availableDomains list', () => {
     const state = buildState({});
     expect(state.availableDomains).toEqual([]);
-    mutations.setavailableDomains(state, { availableDomains: [{ uid: '1', name: 'Query 1' }] });
+    mutations.setAvailableDomains(state, { availableDomains: [{ uid: '1', name: 'Query 1' }] });
     expect(state.availableDomains).toEqual([{ uid: '1', name: 'Query 1' }]);
   });
 

--- a/ui/tests/unit/store.spec.ts
+++ b/ui/tests/unit/store.spec.ts
@@ -578,11 +578,11 @@ describe('mutation tests', () => {
     expect(state.domains).toEqual(['foo', 'bar']);
   });
 
-  it('sets queries list', () => {
+  it('sets availableDomains list', () => {
     const state = buildState({});
-    expect(state.queries).toEqual([]);
-    mutations.setQueries(state, { queries: [{ uid: '1', name: 'Query 1' }] });
-    expect(state.queries).toEqual([{ uid: '1', name: 'Query 1' }]);
+    expect(state.availableDomains).toEqual([]);
+    mutations.setavailableDomains(state, { availableDomains: [{ uid: '1', name: 'Query 1' }] });
+    expect(state.availableDomains).toEqual([{ uid: '1', name: 'Query 1' }]);
   });
 
   it('sets currentPipelineName', () => {


### PR DESCRIPTION
We will need to retrieve domain name for uid on a model that can be different than {type: 'ref', uid: xxx}, i thought than it won't be very impacting on performances to check if a domain (even only a string) is referencing as an uid into the list of availableDomains (previously queries but renamed because it could be other things than queries). This way if we find a reference as uid in the list we will use the domain instead, we always suppose that the domain can be an uid, even if it is only a string.