### PR TITLE
fix(store): use default value for available variables [TCTC-5196]

### DIFF
--- a/ui/src/store/state.ts
+++ b/ui/src/store/state.ts
@@ -96,6 +96,7 @@ export function emptyState(): VQBState {
     backendMessages: [],
     isLoading: { dataset: false, uniqueValues: false },
     isRequestOnGoing: false,
+    availableVariables: [],
     variables: {},
     variableDelimiters: undefined,
     translator: 'mongo50',


### PR DESCRIPTION
We need a default value for available variables otherwise it's no well set on init setupVQBStore hook