### PR TITLE
fix(backend/pandas): Convert target columns to timestamps before operating on them in evolution step TCTC-4826

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Pandas: The `evolution` step now works with columns containing `datetime.date` instances.
+
 ## [0.26.3] - 2022-12-07
 
 - Pandas: Ensure the `addmissingdates` step always inserts Timestamp objects rather than integers

--- a/server/src/weaverbird/backends/pandas_executor/steps/evolution.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/evolution.py
@@ -1,4 +1,4 @@
-from pandas import DataFrame, DateOffset
+from pandas import DataFrame, DateOffset, to_datetime
 
 from weaverbird.backends.pandas_executor.types import DomainRetriever, PipelineExecutor
 from weaverbird.exceptions import DuplicateError
@@ -20,6 +20,9 @@ def execute_evolution(
 ) -> DataFrame:
     new_column = step.new_column or f"{step.value_col}_EVOL_{step.evolution_format.upper()}"
     df = df.reset_index(drop=True)
+    # Ensure we do have a datetime series rather than object (that would be the case for
+    # datetime.date instances)
+    df[step.date_col] = to_datetime(df[step.date_col])
 
     id_cols = [step.date_col] + step.index_columns
     if df.set_index(id_cols).index.duplicated().any():

--- a/server/tests/steps/test_evolution.py
+++ b/server/tests/steps/test_evolution.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 import numpy as np
 import pytest
@@ -21,6 +21,17 @@ def sample_df():
     )
 
 
+@pytest.fixture
+def sample_dates_df():
+    return DataFrame(
+        {
+            "DATE": [date(2019, month, 1) for month in (6, 7, 8, 9, 11, 12)],
+            "VALUE": [79, 81, 77, 75, 78, 88],
+        },
+        index=[1, 3, 2, 5, 6, 4],  # make sure the evolution handles mixed indexes
+    )
+
+
 def test_evolution_absolute(sample_df: DataFrame):
     step = EvolutionStep(
         name="evolution",
@@ -32,6 +43,20 @@ def test_evolution_absolute(sample_df: DataFrame):
     df_result = execute_evolution(step, sample_df)
 
     expected_result = sample_df.assign(VALUE_EVOL_ABS=[None, 2, -4, -2, None, 10])
+    assert_dataframes_equals(df_result, expected_result)
+
+
+def test_evolution_absolute_with_dates(sample_dates_df: DataFrame):
+    step = EvolutionStep(
+        name="evolution",
+        dateCol="DATE",
+        valueCol="VALUE",
+        evolutionType="vsLastMonth",
+        evolutionFormat="abs",
+    )
+    df_result = execute_evolution(step, sample_dates_df)
+
+    expected_result = sample_dates_df.assign(VALUE_EVOL_ABS=[None, 2, -4, -2, None, 10])
     assert_dataframes_equals(df_result, expected_result)
 
 


### PR DESCRIPTION
Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>