### PR TITLE
fix(backend/pandas): Convert target columns to timestamps before operating on them in duration step TCTC-4823

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 - Pandas: The `dateextract` step now works with columns containing `datetime.date` instances.
-
 - Pandas: The `evolution` step now works with columns containing `datetime.date` instances.
+- Pandas: The `duration` step now works with columns containing datetime.date instances
 
 ## [0.26.3] - 2022-12-07
 

--- a/server/src/weaverbird/backends/pandas_executor/steps/duration.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/duration.py
@@ -1,4 +1,4 @@
-from pandas import DataFrame
+from pandas import DataFrame, to_datetime
 
 from weaverbird.backends.pandas_executor.types import DomainRetriever, PipelineExecutor
 from weaverbird.pipeline.steps import DurationStep
@@ -17,8 +17,8 @@ def execute_duration(
     domain_retriever: DomainRetriever = None,
     execute_pipeline: PipelineExecutor = None,
 ) -> DataFrame:
-    duration_serie_in_seconds = (df[step.end_date_column] - df[step.start_date_column]).astype(
-        "timedelta64[s]"
-    )
+    start_date_series = to_datetime(df[step.start_date_column])
+    end_date_series = to_datetime(df[step.end_date_column])
+    duration_serie_in_seconds = (end_date_series - start_date_series).astype("timedelta64[s]")
     duration_serie_in_given_unit = duration_serie_in_seconds / DURATIONS_IN_SECOND[step.duration_in]
     return df.assign(**{step.new_column_name: duration_serie_in_given_unit})

--- a/server/tests/steps/test_duration.py
+++ b/server/tests/steps/test_duration.py
@@ -43,6 +43,44 @@ def test_duration(time_delta_parameters: dict[str, int], duration_in: str, expec
     assert_dataframes_equals(result_df, expected_result)
 
 
+@pytest.mark.parametrize(
+    "time_delta_parameters, duration_in, expected_result",
+    [
+        ({"days": 30}, "hours", 30.0 * 24),
+        ({"days": 1, "hours": 12}, "hours", 36),
+        ({"hours": 1}, "days", 1 / 24.0),
+    ],
+)
+def test_duration_with_dates(
+    time_delta_parameters: dict[str, int], duration_in: str, expected_result: float
+):
+    step = DurationStep(
+        name="duration",
+        newColumnName="DURATION",
+        startDateColumn="START_DATE",
+        endDateColumn="END_DATE",
+        durationIn=duration_in,
+    )
+
+    now_as_date = datetime.now().date()
+    now = datetime(now_as_date.year, now_as_date.month, now_as_date.day)
+
+    delta = timedelta(**time_delta_parameters)
+    sample_df = pd.DataFrame({"START_DATE": [now_as_date], "END_DATE": [now + delta]})
+
+    result_df = execute_duration(step, sample_df)
+
+    expected_result = pd.DataFrame(
+        {
+            "START_DATE": [now],
+            "END_DATE": [now + delta],
+            "DURATION": [expected_result],
+        }
+    )
+
+    assert_dataframes_equals(result_df, expected_result)
+
+
 def test_benchmark_duration(benchmark):
     dates = [datetime.today() + timedelta(days=nb_day) for nb_day in list(range(1, 2001))]
     after_dates = [date + timedelta(days=1) for date in dates]


### PR DESCRIPTION
Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>