### PR TITLE
fix(new-date-input): show all options for relative date dropdown (2nd fix) [TCTC-3428] [TCTC-2484] 

### DIFF
--- a/ui/src/components/stepforms/widgets/Autocomplete.vue
+++ b/ui/src/components/stepforms/widgets/Autocomplete.vue
@@ -19,6 +19,7 @@
         :allow-empty="false"
         :track-by="trackBy"
         :label="label"
+        :maxHeight="maxHeight"
         openDirection="bottom"
         @input="updateValue"
       >
@@ -88,6 +89,9 @@ export default class AutocompleteWidget extends FormWidget {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop({ type: Number, default: undefined })
+  maxHeight!: number;
 
   updateValue(newValue?: string | object) {
     this.$emit('input', newValue);

--- a/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -32,6 +32,7 @@
         placeholder="Select a date"
         trackBy="identifier"
         label="label"
+        :maxHeight="240"
       />
     </div>
   </div>


### PR DESCRIPTION
Fix the fix 😅 

A bug occurs in some cases with multiselect in the date popover.

Indeed, sometimes the dropdown was overflowing the popover, so we can't see the end of its content.

<img width="395" alt="Screenshot 2023-01-10 at 18 04 50" src="https://user-images.githubusercontent.com/18734475/211640060-c16da5ae-1f57-45bf-9861-1f17648f75a4.png">

It happens because VueMultiselect appends the dropdown next to the triggerer, instead of into the body. But the height calculation is bases on the window height... And the library doesn't provides any props to set another parent.

Quick win approach was to fix the dropdown max-height or remove the overflow hidden to let the dropdown overflow the popover.
First I thought the fixed max-height solution will not work because sometimes the popover is resized when not enough space, but in fact when it happens, we don't have the bug, because the bottom of the screen is reached so multiselect height is good :)

A big thanks to @alice-sevin (find the max-height solution) and @davinov (finding the reason why the dropdown height was sometimes wrong) 🙏 