### PR TITLE
fix(backend/mongo/rollup): Rename `_id` to `__id` in case it is part of aggregation new columns

### DIFF
--- a/server/tests/backends/fixtures/rollup/groupby_with_special_column_name.json
+++ b/server/tests/backends/fixtures/rollup/groupby_with_special_column_name.json
@@ -1,0 +1,189 @@
+{
+  "exclude": [
+    "athena_pypika",
+    "bigquery_pypika",
+    "mysql_pypika",
+    "pandas",
+    "postgres_pypika",
+    "redshift_pypika",
+    "snowflake_pypika"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "rollup",
+        "hierarchy": [
+          "STATE",
+          "CITY"
+        ],
+        "aggregations": [
+          {
+            "newcolumns": [
+              "_id"
+            ],
+            "aggfunction": "first",
+            "columns": [
+              "_id"
+            ]
+          }
+        ],
+        "level_col": "LEVEL",
+        "label_col": "LABEL",
+        "parent_label_col": "PARENT"
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "_id",
+          "type": "number"
+        },
+        {
+          "name": "CITY",
+          "type": "string"
+        },
+        {
+          "name": "STATE",
+          "type": "string"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "_id": 1,
+        "CITY": "SF",
+        "STATE": "CA"
+      },
+      {
+        "_id": 2,
+        "CITY": "SJ",
+        "STATE": "CA"
+      },
+      {
+        "_id": 3,
+        "CITY": "SF",
+        "STATE": "CA"
+      },
+      {
+        "_id": 4,
+        "CITY": "SJ",
+        "STATE": "CA"
+      },
+      {
+        "_id": 5,
+        "CITY": "Miami",
+        "STATE": "FL"
+      },
+      {
+        "_id": 6,
+        "CITY": "Orlando",
+        "STATE": "FL"
+      },
+      {
+        "_id": 7,
+        "CITY": "SJ",
+        "STATE": "PR"
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "STATE",
+          "type": "string"
+        },
+        {
+          "name": "CITY",
+          "type": "string"
+        },
+        {
+          "name": "LABEL",
+          "type": "string"
+        },
+        {
+          "name": "LEVEL",
+          "type": "string"
+        },
+        {
+          "name": "PARENT",
+          "type": "string"
+        },
+        {
+          "name": "__id",
+          "type": "number"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "__id": 1,
+        "STATE": "CA",
+        "CITY": null,
+        "LABEL": "CA",
+        "LEVEL": "STATE",
+        "PARENT": null
+      },
+      {
+        "__id": 5,
+        "STATE": "FL",
+        "CITY": null,
+        "LABEL": "FL",
+        "LEVEL": "STATE",
+        "PARENT": null
+      },
+      {
+        "__id": 7,
+        "STATE": "PR",
+        "CITY": null,
+        "LABEL": "PR",
+        "LEVEL": "STATE",
+        "PARENT": null
+      },
+      {
+        "__id": 1,
+        "STATE": "CA",
+        "CITY": "SF",
+        "LABEL": "SF",
+        "LEVEL": "CITY",
+        "PARENT": "CA"
+      },
+      {
+        "__id": 2,
+        "STATE": "CA",
+        "CITY": "SJ",
+        "LABEL": "SJ",
+        "LEVEL": "CITY",
+        "PARENT": "CA"
+      },
+      {
+        "__id": 5,
+        "STATE": "FL",
+        "CITY": "Miami",
+        "LABEL": "Miami",
+        "LEVEL": "CITY",
+        "PARENT": "FL"
+      },
+      {
+        "__id": 6,
+        "STATE": "FL",
+        "CITY": "Orlando",
+        "LABEL": "Orlando",
+        "LEVEL": "CITY",
+        "PARENT": "FL"
+      },
+      {
+        "__id": 7,
+        "STATE": "PR",
+        "CITY": "SJ",
+        "LABEL": "SJ",
+        "LEVEL": "CITY",
+        "PARENT": "PR"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
`_id` is reserved by mongo. Thus, we cannot overwrite it
