### PR TITLE
[backport] fix(backend/mongo/aggregate): Rename _id to __id in case it's part of an aggregation's new columns

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## [0.27.5] - 2022-12-30
+
+- Mongo: In case the `_id` column is an expected output column for an `aggregation` step, rename it to `__id`
+  to prevent an error.
+
 ## [0.27.4] - 2022-12-27
 
 ### Fixed

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "weaverbird"
-version = "0.27.4"
+version = "0.27.5"
 description = "A visual data pipeline builder with various backends"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 keywords = ["mongodb", "pandas", "sql", "data", "dataviz", "pipeline", "query", "builder"]

--- a/server/src/weaverbird/backends/mongo_translator/steps/aggregate.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/aggregate.py
@@ -3,17 +3,22 @@ from typing import Any
 from weaverbird.backends.mongo_translator.steps.types import MongoStep
 from weaverbird.pipeline.steps import AggregateStep
 
+_ID_COLUMN = "_id"
+_NEW_ID_COLUMN = "__id"
+
 
 def translate_aggregate(step: AggregateStep) -> list[MongoStep]:
     idblock = {col: f"${col}" for col in step.on}
     group: dict[str, dict] = {}
     project: dict[str, Any] = {}
     add_fields = {}
-    group["_id"] = idblock
+    group[_ID_COLUMN] = idblock
 
     for agg_f_step in step.aggregations:
         cols = agg_f_step.columns
-        new_cols = agg_f_step.new_columns
+        # _id is a name reserved by mongo. If for some reason, a user wants to aggregate the _id
+        # column, the aggregation result will be stored in a new __id column
+        new_cols = [col if col != _ID_COLUMN else _NEW_ID_COLUMN for col in agg_f_step.new_columns]
 
         # There is no `$count` operator in Mongo, we have to `$sum` 1s to get
         # an equivalent result
@@ -37,18 +42,18 @@ def translate_aggregate(step: AggregateStep) -> list[MongoStep]:
             {"$unwind": "$_vqbDocsArray"},
             {"$replaceRoot": {"newRoot": {"$mergeObjects": ["$_vqbDocsArray", "$$ROOT"]}}},
             {"$project": {"_vqbDocsArray": 0}},
-            {"$sort": {"_id": 1}},
+            {"$sort": {_ID_COLUMN: 1}},
         ]
     else:
         for group_key in group.keys():
-            if group_key == "_id":
+            if group_key == _ID_COLUMN:
                 for id_key in group[group_key]:
-                    project[id_key] = f"$_id.{id_key}"
+                    project[id_key] = f"${_ID_COLUMN}.{id_key}"
             else:
                 project[group_key] = 1
         return [
             {"$group": group},
             *add_fields_to_add_to_pipeline,
             {"$project": project},
-            {"$sort": {"_id": 1}},
+            {"$sort": {_ID_COLUMN: 1}},
         ]

--- a/server/tests/backends/fixtures/aggregate/first_with_special_column_name_mongo.json
+++ b/server/tests/backends/fixtures/aggregate/first_with_special_column_name_mongo.json
@@ -1,0 +1,120 @@
+{
+  "exclude": [
+    "athena_pypika",
+    "bigquery_pypika",
+    "mysql_pypika",
+    "pandas",
+    "postgres_pypika",
+    "redshift_pypika",
+    "snowflake",
+    "snowflake_pypika"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "aggregate",
+        "on": [
+          "DOUM"
+        ],
+        "aggregations": [
+          {
+            "newcolumns": [
+              "_id"
+            ],
+            "aggfunction": "first",
+            "columns": [
+              "_id"
+            ]
+          }
+        ],
+        "keepOriginalGranularity": false
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "_id",
+          "type": "string"
+        },
+        {
+          "name": "DOUM",
+          "type": "string"
+        },
+        {
+          "name": "VALUE1",
+          "type": "integer"
+        },
+        {
+          "name": "VALUE2",
+          "type": "integer"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "_id": "Label 1",
+        "DOUM": "Group 1",
+        "VALUE1": 13,
+        "VALUE2": 10
+      },
+      {
+        "_id": "Label 2",
+        "DOUM": "Group 1",
+        "VALUE1": 7,
+        "VALUE2": 21
+      },
+      {
+        "_id": "Label 3",
+        "DOUM": "Group 1",
+        "VALUE1": 20,
+        "VALUE2": 4
+      },
+      {
+        "_id": "Label 4",
+        "DOUM": "Group 2",
+        "VALUE1": 1,
+        "VALUE2": 17
+      },
+      {
+        "_id": "Label 5",
+        "DOUM": "Group 2",
+        "VALUE1": 10,
+        "VALUE2": 12
+      },
+      {
+        "_id": "Label 6",
+        "DOUM": "Group 2",
+        "VALUE1": 5,
+        "VALUE2": 2
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "DOUM",
+          "type": "string"
+        },
+        {
+          "name": "__id",
+          "type": "string"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "DOUM": "Group 1",
+        "__id": "Label 1"
+      },
+      {
+        "DOUM": "Group 2",
+        "__id": "Label 4"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
_id is reserved by mongo. Thus, we cannot overwrite it