### PR TITLE
fix(new-date-input): show all options for relative date dropdown [TCTC-3428] [TCTC-2484]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.92.6] - 2023-01-06
+
+### Fixed
+
+- Allow to access all options for relative date dropdown
+
 ## [0.92.5] - 2022-12-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.92.5",
+  "version": "0.92.6",
   "types": "./dist/types/types.d.ts",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 # sonar.projectName=weaverbird
-sonar.projectVersion=0.92.5
+sonar.projectVersion=0.92.6
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./src

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -22,15 +22,16 @@
         openDirection="bottom"
         @input="updateValue"
       >
-        <!-- If you want to use those templates you should provide a 'label' and 
-      'example' key in the options-->
-        <template v-if="withExample" slot="singleLabel" slot-scope="props">
+        <!-- If you want to use those templates, you should provide a 'label' key in the options -->
+        <template v-if="options[0] && options[0].label" slot="singleLabel" slot-scope="props">
           <span class="option__title">{{ props.option.label }}</span>
         </template>
-        <template v-if="withExample" slot="option" slot-scope="props">
+        <template v-if="options[0] && options[0].label" slot="option" slot-scope="props">
           <div class="option__container" :title="props.option.tooltip">
-            <div class="option__title">{{ props.option.label }}</div>
-            <div class="option__example">{{ props.option.example }}</div>
+            <div class="option__title" :title="props.option.label">{{ props.option.label }}</div>
+            <!-- To display an example - e.g. "Wed Jan 04 2023" for "Today" label -
+                you should provide a 'example' key in the options -->
+            <div v-if="withExample" class="option__example">{{ props.option.example }}</div>
           </div>
         </template>
       </multiselect>
@@ -71,7 +72,7 @@ export default class AutocompleteWidget extends Mixins(FormWidget) {
   value!: string | object;
 
   @Prop({ type: Array, default: () => [] })
-  options!: string[];
+  options!: string[] | object[];
 
   @Prop({ type: String, default: undefined })
   trackBy!: string;

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -19,6 +19,7 @@
         :allow-empty="false"
         :track-by="trackBy"
         :label="label"
+        :maxHeight="maxHeight"
         openDirection="bottom"
         @input="updateValue"
       >
@@ -88,6 +89,9 @@ export default class AutocompleteWidget extends Mixins(FormWidget) {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop({ type: Number, default: undefined })
+  maxHeight!: number;
 
   updateValue(newValue?: string | object) {
     this.$emit('input', newValue);

--- a/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -61,7 +61,10 @@
             :selectedTab="selectedTab"
             @tabSelected="selectTab"
           />
-          <div class="widget-date-input__editor-body">
+          <div
+            class="widget-date-input__editor-body"
+            :class="{ 'widget-date-input__editor-body--scrollable': isFixedTabSelected }"
+          >
             <Calendar
               v-if="isFixedTabSelected"
               v-model="currentTabValue"
@@ -466,6 +469,9 @@ export default class NewDateInput extends Vue {
   }
   .widget-date-input__editor-body {
     min-height: 0;
+  }
+  // allow to scroll in the "fixed" section (with calendar)
+  .widget-date-input__editor-body--scrollable {
     overflow: auto;
   }
 }

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -32,6 +32,7 @@
         placeholder="Select a date"
         trackBy="identifier"
         label="label"
+        :maxHeight="240"
       />
     </div>
   </div>

--- a/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -138,12 +138,13 @@ export default class RelativeDateForm extends Vue {
 .widget-relative-date-range-form__container {
   display: flex;
   justify-content: center;
-  margin-bottom: 15px;
+  margin: 5px;
 }
 
 .widget-relative-date-range-form__quantity {
-  flex: 1 25%;
-  margin: 0 !important;
+  flex: 0 0 75px;
+  margin: 0;
+  margin-right: 5px;
   background: white;
 
   ::v-deep .widget-input-number__container {
@@ -155,12 +156,25 @@ export default class RelativeDateForm extends Vue {
   }
 }
 .widget-relative-date-range-form__duration {
-  flex: 1 75%;
-  margin: 0 0 0 15px;
+  flex: 1;
+  margin: 0;
   background: white;
+  // Default min-width for flex items is auto.
+  // Override this value to prevent the element overflowing the container.
+  min-width: 0;
 
   ::v-deep .multiselect__tags {
     padding: 8px 12px;
+  }
+
+  ::v-deep .multiselect__content {
+    max-width: 100%;
+  }
+
+  ::v-deep .option__title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   ::v-deep .multiselect__option {
@@ -185,12 +199,15 @@ export default class RelativeDateForm extends Vue {
 }
 
 .widget-relative-date-range-form__input {
-  flex: 1 100%;
+  flex: 1;
+  // Default min-width for flex items is auto.
+  // Override this value to prevent the element overflowing the container.
+  min-width: 0;
 }
 
 .widget-relative-date-range-form__input--operator {
-  flex: 1 0 25%;
-  margin-right: 15px;
+  flex: 0 0 75px;
+  margin-right: 5px;
 }
 
 .widget-relative-date-range-form__input--base-date {
@@ -199,6 +216,12 @@ export default class RelativeDateForm extends Vue {
 
   ::v-deep .multiselect__tags {
     padding: 8px 12px;
+  }
+
+  ::v-deep .multiselect__placeholder {
+    display: block;
+    line-height: 24px;
+    padding: 0;
   }
 
   ::v-deep .multiselect__option {

--- a/tests/unit/autocomplete-widget.spec.ts
+++ b/tests/unit/autocomplete-widget.spec.ts
@@ -18,17 +18,17 @@ describe('Widget Autocomplete', () => {
     expect(wrapper.find('VariableInput-stub').exists()).toBeTruthy();
   });
 
-  it('should not have specific templates if the prop withExample is false', () => {
+  it('should not have specific templates by default', () => {
     const wrapper = mount(AutocompleteWidget, {
-      propsData: { withExample: false, options: [{ label: 'foo', example: 'bar' }] },
+      propsData: { options: ['foo', 'bar'] },
     });
     expect(wrapper.find('.option__title').exists()).toBeFalsy();
     expect(wrapper.find('.option__container').exists()).toBeFalsy();
   });
 
-  it('should have specific templates if the prop withExample is true', () => {
+  it('should have specific templates a label is provided in options', () => {
     const wrapper = mount(AutocompleteWidget, {
-      propsData: { withExample: true, options: [{ label: 'foo', example: 'bar' }] },
+      propsData: { options: [{ label: 'foo', example: 'bar' }] },
     });
     expect(wrapper.find('.option__title').exists()).toBeTruthy();
     expect(wrapper.find('.option__container').exists()).toBeTruthy();
@@ -76,11 +76,20 @@ describe('Widget Autocomplete', () => {
   it('should add a tooltip to the option', () => {
     const wrapper = mount(AutocompleteWidget, {
       propsData: {
-        withExample: true,
         options: [{ label: 'foo', example: 'bar', tooltip: 'ukulélé' }],
       },
     });
     expect(wrapper.find('.option__container').exists()).toBeTruthy();
     expect(wrapper.find('.option__container').attributes('title')).toEqual('ukulélé');
+  });
+
+  it('should add a title attribute to the title', () => {
+    const wrapper = mount(AutocompleteWidget, {
+      propsData: {
+        options: [{ label: 'foo', example: 'bar' }],
+      },
+    });
+    expect(wrapper.find('.option__title').exists()).toBeTruthy();
+    expect(wrapper.find('.option__title').attributes('title')).toEqual('foo');
   });
 });


### PR DESCRIPTION
Same as master PR https://github.com/ToucanToco/weaverbird/pull/1680, but on this branch for lts versions

The bottom of the relative date dropdown was hidden

- Fix the overflow
- Improve design
- Add title attribute for long labels

When this PR will be OK, I will open a duplicate one for the release 0.92

Before
<img width="616" alt="Screenshot 2023-01-04 at 00 17 15" src="https://user-images.githubusercontent.com/18734475/210457572-1c8aef9b-5daf-4d70-9ace-c953685cfdb8.png">

After
<img width="634" alt="Screenshot 2023-01-04 at 00 13 56" src="https://user-images.githubusercontent.com/18734475/210457611-359d61b3-8060-42e4-9a34-39abc4f7ca21.png">

<img width="629" alt="Screenshot 2023-01-05 at 15 48 15" src="https://user-images.githubusercontent.com/18734475/210829943-188d4673-3b95-455b-a272-8cc04eb9902c.png">

