### PR TITLE
fix(ui): prevent column name to be undefined when filtering TCTC-4962

### DIFF
--- a/ui/src/components/ActionMenu.vue
+++ b/ui/src/components/ActionMenu.vue
@@ -210,7 +210,7 @@ export default class ActionMenu extends Vue {
   }
 
   createFilterStep() {
-    this.createStep({ name: 'filter', condition: this.condition });
+    this.createStep({ name: 'filter', condition: { ...this.condition, column: this.columnName } });
   }
 }
 </script>


### PR DESCRIPTION
In prod, I did reproduce a bug where the filter created when we unselect some values from the column menu is broken. The column is `undefined`.
However, I could not reproduce this locally.

I'm suspecting it to come from the columnName prop value when `<ActionMenu` is instantiated.
Let's test this with the deployed environment: