### PR TITLE
fix(new-date-input): show all options for relative date dropdown [TCTC-3428] [TCTC-2484]

### DIFF
--- a/ui/src/components/stepforms/widgets/Autocomplete.vue
+++ b/ui/src/components/stepforms/widgets/Autocomplete.vue
@@ -23,10 +23,10 @@
         @input="updateValue"
       >
         <!-- If you want to use those templates, you should provide a 'label' key in the options -->
-        <template v-if="withTitleAttribute" slot="singleLabel" slot-scope="props">
+        <template v-if="options[0].label" slot="singleLabel" slot-scope="props">
           <span class="option__title">{{ props.option.label }}</span>
         </template>
-        <template v-if="withTitleAttribute" slot="option" slot-scope="props">
+        <template v-if="options[0].label" slot="option" slot-scope="props">
           <div class="option__container" :title="props.option.tooltip">
             <div class="option__title" :title="props.option.label">{{ props.option.label }}</div>
             <!-- To display an example - e.g. "Wed Jan 04 2023" for "Today" label -
@@ -72,7 +72,7 @@ export default class AutocompleteWidget extends FormWidget {
   value!: string | object;
 
   @Prop({ type: Array, default: () => [] })
-  options!: string[];
+  options!: string[] | object[];
 
   @Prop({ type: String, default: undefined })
   trackBy!: string;
@@ -82,9 +82,6 @@ export default class AutocompleteWidget extends FormWidget {
 
   @Prop({ type: Boolean, default: false })
   withExample!: boolean;
-
-  @Prop({ type: Boolean, default: false })
-  withTitleAttribute!: boolean;
 
   @Prop()
   availableVariables?: VariablesBucket;

--- a/ui/src/components/stepforms/widgets/Autocomplete.vue
+++ b/ui/src/components/stepforms/widgets/Autocomplete.vue
@@ -22,15 +22,16 @@
         openDirection="bottom"
         @input="updateValue"
       >
-        <!-- If you want to use those templates you should provide a 'label' and
-      'example' key in the options-->
-        <template v-if="withExample" slot="singleLabel" slot-scope="props">
+        <!-- If you want to use those templates, you should provide a 'label' key in the options -->
+        <template v-if="withTitleAttribute" slot="singleLabel" slot-scope="props">
           <span class="option__title">{{ props.option.label }}</span>
         </template>
-        <template v-if="withExample" slot="option" slot-scope="props">
+        <template v-if="withTitleAttribute" slot="option" slot-scope="props">
           <div class="option__container" :title="props.option.tooltip">
-            <div class="option__title">{{ props.option.label }}</div>
-            <div class="option__example">{{ props.option.example }}</div>
+            <div class="option__title" :title="props.option.label">{{ props.option.label }}</div>
+            <!-- To display an example - e.g. "Wed Jan 04 2023" for "Today" label -
+                you should provide a 'example' key in the options -->
+            <div v-if="withExample" class="option__example">{{ props.option.example }}</div>
           </div>
         </template>
       </multiselect>
@@ -81,6 +82,9 @@ export default class AutocompleteWidget extends FormWidget {
 
   @Prop({ type: Boolean, default: false })
   withExample!: boolean;
+
+  @Prop({ type: Boolean, default: false })
+  withTitleAttribute!: boolean;
 
   @Prop()
   availableVariables?: VariablesBucket;

--- a/ui/src/components/stepforms/widgets/Autocomplete.vue
+++ b/ui/src/components/stepforms/widgets/Autocomplete.vue
@@ -23,10 +23,10 @@
         @input="updateValue"
       >
         <!-- If you want to use those templates, you should provide a 'label' key in the options -->
-        <template v-if="options[0].label" slot="singleLabel" slot-scope="props">
+        <template v-if="options[0] && options[0].label" slot="singleLabel" slot-scope="props">
           <span class="option__title">{{ props.option.label }}</span>
         </template>
-        <template v-if="options[0].label" slot="option" slot-scope="props">
+        <template v-if="options[0] && options[0].label" slot="option" slot-scope="props">
           <div class="option__container" :title="props.option.tooltip">
             <div class="option__title" :title="props.option.label">{{ props.option.label }}</div>
             <!-- To display an example - e.g. "Wed Jan 04 2023" for "Today" label -

--- a/ui/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -61,7 +61,10 @@
             :selectedTab="selectedTab"
             @tabSelected="selectTab"
           />
-          <div class="widget-date-input__editor-body">
+          <div
+            class="widget-date-input__editor-body"
+            :class="{ 'widget-date-input__editor-body--scrollable': isFixedTabSelected }"
+          >
             <Calendar
               v-if="isFixedTabSelected"
               v-model="currentTabValue"
@@ -456,6 +459,9 @@ export default class NewDateInput extends Vue {
   }
   .widget-date-input__editor-body {
     min-height: 0;
+  }
+  // allow to scroll in the "fixed" section (with calendar)
+  .widget-date-input__editor-body--scrollable {
     overflow: auto;
   }
 }

--- a/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -32,6 +32,7 @@
         placeholder="Select a date"
         trackBy="identifier"
         label="label"
+        :withTitleAttribute="true"
       />
     </div>
   </div>

--- a/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -162,6 +162,16 @@ export default class RelativeDateForm extends Vue {
     padding: 8px 12px;
   }
 
+  ::v-deep .multiselect__content {
+    max-width: 100%;
+  }
+
+  ::v-deep .option__title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   ::v-deep .multiselect__option {
     border: none;
     margin: 5px;

--- a/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -32,7 +32,6 @@
         placeholder="Select a date"
         trackBy="identifier"
         label="label"
-        :withTitleAttribute="true"
       />
     </div>
   </div>

--- a/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -132,12 +132,13 @@ export default class RelativeDateForm extends Vue {
 .widget-relative-date-range-form__container {
   display: flex;
   justify-content: center;
-  margin-bottom: 15px;
+  margin: 5px;
 }
 
 .widget-relative-date-range-form__quantity {
-  flex: 1 25%;
-  margin: 0 !important;
+  flex: 0 0 75px;
+  margin: 0;
+  margin-right: 5px;
   background: white;
 
   ::v-deep .widget-input-number__container {
@@ -149,9 +150,12 @@ export default class RelativeDateForm extends Vue {
   }
 }
 .widget-relative-date-range-form__duration {
-  flex: 1 75%;
-  margin: 0 0 0 15px;
+  flex: 1;
+  margin: 0;
   background: white;
+  // Default min-width for flex items is auto.
+  // Override this value to prevent the element overflowing the container.
+  min-width: 0;
 
   ::v-deep .multiselect__tags {
     padding: 8px 12px;
@@ -179,12 +183,15 @@ export default class RelativeDateForm extends Vue {
 }
 
 .widget-relative-date-range-form__input {
-  flex: 1 100%;
+  flex: 1;
+  // Default min-width for flex items is auto.
+  // Override this value to prevent the element overflowing the container.
+  min-width: 0;
 }
 
 .widget-relative-date-range-form__input--operator {
-  flex: 1 0 25%;
-  margin-right: 15px;
+  flex: 0 0 75px;
+  margin-right: 5px;
 }
 
 .widget-relative-date-range-form__input--base-date {
@@ -193,6 +200,12 @@ export default class RelativeDateForm extends Vue {
 
   ::v-deep .multiselect__tags {
     padding: 8px 12px;
+  }
+
+  ::v-deep .multiselect__placeholder {
+    display: block;
+    line-height: 24px;
+    padding: 0;
   }
 
   ::v-deep .multiselect__option {

--- a/ui/stories/dates/RelativeDateForm.stories.ts
+++ b/ui/stories/dates/RelativeDateForm.stories.ts
@@ -47,3 +47,11 @@ export const Default: StoryObj<RelativeDateForm> = {
     variableDelimiters: { start: '{{', end: '}}' },
   },
 };
+
+export const WithTitleAttribute: StoryObj<RelativeDateForm> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    withTitleAttribute: true,
+  },
+};

--- a/ui/stories/dates/RelativeDateForm.stories.ts
+++ b/ui/stories/dates/RelativeDateForm.stories.ts
@@ -47,11 +47,3 @@ export const Default: StoryObj<RelativeDateForm> = {
     variableDelimiters: { start: '{{', end: '}}' },
   },
 };
-
-export const WithTitleAttribute: StoryObj<RelativeDateForm> = {
-  ...Default,
-  args: {
-    ...Default.args,
-    withTitleAttribute: true,
-  },
-};

--- a/ui/tests/unit/autocomplete-widget.spec.ts
+++ b/ui/tests/unit/autocomplete-widget.spec.ts
@@ -19,17 +19,17 @@ describe('Widget Autocomplete', () => {
     expect(wrapper.find('VariableInput-stub').exists()).toBeTruthy();
   });
 
-  it('should not have specific templates if the prop withTitleAttribute is false', () => {
+  it('should not have specific templates by default', () => {
     const wrapper = mount(AutocompleteWidget, {
-      propsData: { withTitleAttribute: false, options: [{ label: 'foo', example: 'bar' }] },
+      propsData: { options: ['foo', 'bar'] },
     });
     expect(wrapper.find('.option__title').exists()).toBeFalsy();
     expect(wrapper.find('.option__container').exists()).toBeFalsy();
   });
 
-  it('should have specific templates if the prop withTitleAttribute is true', () => {
+  it('should have specific templates a label is provided in options', () => {
     const wrapper = mount(AutocompleteWidget, {
-      propsData: { withTitleAttribute: true, options: [{ label: 'foo', example: 'bar' }] },
+      propsData: { options: [{ label: 'foo', example: 'bar' }] },
     });
     expect(wrapper.find('.option__title').exists()).toBeTruthy();
     expect(wrapper.find('.option__container').exists()).toBeTruthy();
@@ -71,7 +71,6 @@ describe('Widget Autocomplete', () => {
   it('should add a tooltip to the option', () => {
     const wrapper = mount(AutocompleteWidget, {
       propsData: {
-        withTitleAttribute: true,
         options: [{ label: 'foo', example: 'bar', tooltip: 'ukulélé' }],
       },
     });
@@ -82,7 +81,6 @@ describe('Widget Autocomplete', () => {
   it('should add a title attribute to the title', () => {
     const wrapper = mount(AutocompleteWidget, {
       propsData: {
-        withTitleAttribute: true,
         options: [{ label: 'foo', example: 'bar' }],
       },
     });

--- a/ui/tests/unit/autocomplete-widget.spec.ts
+++ b/ui/tests/unit/autocomplete-widget.spec.ts
@@ -19,17 +19,17 @@ describe('Widget Autocomplete', () => {
     expect(wrapper.find('VariableInput-stub').exists()).toBeTruthy();
   });
 
-  it('should not have specific templates if the prop withExample is false', () => {
+  it('should not have specific templates if the prop withTitleAttribute is false', () => {
     const wrapper = mount(AutocompleteWidget, {
-      propsData: { withExample: false, options: [{ label: 'foo', example: 'bar' }] },
+      propsData: { withTitleAttribute: false, options: [{ label: 'foo', example: 'bar' }] },
     });
     expect(wrapper.find('.option__title').exists()).toBeFalsy();
     expect(wrapper.find('.option__container').exists()).toBeFalsy();
   });
 
-  it('should have specific templates if the prop withExample is true', () => {
+  it('should have specific templates if the prop withTitleAttribute is true', () => {
     const wrapper = mount(AutocompleteWidget, {
-      propsData: { withExample: true, options: [{ label: 'foo', example: 'bar' }] },
+      propsData: { withTitleAttribute: true, options: [{ label: 'foo', example: 'bar' }] },
     });
     expect(wrapper.find('.option__title').exists()).toBeTruthy();
     expect(wrapper.find('.option__container').exists()).toBeTruthy();
@@ -71,11 +71,22 @@ describe('Widget Autocomplete', () => {
   it('should add a tooltip to the option', () => {
     const wrapper = mount(AutocompleteWidget, {
       propsData: {
-        withExample: true,
+        withTitleAttribute: true,
         options: [{ label: 'foo', example: 'bar', tooltip: 'ukulélé' }],
       },
     });
     expect(wrapper.find('.option__container').exists()).toBeTruthy();
     expect(wrapper.find('.option__container').attributes('title')).toEqual('ukulélé');
+  });
+
+  it('should add a title attribute to the title', () => {
+    const wrapper = mount(AutocompleteWidget, {
+      propsData: {
+        withTitleAttribute: true,
+        options: [{ label: 'foo', example: 'bar' }],
+      },
+    });
+    expect(wrapper.find('.option__title').exists()).toBeTruthy();
+    expect(wrapper.find('.option__title').attributes('title')).toEqual('foo');
   });
 });


### PR DESCRIPTION
The bottom of the relative date dropdown was hidden

- Fix the overflow
- Improve design
- Add title attribute for long labels

When this PR will be OK, I will open a duplicate one for the release 0.92

Before
<img width="616" alt="Screenshot 2023-01-04 at 00 17 15" src="https://user-images.githubusercontent.com/18734475/210457572-1c8aef9b-5daf-4d70-9ace-c953685cfdb8.png">

After
<img width="634" alt="Screenshot 2023-01-04 at 00 13 56" src="https://user-images.githubusercontent.com/18734475/210457611-359d61b3-8060-42e4-9a34-39abc4f7ca21.png">

<img width="629" alt="Screenshot 2023-01-05 at 15 48 15" src="https://user-images.githubusercontent.com/18734475/210829943-188d4673-3b95-455b-a272-8cc04eb9902c.png">

