### PR TITLE
feat(variables): enable to add specific variable delimiters for trusted variables [TCTC-5807]

### DIFF
--- a/playground/dist/app.js
+++ b/playground/dist/app.js
@@ -69,6 +69,13 @@ const AVAILABLE_VARIABLES = [
     identifier: 'city',
     value: 'New York',
   },
+  {
+    category: 'User',
+    label: 'Username',
+    identifier: 'user.username',
+    value: 'Ange',
+    trusted: true,
+  }
 ];
 
 // Create a code editor config for a specific lang
@@ -869,6 +876,9 @@ async function buildVueApp() {
       });
       this.store.setVariableDelimiters({
         variableDelimiters: { start: '<%=', end: '%>' },
+      });
+      this.store.setTrustedVariableDelimiters({
+        variableDelimiters: { start: '{{', end: '}}' },
       });
       const collections = await backendService.listCollections();
       this.store.setDomains({ domains: collections });

--- a/ui/Playground.vue
+++ b/ui/Playground.vue
@@ -150,6 +150,13 @@ const AVAILABLE_VARIABLES = [
     identifier: 'city',
     value: 'New York',
   },
+  {
+    category: 'User',
+    label: 'Username',
+    identifier: 'user.username',
+    value: 'Ange',
+    trusted: true,
+  }
 ];
 
 // Create a code editor config for a specific lang
@@ -915,6 +922,9 @@ export default defineComponent({
     });
     this.store.setVariableDelimiters({
       variableDelimiters: { start: '<%=', end: '%>' },
+    });
+    this.store.setTrustedVariableDelimiters({
+      variableDelimiters: { start: '{{', end: '}}' },
     });
     const collections = await backendService.listCollections();
     this.store.setDomains({ domains: collections });

--- a/ui/src/components/DatePicker/transform-value-to-date-or-range.ts
+++ b/ui/src/components/DatePicker/transform-value-to-date-or-range.ts
@@ -40,12 +40,14 @@ export const transformRelativeDateToDate = (
   relativeDate: RelativeDate,
   relativeAvailableVariables: VariablesBucket = [],
   variableDelimiters: VariableDelimiters = { start: '', end: '' },
+  trustedVariableDelimiters?: VariableDelimiters,
 ): Date | undefined => {
   // retrieve relative date variable value in order to use it to calculate date
   const value = retrieveVariable(
     relativeDate.date,
     relativeAvailableVariables,
     variableDelimiters,
+    trustedVariableDelimiters,
   )?.value;
   if (!(value instanceof Date)) return;
 
@@ -71,12 +73,14 @@ export const transformRelativeDateToDateRange = (
   relativeDate: RelativeDate,
   relativeAvailableVariables: VariablesBucket = [],
   variableDelimiters: VariableDelimiters = { start: '', end: '' },
+  trustedVariableDelimiters?: VariableDelimiters,
 ): DateRange | undefined => {
   // retrieve relative date variable value in order to use it to calculate date
   const value = retrieveVariable(
     relativeDate.date,
     relativeAvailableVariables,
     variableDelimiters,
+    trustedVariableDelimiters,
   )?.value;
   if (!(value instanceof Date)) return;
 
@@ -145,6 +149,7 @@ export const transformValueToDate = (
   availableVariables: VariablesBucket = [],
   relativeAvailableVariables: VariablesBucket = [],
   variableDelimiters: VariableDelimiters = { start: '', end: '' },
+  trustedVariableDelimiters?: VariableDelimiters,
 ): Date | undefined => {
   // Undefined
   if (!value) {
@@ -156,7 +161,12 @@ export const transformValueToDate = (
   }
   // Variable reference
   else if (typeof value === 'string') {
-    const variableValue = retrieveVariable(value, availableVariables, variableDelimiters)?.value;
+    const variableValue = retrieveVariable(
+      value,
+      availableVariables,
+      variableDelimiters,
+      trustedVariableDelimiters,
+    )?.value;
     // if a variable is customizable, it can refers to another variable of any type
     // loop to find the variable value as Date or DateRange
     return transformValueToDate(
@@ -164,11 +174,17 @@ export const transformValueToDate = (
       availableVariables,
       relativeAvailableVariables,
       variableDelimiters,
+      trustedVariableDelimiters,
     );
   }
   // RelativeDate
   else {
-    return transformRelativeDateToDate(value, relativeAvailableVariables, variableDelimiters);
+    return transformRelativeDateToDate(
+      value,
+      relativeAvailableVariables,
+      variableDelimiters,
+      trustedVariableDelimiters,
+    );
   }
 };
 
@@ -196,6 +212,7 @@ export const transformValueToDateRange = (
   availableVariables: VariablesBucket = [],
   relativeAvailableVariables: VariablesBucket = [],
   variableDelimiters: VariableDelimiters = { start: '', end: '' },
+  trustedVariableDelimiters?: VariableDelimiters,
 ): DateRange | undefined => {
   let dateRange: DateRange | undefined;
   // Undefined
@@ -208,7 +225,12 @@ export const transformValueToDateRange = (
   }
   // Variable reference
   else if (typeof value === 'string') {
-    const variableValue = retrieveVariable(value, availableVariables, variableDelimiters)?.value;
+    const variableValue = retrieveVariable(
+      value,
+      availableVariables,
+      variableDelimiters,
+      trustedVariableDelimiters,
+    )?.value;
     // if a variable is customizable, it can refers to another variable of any type
     // loop to find the variable value as Date or DateRange
     dateRange = transformValueToDateRange(
@@ -216,6 +238,7 @@ export const transformValueToDateRange = (
       availableVariables,
       relativeAvailableVariables,
       variableDelimiters,
+      trustedVariableDelimiters,
     );
   }
   // RelativeDate
@@ -224,6 +247,7 @@ export const transformValueToDateRange = (
       value,
       relativeAvailableVariables,
       variableDelimiters,
+      trustedVariableDelimiters,
     );
   }
   return setDateRangeHours(dateRange);

--- a/ui/src/components/FilterEditor.vue
+++ b/ui/src/components/FilterEditor.vue
@@ -12,6 +12,7 @@
           :columnNamesProp="Object.keys(columnTypes)"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
+          :trusted-variable-delimiters="trustedVariableDelimiters"
           :hideColumnVariables="hideColumnVariables"
           :data-path="slotProps.dataPath"
           :errors="errors"
@@ -66,6 +67,9 @@ export default class FilterEditor extends Vue {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop()
   hideColumnVariables?: boolean;

--- a/ui/src/components/Pipeline.vue
+++ b/ui/src/components/Pipeline.vue
@@ -19,6 +19,7 @@
         :step="step"
         :indexInPipeline="index"
         :variable-delimiters="variableDelimiters"
+        :trusted-variable-delimiters="trustedVariableDelimiters"
         @selectedStep="selectStep({ index: index })"
         @editStep="editStep"
         @toggleDelete="toggleStepToDelete({ index })"
@@ -81,6 +82,7 @@ export default class PipelineComponent extends Vue {
 
   @State(VQBModule) domains!: string[];
   @State(VQBModule) variableDelimiters!: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters!: VariableDelimiters;
 
   @Getter(VQBModule, 'computedActiveStepIndex') activeStepIndex!: number;
   @Getter(VQBModule) domainStep!: DomainStep;

--- a/ui/src/components/Step.vue
+++ b/ui/src/components/Step.vue
@@ -147,15 +147,15 @@ export default class Step extends Vue {
   get errorMessage(): string | undefined {
     return this.stepErrors(this.indexInPipeline);
   }
-  // TODO
+
   get stepTitle(): string {
     const replaceDelimiters = { start: '', end: '' };
-    return labelWithReadeableVariables(this.stepName, this.variableDelimiters, replaceDelimiters);
+    return labelWithReadeableVariables(this.stepName, this.variableDelimiters, replaceDelimiters, this.trustedVariableDelimiters);
   }
 
   get stepLabel(): string {
     const replaceDelimiters = { start: '<em>', end: '</em>' };
-    return labelWithReadeableVariables(this.stepName, this.variableDelimiters, replaceDelimiters);
+    return labelWithReadeableVariables(this.stepName, this.variableDelimiters, replaceDelimiters, this.trustedVariableDelimiters);
   }
 
   get classContainer() {

--- a/ui/src/components/Step.vue
+++ b/ui/src/components/Step.vue
@@ -117,6 +117,9 @@ export default class Step extends Vue {
   variableDelimiters!: VariableDelimiters;
 
   @Prop()
+  trustedVariableDelimiters!: VariableDelimiters;
+
+  @Prop()
   readonly indexInPipeline!: number;
 
   isEditingPreviewSourceSubset = false;
@@ -144,7 +147,7 @@ export default class Step extends Vue {
   get errorMessage(): string | undefined {
     return this.stepErrors(this.indexInPipeline);
   }
-
+  // TODO
   get stepTitle(): string {
     const replaceDelimiters = { start: '', end: '' };
     return labelWithReadeableVariables(this.stepName, this.variableDelimiters, replaceDelimiters);

--- a/ui/src/components/Step.vue
+++ b/ui/src/components/Step.vue
@@ -150,12 +150,22 @@ export default class Step extends Vue {
 
   get stepTitle(): string {
     const replaceDelimiters = { start: '', end: '' };
-    return labelWithReadeableVariables(this.stepName, this.variableDelimiters, replaceDelimiters, this.trustedVariableDelimiters);
+    return labelWithReadeableVariables(
+      this.stepName,
+      this.variableDelimiters,
+      replaceDelimiters,
+      this.trustedVariableDelimiters,
+    );
   }
 
   get stepLabel(): string {
     const replaceDelimiters = { start: '<em>', end: '</em>' };
-    return labelWithReadeableVariables(this.stepName, this.variableDelimiters, replaceDelimiters, this.trustedVariableDelimiters);
+    return labelWithReadeableVariables(
+      this.stepName,
+      this.variableDelimiters,
+      replaceDelimiters,
+      this.trustedVariableDelimiters,
+    );
   }
 
   get classContainer() {

--- a/ui/src/components/stepforms/AbsoluteValueStepForm.vue
+++ b/ui/src/components/stepforms/AbsoluteValueStepForm.vue
@@ -24,6 +24,7 @@
       :warning="duplicateColumnName"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -55,6 +56,8 @@ export default class AbsoluteValueStepForm extends BaseStepForm<AbsoluteValueSte
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'absolutevalue', column: '', newColumn: '' }) })
   declare initialStepValue: AbsoluteValueStep;

--- a/ui/src/components/stepforms/AddMissingDatesStepForm.vue
+++ b/ui/src/components/stepforms/AddMissingDatesStepForm.vue
@@ -15,6 +15,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <AutocompleteWidget
       class="datesGranularityInput"
@@ -34,6 +35,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -68,6 +70,7 @@ export default class AddMissingDatesStepForm extends BaseStepForm<AddMissingDate
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/AddTextColumnStepForm.vue
+++ b/ui/src/components/stepforms/AddTextColumnStepForm.vue
@@ -16,6 +16,7 @@
       :warning="duplicateColumnName"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="textInput"
@@ -26,6 +27,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -55,6 +57,7 @@ export default class AddTextColumnStepForm extends BaseStepForm<AddTextColumnSte
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'text', newColumn: '', text: '' }) })
   declare initialStepValue: AddTextColumnStep;

--- a/ui/src/components/stepforms/AggregateStepForm.vue
+++ b/ui/src/components/stepforms/AggregateStepForm.vue
@@ -17,6 +17,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <ListWidget
       addFieldName="Add aggregation"
@@ -30,6 +31,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <CheckboxWidget
       class="keepOriginalGranularityCheckbox"
@@ -71,6 +73,7 @@ export default class AggregateStepForm extends BaseStepForm<AggregateStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/ArgmaxStepForm.vue
+++ b/ui/src/components/stepforms/ArgmaxStepForm.vue
@@ -15,6 +15,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <MultiselectWidget
       class="groupbyColumnsInput"
@@ -26,6 +27,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -57,6 +59,7 @@ export default class ArgmaxStepForm extends BaseStepForm<ArgmaxStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'argmax', column: '' }) })
   declare initialStepValue: ArgmaxStep;

--- a/ui/src/components/stepforms/ArgminStepForm.vue
+++ b/ui/src/components/stepforms/ArgminStepForm.vue
@@ -15,6 +15,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <MultiselectWidget
       class="groupbyColumnsInput"
@@ -26,6 +27,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -57,6 +59,7 @@ export default class ArgminStepForm extends BaseStepForm<ArgminStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'argmin', column: '' }) })
   declare initialStepValue: ArgminStep;

--- a/ui/src/components/stepforms/ColumnPicker.vue
+++ b/ui/src/components/stepforms/ColumnPicker.vue
@@ -9,6 +9,7 @@
     :errors="errors"
     :available-variables="availableVariables"
     :variable-delimiters="variableDelimiters"
+    :trusted-variable-delimiters="trustedVariableDelimiters"
   />
 </template>
 
@@ -44,6 +45,9 @@ export default class ColumnPicker extends Vue {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   // Whether the column data of ColumnPicker should react to a change of
   // selected column

--- a/ui/src/components/stepforms/CompareTextStepForm.vue
+++ b/ui/src/components/stepforms/CompareTextStepForm.vue
@@ -25,6 +25,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <ColumnPicker
       class="strCol2Input"
@@ -36,6 +37,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -67,6 +69,7 @@ export default class CompareTextStepForm extends BaseStepForm<CompareTextStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/ComputeDurationStepForm.vue
+++ b/ui/src/components/stepforms/ComputeDurationStepForm.vue
@@ -25,6 +25,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <ColumnPicker
       class="endDateColumnInput"
@@ -36,6 +37,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <AutocompleteWidget
       class="durationInInput"
@@ -80,6 +82,7 @@ export default class ComputeDurationStepForm extends BaseStepForm<ComputeDuratio
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/ConcatenateStepForm.vue
+++ b/ui/src/components/stepforms/ConcatenateStepForm.vue
@@ -19,6 +19,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="separator"
@@ -68,6 +69,7 @@ export default class ConcatenateStepForm extends BaseStepForm<ConcatenateStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/CumSumStepForm.vue
+++ b/ui/src/components/stepforms/CumSumStepForm.vue
@@ -18,6 +18,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       unstyled-items
     />
     <ColumnPicker
@@ -39,6 +40,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -75,6 +77,7 @@ export default class CumSumStepForm extends BaseStepForm<CumSumStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/DissolveStepForm.vue
+++ b/ui/src/components/stepforms/DissolveStepForm.vue
@@ -16,6 +16,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <ListWidget
       v-model="editedStep.aggregations"
@@ -29,6 +30,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <CheckboxWidget
       class="keepNullsCheckbox"
@@ -68,6 +70,7 @@ export default class DissolveStepForm extends BaseStepForm<DissolveStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/EvolutionStepForm.vue
+++ b/ui/src/components/stepforms/EvolutionStepForm.vue
@@ -25,6 +25,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <AutocompleteWidget
       class="evolutionType"
@@ -52,6 +53,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="newColumnInput"
@@ -104,6 +106,7 @@ export default class EvolutionStepForm extends BaseStepForm<EvolutionStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/FilterStepForm.vue
+++ b/ui/src/components/stepforms/FilterStepForm.vue
@@ -12,6 +12,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :columnTypes="columnTypes"
       @filterTreeUpdated="updateFilterTree"
     />
@@ -57,6 +58,7 @@ export default class FilterStepForm extends BaseStepForm<FilterStep> {
 
   @State(VQBModule) availableVariables?: VariablesBucket;
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Getter(VQBModule) columnTypes!: ColumnTypeMapping;
 

--- a/ui/src/components/stepforms/FormulaStepForm.vue
+++ b/ui/src/components/stepforms/FormulaStepForm.vue
@@ -16,6 +16,7 @@
       :warning="duplicateColumnName"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="formulaInput"
@@ -56,6 +57,7 @@ export default class FormulaStepForm extends BaseStepForm<FormulaStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'formula', newColumn: '', formula: '' }) })
   declare initialStepValue: FormulaStep;

--- a/ui/src/components/stepforms/IfThenElseStepForm.vue
+++ b/ui/src/components/stepforms/IfThenElseStepForm.vue
@@ -21,6 +21,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :column-types="columnTypes"
       @input="updateIfThenElse"
     />
@@ -55,6 +56,7 @@ export default class IfThenElseStepForm extends BaseStepForm<IfThenElseStep> {
 
   @State(VQBModule) availableVariables?: VariablesBucket;
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Getter(VQBModule) columnTypes!: ColumnTypeMapping;
 

--- a/ui/src/components/stepforms/MovingAverageStepForm.vue
+++ b/ui/src/components/stepforms/MovingAverageStepForm.vue
@@ -16,6 +16,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <ColumnPicker
       class="columnToSortInput"
@@ -27,6 +28,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="movingWindowInput"
@@ -38,6 +40,7 @@
       :errors="movingWindow"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <MultiselectWidget
       class="groupsInput"
@@ -49,6 +52,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="newColumnNameInput"
@@ -90,6 +94,7 @@ export default class MovingAverageStepForm extends BaseStepForm<MovingAverageSte
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/PivotStepForm.vue
+++ b/ui/src/components/stepforms/PivotStepForm.vue
@@ -15,6 +15,7 @@
       data-path=".index"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :errors="errors"
     />
     <ColumnPicker
@@ -25,6 +26,7 @@
       data-path=".columnToPivot"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :errors="errors"
     />
     <AutocompleteWidget
@@ -36,6 +38,7 @@
       data-path=".valueColumn"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :errors="errors"
     />
     <AutocompleteWidget
@@ -80,6 +83,7 @@ export default class PivotStepForm extends BaseStepForm<PivotStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/RankStepForm.vue
+++ b/ui/src/components/stepforms/RankStepForm.vue
@@ -16,6 +16,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <AutocompleteWidget
       class="orderInput"
@@ -41,6 +42,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="newColumnNameInput"
@@ -84,6 +86,7 @@ export default class RankStepForm extends BaseStepForm<RankStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/RenameStepForm.vue
+++ b/ui/src/components/stepforms/RenameStepForm.vue
@@ -20,6 +20,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       unstyled-items
     />
     <StepFormButtonbar />
@@ -51,6 +52,7 @@ export default class RenameStepForm extends BaseStepForm<RenameStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'rename', toRename: [['', '']] }) })
   declare initialStepValue: RenameStep;

--- a/ui/src/components/stepforms/ReplaceStepForm.vue
+++ b/ui/src/components/stepforms/ReplaceStepForm.vue
@@ -26,6 +26,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       unstyled-items
     />
     <StepFormButtonbar />
@@ -61,6 +62,7 @@ export default class ReplaceStepForm extends BaseStepForm<ReplaceStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'replace', searchColumn: '', toReplace: [[]] }) })
   declare initialStepValue: ReplaceStep;

--- a/ui/src/components/stepforms/SplitStepForm.vue
+++ b/ui/src/components/stepforms/SplitStepForm.vue
@@ -15,6 +15,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="delimiter"
@@ -63,6 +64,7 @@ export default class SplitStepForm extends BaseStepForm<SplitStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/TopStepForm.vue
+++ b/ui/src/components/stepforms/TopStepForm.vue
@@ -25,6 +25,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <AutocompleteWidget
       class="sortOrderInput"
@@ -45,6 +46,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <StepFormButtonbar />
   </div>
@@ -80,6 +82,7 @@ export default class TopStepForm extends BaseStepForm<TopStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({ type: Object, default: () => ({ name: 'top', rankOn: '', sort: 'desc' }) })
   declare initialStepValue: TopStep;

--- a/ui/src/components/stepforms/UnpivotStepForm.vue
+++ b/ui/src/components/stepforms/UnpivotStepForm.vue
@@ -17,6 +17,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <MultiselectWidget
       class="unpivotColumnInput"
@@ -29,6 +30,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <CheckboxWidget
       v-if="translator !== 'snowflake'"
@@ -67,6 +69,7 @@ export default class UnpivotStepForm extends BaseStepForm<UnpivotStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/WaterfallStepForm.vue
+++ b/ui/src/components/stepforms/WaterfallStepForm.vue
@@ -16,6 +16,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <ColumnPicker
       class="milestonesColumnInput"
@@ -27,6 +28,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="startInput"
@@ -37,6 +39,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="endInput"
@@ -47,6 +50,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <ColumnPicker
       class="childrenColumnInput"
@@ -58,6 +62,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <ColumnPicker
       class="parentsColumnInput"
@@ -69,6 +74,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <MultiselectWidget
       class="groupbyInput"
@@ -80,6 +86,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <AutocompleteWidget
       class="sortByInput"
@@ -129,6 +136,7 @@ export default class WaterfallStepForm extends BaseStepForm<WaterfallStep> {
   @State(VQBModule) availableVariables?: VariablesBucket;
 
   @State(VQBModule) variableDelimiters?: VariableDelimiters;
+  @State(VQBModule) trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/widgets/Aggregation.vue
+++ b/ui/src/components/stepforms/widgets/Aggregation.vue
@@ -11,6 +11,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <AutocompleteWidget
       class="aggregationFunctionInput"
@@ -57,6 +58,9 @@ export default class AggregationWidget extends Vue {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   @Getter(VQBModule) columnNames!: string[];
 

--- a/ui/src/components/stepforms/widgets/Autocomplete.vue
+++ b/ui/src/components/stepforms/widgets/Autocomplete.vue
@@ -9,6 +9,7 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :has-arrow="true"
       @input="updateValue"
     >
@@ -89,6 +90,9 @@ export default class AutocompleteWidget extends FormWidget {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({ type: Number, default: undefined })
   maxHeight!: number;

--- a/ui/src/components/stepforms/widgets/CumSum.vue
+++ b/ui/src/components/stepforms/widgets/CumSum.vue
@@ -10,6 +10,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="newColumn"
@@ -20,6 +21,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
   </div>
 </template>
@@ -60,6 +62,9 @@ export default class CumSumWidget extends Vue {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   @Getter(VQBModule) columnNames!: string[];
 

--- a/ui/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -79,6 +79,7 @@
               v-model="currentTabValue"
               :availableVariables="relativeAvailableVariables"
               :variableDelimiters="variableDelimiters"
+              :trusted-variable-delimiters="trustedVariableDelimiters"
             />
           </div>
           <div class="widget-date-input__editor-footer">
@@ -170,6 +171,9 @@ export default class DateRangeInput extends Vue {
   @Prop({ default: () => ({ start: '', end: '' }) })
   variableDelimiters!: VariableDelimiters;
 
+  @Prop({ default: undefined })
+  trustedVariableDelimiters!: VariableDelimiters;
+
   @Prop({ default: () => true })
   enableRelativeDate!: boolean;
 
@@ -249,7 +253,11 @@ export default class DateRangeInput extends Vue {
 
   get variable(): AvailableVariable | undefined {
     if (typeof this.value !== 'string') return undefined;
-    const identifier = extractVariableIdentifier(this.value, this.variableDelimiters);
+    const identifier = extractVariableIdentifier(
+      this.value, 
+      this.variableDelimiters, 
+      this.trustedVariableDelimiters
+    );
     return this.availableVariables.find((v) => v.identifier === identifier);
   }
 
@@ -306,6 +314,7 @@ export default class DateRangeInput extends Vue {
         this.value,
         this.relativeAvailableVariables,
         this.variableDelimiters,
+        this.trustedVariableDelimiters,
       );
     } else {
       return t('SELECT_PERIOD_PLACEHOLDER', this.locale);

--- a/ui/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -254,9 +254,9 @@ export default class DateRangeInput extends Vue {
   get variable(): AvailableVariable | undefined {
     if (typeof this.value !== 'string') return undefined;
     const identifier = extractVariableIdentifier(
-      this.value, 
-      this.variableDelimiters, 
-      this.trustedVariableDelimiters
+      this.value,
+      this.variableDelimiters,
+      this.trustedVariableDelimiters,
     );
     return this.availableVariables.find((v) => v.identifier === identifier);
   }

--- a/ui/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -193,9 +193,9 @@ export default class NewDateInput extends Vue {
   get variable(): AvailableVariable | undefined {
     if (typeof this.value !== 'string') return undefined;
     const identifier = extractVariableIdentifier(
-      this.value, 
-      this.variableDelimiters, 
-      this.trustedVariableDelimiters
+      this.value,
+      this.variableDelimiters,
+      this.trustedVariableDelimiters,
     );
     return this.availableVariables.find((v) => v.identifier === identifier);
   }
@@ -203,9 +203,9 @@ export default class NewDateInput extends Vue {
   get advancedVariable(): string | undefined {
     if (typeof this.value !== 'string') return undefined;
     const identifier = extractVariableIdentifier(
-      this.value, 
+      this.value,
       this.variableDelimiters,
-      this.trustedVariableDelimiters
+      this.trustedVariableDelimiters,
     );
     return identifier && !this.variable ? this.value : undefined;
   }

--- a/ui/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -17,6 +17,7 @@
         :value="value"
         :available-variables="availableVariables"
         :variable-delimiters="variableDelimiters"
+        :trusted-variable-delimiters="trustedVariableDelimiters"
         :isDate="true"
         @edited="openAdvancedVariableModal"
         @removed="resetValue"
@@ -75,6 +76,7 @@
               v-model="currentTabValue"
               :availableVariables="relativeAvailableVariables"
               :variableDelimiters="variableDelimiters"
+              :trusted-variable-delimiters="trustedVariableDelimiters"
             />
           </div>
           <div class="widget-date-input__editor-footer">
@@ -152,6 +154,9 @@ export default class NewDateInput extends Vue {
   @Prop({ default: () => ({ start: '', end: '' }) })
   variableDelimiters!: VariableDelimiters;
 
+  @Prop({ default: undefined })
+  trustedVariableDelimiters!: VariableDelimiters;
+
   @Prop({ default: true })
   enableCustom!: boolean;
 
@@ -187,13 +192,21 @@ export default class NewDateInput extends Vue {
 
   get variable(): AvailableVariable | undefined {
     if (typeof this.value !== 'string') return undefined;
-    const identifier = extractVariableIdentifier(this.value, this.variableDelimiters);
+    const identifier = extractVariableIdentifier(
+      this.value, 
+      this.variableDelimiters, 
+      this.trustedVariableDelimiters
+    );
     return this.availableVariables.find((v) => v.identifier === identifier);
   }
 
   get advancedVariable(): string | undefined {
     if (typeof this.value !== 'string') return undefined;
-    const identifier = extractVariableIdentifier(this.value, this.variableDelimiters);
+    const identifier = extractVariableIdentifier(
+      this.value, 
+      this.variableDelimiters,
+      this.trustedVariableDelimiters
+    );
     return identifier && !this.variable ? this.value : undefined;
   }
 
@@ -231,6 +244,7 @@ export default class NewDateInput extends Vue {
         this.value,
         this.relativeAvailableVariables,
         this.variableDelimiters,
+        this.trustedVariableDelimiters,
       );
     } else {
       return 'Select a date';

--- a/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -96,9 +96,9 @@ export default class RelativeDateForm extends Vue {
 
   get baseDate(): AvailableVariable | undefined {
     const identifier = extractVariableIdentifier(
-      this.value.date, 
-      this.variableDelimiters, 
-      this.trustedVariableDelimiters
+      this.value.date,
+      this.variableDelimiters,
+      this.trustedVariableDelimiters,
     );
     return this.availableVariables.find((v) => v.identifier === identifier);
   }

--- a/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -65,6 +65,9 @@ export default class RelativeDateForm extends Vue {
   @Prop({ default: () => ({ start: '', end: '' }) })
   variableDelimiters!: VariableDelimiters;
 
+  @Prop({ default: undefined })
+  trustedVariableDelimiters!: VariableDelimiters;
+
   @Prop({ default: () => ({ date: '', quantity: 1, duration: 'year', operator: 'until' }) })
   value!: RelativeDate;
 
@@ -92,7 +95,11 @@ export default class RelativeDateForm extends Vue {
   }
 
   get baseDate(): AvailableVariable | undefined {
-    const identifier = extractVariableIdentifier(this.value.date, this.variableDelimiters);
+    const identifier = extractVariableIdentifier(
+      this.value.date, 
+      this.variableDelimiters, 
+      this.trustedVariableDelimiters
+    );
     return this.availableVariables.find((v) => v.identifier === identifier);
   }
 

--- a/ui/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/ui/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -9,6 +9,7 @@
         :value="value.column"
         :available-variables="hideColumnVariables ? undefined : availableVariables"
         :variable-delimiters="hideColumnVariables ? undefined : variableDelimiters"
+        :trusted-variable-delimiters="hideColumnVariables ? undefined : trustedVariableDelimiters"
         :options="columnNames"
         @input="updateStepColumn"
         placeholder="Column"
@@ -39,6 +40,7 @@
       :value="value.value"
       :available-variables="availableVariablesForInputWidget"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :placeholder="placeholder"
       :data-path="`${dataPath}.value`"
       :errors="errors"
@@ -172,6 +174,11 @@ export default defineComponent({
 
     variableDelimiters: {
       type: Object as PropType<VariableDelimiters>,
+    },
+
+    trustedVariableDelimiters: {
+      type: Object as PropType<VariableDelimiters | undefined>,
+      default: undefined,
     },
 
     hideColumnVariables: {

--- a/ui/src/components/stepforms/widgets/IfThenElseWidget.vue
+++ b/ui/src/components/stepforms/widgets/IfThenElseWidget.vue
@@ -27,6 +27,7 @@
           :data-path="`${dataPath}.if`"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
+          :trusted-variable-delimiters="trustedVariableDelimiters"
           :column-types="columnTypes"
           @filterTreeUpdated="updateFilterTree"
         />
@@ -55,6 +56,7 @@
           :errors="errors"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
+          :trusted-variable-delimiters="trustedVariableDelimiters"
           @input="updateThenFormula"
         />
       </div>
@@ -80,6 +82,7 @@
             :errors="errors"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
+            :trusted-variable-delimiters="trustedVariableDelimiters"
             @input="updateElseFormula"
           />
         </div>
@@ -92,6 +95,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :column-types="columnTypes"
       @input="updateElseFormula"
       @deletedElseIf="transformElseIfIntoElse"
@@ -138,6 +142,9 @@ export default class IfThenElseWidget extends Vue {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({
     type: Object,

--- a/ui/src/components/stepforms/widgets/InputDate.vue
+++ b/ui/src/components/stepforms/widgets/InputDate.vue
@@ -10,6 +10,7 @@
       :value="parsedValue"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :has-arrow="true"
       @input="updateValue"
     >
@@ -67,6 +68,9 @@ export default class InputDateWidget extends FormWidget {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   get parsedValue(): string {
     return this.value instanceof Date ? this.parseDateToString(this.value) : this.value;

--- a/ui/src/components/stepforms/widgets/InputNumber.vue
+++ b/ui/src/components/stepforms/widgets/InputNumber.vue
@@ -10,6 +10,7 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :has-arrow="true"
       @input="updateValue"
     >
@@ -77,6 +78,9 @@ export default class InputNumberWidget extends FormWidget {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   isFocused = false;
 

--- a/ui/src/components/stepforms/widgets/InputText.vue
+++ b/ui/src/components/stepforms/widgets/InputText.vue
@@ -11,6 +11,7 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       @input="updateValue"
     >
       <input
@@ -66,6 +67,9 @@ export default class InputTextWidget extends FormWidget {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   updateValue(newValue: string | undefined) {
     this.$emit('input', newValue || undefined);

--- a/ui/src/components/stepforms/widgets/JoinColumns.vue
+++ b/ui/src/components/stepforms/widgets/JoinColumns.vue
@@ -9,6 +9,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <!-- defaults to a simple text input if we don't have any column names -->
     <AutocompleteWidget
@@ -22,6 +23,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       v-else
@@ -33,6 +35,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
   </div>
 </template>
@@ -72,6 +75,9 @@ export default class JoinColumns extends Vue {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   @Getter(VQBModule) columnNames!: string[];
 

--- a/ui/src/components/stepforms/widgets/List.vue
+++ b/ui/src/components/stepforms/widgets/List.vue
@@ -17,6 +17,7 @@
             :options="options"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
+            :trusted-variable-delimiters="trustedVariableDelimiters"
             @input="updateChildValue($event, index)"
             :data-path="`${dataPath}.${index}`"
             :errors="errors"
@@ -107,6 +108,9 @@ export default class ListWidget extends FormWidget {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   // Remove gray box and padding around list elements
   @Prop({ type: Boolean, default: false })

--- a/ui/src/components/stepforms/widgets/MultiInputText.vue
+++ b/ui/src/components/stepforms/widgets/MultiInputText.vue
@@ -5,6 +5,7 @@
       :value="value"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :edited-advanced-variable="editedAdvancedVariable"
       @resetEditedAdvancedVariable="resetEditedAdvancedVariable"
       @input="updateValue"
@@ -32,6 +33,7 @@
             v-if="isVariable(option)"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
+            :trusted-variable-delimiters="trustedVariableDelimiters"
             :value="option"
             @removed="remove(option)"
             @edited="editAdvancedVariable"
@@ -88,6 +90,9 @@ export default class MultiInputTextWidget extends Vue {
   @Prop({ default: undefined })
   variableDelimiters!: VariableDelimiters;
 
+  @Prop({ default: undefined })
+  trustedVariableDelimiters!: VariableDelimiters;
+
   @Prop({ default: true })
   multiVariable!: boolean;
 
@@ -121,7 +126,11 @@ export default class MultiInputTextWidget extends Vue {
    * Verify if we need to use regular template or variable one
    **/
   isVariable(value: string) {
-    const identifier = extractVariableIdentifier(value, this.variableDelimiters);
+    const identifier = extractVariableIdentifier(
+      value, 
+      this.variableDelimiters, 
+      this.VariableDelimiters
+    );
     return identifier != null;
   }
 

--- a/ui/src/components/stepforms/widgets/MultiInputText.vue
+++ b/ui/src/components/stepforms/widgets/MultiInputText.vue
@@ -127,9 +127,9 @@ export default class MultiInputTextWidget extends Vue {
    **/
   isVariable(value: string) {
     const identifier = extractVariableIdentifier(
-      value, 
-      this.variableDelimiters, 
-      this.VariableDelimiters
+      value,
+      this.variableDelimiters,
+      this.trustedVariableDelimiters,
     );
     return identifier != null;
   }

--- a/ui/src/components/stepforms/widgets/MultiVariableInput.vue
+++ b/ui/src/components/stepforms/widgets/MultiVariableInput.vue
@@ -3,6 +3,7 @@
     <VariableInputBase
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :has-arrow="hasArrow"
       :is-multiple="true"
       :value="value"
@@ -38,6 +39,9 @@ export default class MultiVariableInput extends Vue {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   @Prop({ default: () => '' })
   editedAdvancedVariable!: string;

--- a/ui/src/components/stepforms/widgets/Multiselect.vue
+++ b/ui/src/components/stepforms/widgets/Multiselect.vue
@@ -6,6 +6,7 @@
       :value="stringValue"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :has-arrow="true"
       :edited-advanced-variable="editedAdvancedVariable"
       @resetEditedAdvancedVariable="resetEditedAdvancedVariable"
@@ -37,6 +38,7 @@
             v-if="isVariable(option)"
             :available-variables="availableVariables"
             :variable-delimiters="variableDelimiters"
+            :trusted-variable-delimiters="trustedVariableDelimiters"
             :value="customLabel(option)"
             @removed="remove(option)"
             @edited="editAdvancedVariable"
@@ -112,6 +114,9 @@ export default class MultiselectWidget extends FormWidget {
   @Prop({ default: undefined })
   variableDelimiters!: VariableDelimiters;
 
+  @Prop({ default: undefined })
+  trustedVariableDelimiters!: VariableDelimiters;
+
   editedValue: string[] | object[] = [];
 
   /**
@@ -159,7 +164,11 @@ export default class MultiselectWidget extends FormWidget {
    * Verify if we need to use regular template or variable one
    **/
   isVariable(value: string | object) {
-    const identifier = extractVariableIdentifier(this.customLabel(value), this.variableDelimiters);
+    const identifier = extractVariableIdentifier(
+      this.customLabel(value), 
+      this.variableDelimiters, 
+      this.trustedVariableDelimiters
+    );
     return identifier != null;
   }
 

--- a/ui/src/components/stepforms/widgets/Multiselect.vue
+++ b/ui/src/components/stepforms/widgets/Multiselect.vue
@@ -165,9 +165,9 @@ export default class MultiselectWidget extends FormWidget {
    **/
   isVariable(value: string | object) {
     const identifier = extractVariableIdentifier(
-      this.customLabel(value), 
-      this.variableDelimiters, 
-      this.trustedVariableDelimiters
+      this.customLabel(value),
+      this.variableDelimiters,
+      this.trustedVariableDelimiters,
     );
     return identifier != null;
   }

--- a/ui/src/components/stepforms/widgets/Rename.vue
+++ b/ui/src/components/stepforms/widgets/Rename.vue
@@ -10,6 +10,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="newColumn"
@@ -20,6 +21,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
   </div>
 </template>
@@ -60,6 +62,9 @@ export default class RenameWidget extends Vue {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   @Getter(VQBModule) columnNames!: string[];
 

--- a/ui/src/components/stepforms/widgets/Replace.vue
+++ b/ui/src/components/stepforms/widgets/Replace.vue
@@ -8,6 +8,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="newValue"
@@ -17,6 +18,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
   </div>
 </template>
@@ -53,6 +55,9 @@ export default class ReplaceWidget extends Vue {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   created() {
     if (isEqual(this.value, ['', ''])) {

--- a/ui/src/components/stepforms/widgets/TotalDimensions.vue
+++ b/ui/src/components/stepforms/widgets/TotalDimensions.vue
@@ -60,7 +60,7 @@ export default class TotalDimensionsWidget extends Vue {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
-  
+
   @Prop()
   trustedVariableDelimiters?: VariableDelimiters;
 

--- a/ui/src/components/stepforms/widgets/TotalDimensions.vue
+++ b/ui/src/components/stepforms/widgets/TotalDimensions.vue
@@ -9,6 +9,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
     <InputTextWidget
       class="widget-totals__total-rows-label"
@@ -18,6 +19,7 @@
       :errors="errors"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
     />
   </div>
 </template>
@@ -58,6 +60,9 @@ export default class TotalDimensionsWidget extends Vue {
 
   @Prop()
   variableDelimiters?: VariableDelimiters;
+  
+  @Prop()
+  trustedVariableDelimiters?: VariableDelimiters;
 
   @Getter(VQBModule) columnNames!: string[];
 

--- a/ui/src/components/stepforms/widgets/VariableInput.vue
+++ b/ui/src/components/stepforms/widgets/VariableInput.vue
@@ -6,6 +6,7 @@
           :value="value"
           :available-variables="availableVariables"
           :variable-delimiters="variableDelimiters"
+          :trusted-variable-delimiters="trustedVariableDelimiters"
           @removed="dismissVariable"
           @edited="editAdvancedVariable"
         />
@@ -14,6 +15,7 @@
     <VariableInputBase
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
+      :trusted-variable-delimiters="trustedVariableDelimiters"
       :has-arrow="hasArrow"
       :edited-advanced-variable="editedAdvancedVariable"
       @chooseAdvancedVariable="chooseVariable"
@@ -55,6 +57,9 @@ export default class VariableInput extends Vue {
   @Prop({ default: undefined })
   variableDelimiters!: VariableDelimiters;
 
+  @Prop({ default: undefined })
+  trustedVariableDelimiters!: VariableDelimiters;
+
   @Prop({ default: false })
   hasArrow?: boolean; //move variable-chooser button to the left if parent has an expand arrow
 
@@ -62,7 +67,11 @@ export default class VariableInput extends Vue {
    * Verify if we need to display the slot or the variableTag
    */
   get isVariable() {
-    const identifier = extractVariableIdentifier(this.value, this.variableDelimiters);
+    const identifier = extractVariableIdentifier(
+      this.value, 
+      this.variableDelimiters, 
+      this.trustedVariableDelimiters
+    );
     return identifier != null;
   }
 

--- a/ui/src/components/stepforms/widgets/VariableInput.vue
+++ b/ui/src/components/stepforms/widgets/VariableInput.vue
@@ -68,9 +68,9 @@ export default class VariableInput extends Vue {
    */
   get isVariable() {
     const identifier = extractVariableIdentifier(
-      this.value, 
-      this.variableDelimiters, 
-      this.trustedVariableDelimiters
+      this.value,
+      this.variableDelimiters,
+      this.trustedVariableDelimiters,
     );
     return identifier != null;
   }

--- a/ui/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
+++ b/ui/src/components/stepforms/widgets/VariableInputs/VariableChooser.vue
@@ -23,8 +23,7 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import { POPOVER_ALIGN } from '@/components/constants';
 import Popover from '@/components/Popover.vue';
-import { extractVariableIdentifier } from '@/lib/variables';
-import type { VariableDelimiters, VariablesBucket } from '@/lib/variables';
+import type { VariablesBucket } from '@/lib/variables';
 
 import VariableList from './VariableList.vue';
 /**

--- a/ui/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
+++ b/ui/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
@@ -42,7 +42,7 @@
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 
-import { extractVariableIdentifier } from '@/lib/variables';
+import { extractVariableIdentifier, isTrustedVariable } from '@/lib/variables';
 import type { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 
 import AdvancedVariableModal from './AdvancedVariableModal.vue';
@@ -72,6 +72,9 @@ export default class VariableInputBase extends Vue {
   @Prop({ default: () => ({ start: '{{', end: '}}' }) })
   variableDelimiters!: VariableDelimiters;
 
+  @Prop({ default: undefined })
+  trustedVariableDelimiters!: VariableDelimiters;
+
   @Prop({ default: () => '' })
   editedAdvancedVariable!: string;
 
@@ -92,10 +95,10 @@ export default class VariableInputBase extends Vue {
    */
   get selectedVariables(): string | string[] {
     if (!Array.isArray(this.value)) {
-      return extractVariableIdentifier(this.value, this.variableDelimiters) ?? '';
+      return extractVariableIdentifier(this.value, this.variableDelimiters, this.trustedVariableDelimiters) ?? '';
     } else {
       return this.value.reduce((variables: string[], value: string) => {
-        const identifier = extractVariableIdentifier(value, this.variableDelimiters);
+        const identifier = extractVariableIdentifier(value, this.variableDelimiters, this.trustedVariableDelimiters);
         // in case value is a simple string we still want to keep it in array
         return [...variables, identifier || value];
       }, []);
@@ -128,13 +131,22 @@ export default class VariableInputBase extends Vue {
   }
 
   setVariableDelimiters(value: string | string[]): string | string[] {
-    const addVariableDelimiters = (variableIdentifier: string) =>
-      `${this.variableDelimiters.start} ${variableIdentifier} ${this.variableDelimiters.end}`;
-    // check if value is a variable
-    const isVariable = (identifier: string): boolean =>
-      Boolean(this.availableVariables.find((v) => v.identifier === identifier));
+    const retrieveVariableDelimiters = (variableIdentifier: string): VariableDelimiters | undefined => {
+      const variable = this.availableVariables.find((v) => v.identifier === variableIdentifier);
+      if (!variable) {
+        return; // if variable is unfound we don't want to display any delimiters
+      } else if (isTrustedVariable(variable)) {
+        return this.trustedVariableDelimiters;
+      }
+      return this.variableDelimiters;
+    }
+    const addVariableDelimiters = (variableIdentifier: string): string => {
+      const delimiters = retrieveVariableDelimiters(variableIdentifier)
+      if (!delimiters) return variableIdentifier;
+      return `${delimiters.start} ${variableIdentifier} ${delimiters.end}`;
+    }
     return Array.isArray(value)
-      ? value.map((v) => (isVariable(v) ? addVariableDelimiters(v) : v))
+      ? value.map((v) => addVariableDelimiters(v))
       : addVariableDelimiters(value);
   }
 

--- a/ui/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
+++ b/ui/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
@@ -95,10 +95,20 @@ export default class VariableInputBase extends Vue {
    */
   get selectedVariables(): string | string[] {
     if (!Array.isArray(this.value)) {
-      return extractVariableIdentifier(this.value, this.variableDelimiters, this.trustedVariableDelimiters) ?? '';
+      return (
+        extractVariableIdentifier(
+          this.value,
+          this.variableDelimiters,
+          this.trustedVariableDelimiters,
+        ) ?? ''
+      );
     } else {
       return this.value.reduce((variables: string[], value: string) => {
-        const identifier = extractVariableIdentifier(value, this.variableDelimiters, this.trustedVariableDelimiters);
+        const identifier = extractVariableIdentifier(
+          value,
+          this.variableDelimiters,
+          this.trustedVariableDelimiters,
+        );
         // in case value is a simple string we still want to keep it in array
         return [...variables, identifier || value];
       }, []);
@@ -131,7 +141,9 @@ export default class VariableInputBase extends Vue {
   }
 
   setVariableDelimiters(value: string | string[]): string | string[] {
-    const retrieveVariableDelimiters = (variableIdentifier: string): VariableDelimiters | undefined => {
+    const retrieveVariableDelimiters = (
+      variableIdentifier: string,
+    ): VariableDelimiters | undefined => {
       const variable = this.availableVariables.find((v) => v.identifier === variableIdentifier);
       if (!variable) {
         return; // if variable is unfound we don't want to display any delimiters
@@ -139,12 +151,12 @@ export default class VariableInputBase extends Vue {
         return this.trustedVariableDelimiters;
       }
       return this.variableDelimiters;
-    }
+    };
     const addVariableDelimiters = (variableIdentifier: string): string => {
-      const delimiters = retrieveVariableDelimiters(variableIdentifier)
+      const delimiters = retrieveVariableDelimiters(variableIdentifier);
       if (!delimiters) return variableIdentifier;
       return `${delimiters.start} ${variableIdentifier} ${delimiters.end}`;
-    }
+    };
     return Array.isArray(value)
       ? value.map((v) => addVariableDelimiters(v))
       : addVariableDelimiters(value);

--- a/ui/src/components/stepforms/widgets/VariableInputs/VariableTag.vue
+++ b/ui/src/components/stepforms/widgets/VariableInputs/VariableTag.vue
@@ -61,6 +61,9 @@ export default class VariableTag extends Vue {
 
   @Prop({ default: undefined })
   variableDelimiters!: VariableDelimiters;
+  
+  @Prop({ default: undefined })
+  trustedVariableDelimiters!: VariableDelimiters;  
 
   @Prop({ default: false })
   isDate!: boolean;
@@ -69,7 +72,7 @@ export default class VariableTag extends Vue {
    * Retrieve identifier by removing delimiters from value.
    */
   get variableIdentifier() {
-    return extractVariableIdentifier(this.value, this.variableDelimiters);
+    return extractVariableIdentifier(this.value, this.variableDelimiters, this.trustedVariableDelimiters);
   }
 
   /**

--- a/ui/src/components/stepforms/widgets/VariableInputs/VariableTag.vue
+++ b/ui/src/components/stepforms/widgets/VariableInputs/VariableTag.vue
@@ -61,9 +61,9 @@ export default class VariableTag extends Vue {
 
   @Prop({ default: undefined })
   variableDelimiters!: VariableDelimiters;
-  
+
   @Prop({ default: undefined })
-  trustedVariableDelimiters!: VariableDelimiters;  
+  trustedVariableDelimiters!: VariableDelimiters;
 
   @Prop({ default: false })
   isDate!: boolean;
@@ -72,7 +72,11 @@ export default class VariableTag extends Vue {
    * Retrieve identifier by removing delimiters from value.
    */
   get variableIdentifier() {
-    return extractVariableIdentifier(this.value, this.variableDelimiters, this.trustedVariableDelimiters);
+    return extractVariableIdentifier(
+      this.value,
+      this.variableDelimiters,
+      this.trustedVariableDelimiters,
+    );
   }
 
   /**

--- a/ui/src/lib/dates.ts
+++ b/ui/src/lib/dates.ts
@@ -130,8 +130,13 @@ export const relativeDateToString = (
   relativeDate: RelativeDate,
   availableVariables: VariablesBucket = [],
   variableDelimiters: VariableDelimiters = { start: '', end: '' },
+  trustedVariableDelimiters?: VariableDelimiters,
 ): string => {
-  const identifier = extractVariableIdentifier(relativeDate.date, variableDelimiters);
+  const identifier = extractVariableIdentifier(
+    relativeDate.date,
+    variableDelimiters,
+    trustedVariableDelimiters,
+  );
   const baseDateLabel =
     availableVariables.find((v) => v.identifier === identifier)?.label ?? identifier;
   const duration: string | undefined = DEFAULT_DURATIONS.find(

--- a/ui/src/lib/labeller.ts
+++ b/ui/src/lib/labeller.ts
@@ -396,6 +396,7 @@ function _replaceAll(str: string, search: string, replace: string) {
   return str.replace(new RegExp(search, 'g'), replace);
 }
 
+// TODO
 export function labelWithReadeableVariables(
   label: string | null,
   variableDelimiters: VariableDelimiters | null,

--- a/ui/src/lib/labeller.ts
+++ b/ui/src/lib/labeller.ts
@@ -396,17 +396,35 @@ function _replaceAll(str: string, search: string, replace: string) {
   return str.replace(new RegExp(search, 'g'), replace);
 }
 
-// TODO
-export function labelWithReadeableVariables(
+function _replaceDelimitersInLabel(
   label: string | null,
-  variableDelimiters: VariableDelimiters | null,
   replaceDelimiters: VariableDelimiters | null,
+  variableDelimiters?: VariableDelimiters | null,
 ): string {
   if (!variableDelimiters || !replaceDelimiters || !label) {
     return label || '';
   }
   const formattedLabel = _replaceAll(label, variableDelimiters.start, replaceDelimiters.start);
   return _replaceAll(formattedLabel, variableDelimiters.end, replaceDelimiters.end);
+}
+
+export function labelWithReadeableVariables(
+  label: string | null,
+  variableDelimiters: VariableDelimiters | null,
+  replaceDelimiters: VariableDelimiters | null,
+  trustedVariableDelimiters?: VariableDelimiters,
+): string {
+  const labelWithoutTrustedVariableDelimiters = _replaceDelimitersInLabel(
+    label,
+    replaceDelimiters,
+    trustedVariableDelimiters,
+  );
+  const labelWithoutTrustedAndDefaultVariableDelimiters = _replaceDelimitersInLabel(
+    labelWithoutTrustedVariableDelimiters,
+    replaceDelimiters,
+    variableDelimiters,
+  );
+  return labelWithoutTrustedAndDefaultVariableDelimiters;
 }
 
 // enable to retrieve the related name of a query referenced behind an uid

--- a/ui/src/lib/variables.ts
+++ b/ui/src/lib/variables.ts
@@ -1,9 +1,27 @@
+/* notify which delimiters should be used (default or trusted ones)
+  this way we can use different delimiters for each variable
+  [...
+  { 
+    identifier: 'data.client',
+    label: 'Data from client',
+    // => if variable is not trusted it will use default delimiters
+  },
+  {
+    identifier: 'data.server',
+    label: 'Data from server',
+    ...
+    trusted: true -> it will use trusted delimiters
+  }
+  ...]
+*/
+
 export interface AvailableVariable {
   identifier: string; // how the variable will be written in the code
   value?: any; // current value of the variable
   category?: string;
   label: string;
   selected?: boolean;
+  trusted?: boolean;
 }
 
 export type VariablesBucket = AvailableVariable[];
@@ -18,13 +36,11 @@ export interface VariableDelimiters {
   end: string;
 }
 
-/**
- * Determine if value is variable surrounded by delimiters or not, and if yes, extract its identifier.
- */
-export function extractVariableIdentifier(
+/* Retrieve the identifier in a string with specific delimiters (trusted/default) */
+function extractVariableIdentifierWithDelimiters(
   value: any,
-  variableDelimiters: VariableDelimiters,
-): string | undefined {
+  variableDelimiters?: VariableDelimiters,
+) {
   if (typeof value !== 'string' || !variableDelimiters) {
     return undefined;
   }
@@ -55,6 +71,21 @@ export function extractVariableIdentifier(
   }
 }
 
+/**
+ * Determine if value is variable surrounded by delimiters or not, and if yes, extract its identifier.
+ */
+export function extractVariableIdentifier(
+  value: any,
+  variableDelimiters: VariableDelimiters,
+  trustedVariableDelimiters?: VariableDelimiters,
+): string | undefined {
+  // extract variable from trusted or default delimiters
+  return (
+    extractVariableIdentifierWithDelimiters(value, trustedVariableDelimiters) ??
+    extractVariableIdentifierWithDelimiters(value, variableDelimiters)
+  );
+}
+
 /*
 Retrieve a variable in a list of available variables based on the value with variable delimiters and identifier: ex {{toto}}
 */
@@ -62,9 +93,25 @@ export const retrieveVariable = (
   value: string,
   availableVariables: VariablesBucket = [],
   variableDelimiters: VariableDelimiters = { start: '', end: '' },
+  trustedVariableDelimiters?: VariableDelimiters,
 ): AvailableVariable | undefined => {
+  // Retrieve the type of variable (trusted or default)
+  const trimmedValue = value.trim();
+  const isVariable =
+    trustedVariableDelimiters &&
+    trimmedValue.startsWith(trustedVariableDelimiters.start) &&
+    trimmedValue.endsWith(trustedVariableDelimiters.end);
   // retrieve the variable identifier
-  const identifier = extractVariableIdentifier(value, variableDelimiters);
+  const identifier = extractVariableIdentifierWithDelimiters(
+    value,
+    isVariable ? trustedVariableDelimiters : variableDelimiters,
+  );
   // search on relative available variables
-  return availableVariables.find((v: AvailableVariable) => v.identifier === identifier);
+  return availableVariables.find(
+    (v: AvailableVariable) => v.identifier === identifier,
+  );
 };
+
+export const isTrustedVariable = (variable?: AvailableVariable): Boolean => {
+  return !!variable?.trusted;
+}

--- a/ui/src/lib/variables.ts
+++ b/ui/src/lib/variables.ts
@@ -107,11 +107,9 @@ export const retrieveVariable = (
     isVariable ? trustedVariableDelimiters : variableDelimiters,
   );
   // search on relative available variables
-  return availableVariables.find(
-    (v: AvailableVariable) => v.identifier === identifier,
-  );
+  return availableVariables.find((v: AvailableVariable) => v.identifier === identifier);
 };
 
-export const isTrustedVariable = (variable?: AvailableVariable): Boolean => {
+export const isTrustedVariable = (variable?: AvailableVariable): boolean => {
   return !!variable?.trusted;
-}
+};

--- a/ui/src/store/actions.ts
+++ b/ui/src/store/actions.ts
@@ -41,6 +41,11 @@ export type VQBActions = {
   }: {
     variableDelimiters: VariableDelimiters | undefined;
   }) => void;
+  setTrustedVariableDelimiters: ({
+    variableDelimiters,
+  }: {
+    variableDelimiters: VariableDelimiters | undefined;
+  }) => void;
   setDomains: ({ domains }: { domains: string[] }) => void;
   setAvailableDomains: ({
     availableDomains,
@@ -120,6 +125,9 @@ const actions: PiniaActionAdaptor<VQBActions, VQBStore> = {
     this.variableDelimiters = variableDelimiters;
     // Forward them to translators
     setVariableDelimiters(variableDelimiters);
+  },
+  setTrustedVariableDelimiters({ variableDelimiters }) {
+    this.trustedVariableDelimiters = variableDelimiters;
   },
   // DOMAINS & PIPELINES
   setDomains({ domains }) {

--- a/ui/src/store/state.ts
+++ b/ui/src/store/state.ts
@@ -23,6 +23,7 @@ export interface VQBState {
   // for templating
   availableVariables?: VariablesBucket;
   variableDelimiters?: VariableDelimiters;
+  trustedVariableDelimiters?: VariableDelimiters;
   variables?: ScopeContext;
   interpolateFunc?: InterpolateFunction;
 

--- a/ui/src/store/state.ts
+++ b/ui/src/store/state.ts
@@ -100,6 +100,7 @@ export function emptyState(): VQBState {
     availableVariables: [],
     variables: {},
     variableDelimiters: undefined,
+    trustedVariableDelimiters: undefined,
     translator: 'mongo50',
     backendService: UnsetBackendService,
     interpolateFunc: (x: string | any[], _context: ScopeContext) => x,

--- a/ui/stories/FilterEditor.stories.ts
+++ b/ui/stories/FilterEditor.stories.ts
@@ -126,7 +126,7 @@ export const WithVariables: StoryFn<typeof FilterEditor> = () => ({
           identifier: 'date',
           value: '27/12/2093',
           trusted: true,
-        }
+        },
       ],
       filterTree: {
         column: 'my_col',

--- a/ui/stories/FilterEditor.stories.ts
+++ b/ui/stories/FilterEditor.stories.ts
@@ -77,6 +77,7 @@ export const WithVariables: StoryFn<typeof FilterEditor> = () => ({
         @filterTreeUpdated="updateFilterTree"
         :available-variables="availableVariables"
         :variableDelimiters="variableDelimiters"
+        :trustedVariableDelimiters="trustedVariableDelimiters"
       />
       <pre style="margin-top: 30px;">{{ filterTreeStringify }}</pre>
     </div>
@@ -89,12 +90,18 @@ export const WithVariables: StoryFn<typeof FilterEditor> = () => ({
   data(): {
     availableVariables: AvailableVariable[];
     variableDelimiters: VariableDelimiters;
+    trustedVariableDelimiters: VariableDelimiters;
     filterTree: FilterCondition;
     defaultValue: FilterCondition;
   } {
     return {
       availableVariables: [
-        { category: 'Values', label: 'The best number', identifier: 'bestNumber', value: 42 },
+        {
+          category: 'Values',
+          label: 'The best number',
+          identifier: 'bestNumber',
+          value: 42,
+        },
         {
           category: 'Values',
           label: 'King in the North',
@@ -113,13 +120,21 @@ export const WithVariables: StoryFn<typeof FilterEditor> = () => ({
           identifier: 'pokedeck',
           value: ['pikachu', 'carapuce', 'evoli'],
         },
+        {
+          category: 'Trusted',
+          label: 'Date',
+          identifier: 'date',
+          value: '27/12/2093',
+          trusted: true,
+        }
       ],
       filterTree: {
         column: 'my_col',
         operator: 'in',
-        value: ['{{ someArray }}'],
+        value: ['<%= someArray %>'],
       },
-      variableDelimiters: { start: '{{', end: '}}' },
+      variableDelimiters: { start: '<%=', end: '%>' },
+      trustedVariableDelimiters: { start: '{{', end: '}}' },
       defaultValue: { column: '', value: '', operator: 'eq' },
     };
   },

--- a/ui/tests/unit/labeller.spec.ts
+++ b/ui/tests/unit/labeller.spec.ts
@@ -870,6 +870,19 @@ describe('Labeller', () => {
       );
     });
 
+    it('generates label where trusted variable delimiters are replaced with selected ones', () => {
+      const trustedVariableDelimiters: VariableDelimiters = { start: '{{ ', end: ' }}' };
+      const variableDelimiters: VariableDelimiters = { start: '<%= ', end: ' %>' };
+      expect(
+        lwv(
+          'Replace column <%= client %> with {{ server }}',
+          variableDelimiters,
+          replaceDelimiters,
+          trustedVariableDelimiters,
+        ),
+      ).toEqual('Replace column <em>client</em> with <em>server</em>');
+    });
+
     it('generates keep label unchanged when there is no variableDelimiters', () => {
       expect(lwv(label, null, replaceDelimiters)).toEqual('Replace column {{ date.year }} with 9');
     });

--- a/ui/tests/unit/variable-input-base.spec.ts
+++ b/ui/tests/unit/variable-input-base.spec.ts
@@ -85,7 +85,12 @@ describe('Variable Input', () => {
   describe('with multiple selected variables', () => {
     beforeEach(async () => {
       wrapper.setProps({
-        value: ['{{ appRequesters.city }}', '{{ appRequesters.country }}', '<< server.data >>', 'toto'],
+        value: [
+          '{{ appRequesters.city }}',
+          '{{ appRequesters.country }}',
+          '<< server.data >>',
+          'toto',
+        ],
       });
       await wrapper.vm.$nextTick();
     });

--- a/ui/tests/unit/variable-input-base.spec.ts
+++ b/ui/tests/unit/variable-input-base.spec.ts
@@ -12,6 +12,7 @@ describe('Variable Input', () => {
       sync: false,
       propsData: {
         variableDelimiters: { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '<<', end: '>>' },
         availableVariables: [
           {
             category: 'App variables',
@@ -42,6 +43,13 @@ describe('Variable Input', () => {
             label: 'city',
             identifier: 'appRequesters.city',
             value: 'New York',
+          },
+          {
+            category: 'Server variables',
+            label: 'server',
+            identifier: 'server.data',
+            value: 'Data from server',
+            trusted: true,
           },
         ],
         value: '{{ appRequesters.city }}',
@@ -77,7 +85,7 @@ describe('Variable Input', () => {
   describe('with multiple selected variables', () => {
     beforeEach(async () => {
       wrapper.setProps({
-        value: ['{{ appRequesters.city }}', '{{ appRequesters.country }}', 'toto'],
+        value: ['{{ appRequesters.city }}', '{{ appRequesters.country }}', '<< server.data >>', 'toto'],
       });
       await wrapper.vm.$nextTick();
     });
@@ -86,6 +94,7 @@ describe('Variable Input', () => {
       expect(wrapper.find('VariableChooser-stub').props().selectedVariables).toStrictEqual([
         'appRequesters.city',
         'appRequesters.country',
+        'server.data',
         // toto is a simple string not a variable so keep it unchanged
         'toto',
       ]);
@@ -180,7 +189,7 @@ describe('Variable Input', () => {
           wrapper.setProps({ isMultiple: true });
           wrapper
             .find('VariableChooser-stub')
-            .vm.$emit('input', ['appRequesters.view', 'appRequesters.city', 'toto']);
+            .vm.$emit('input', ['appRequesters.view', 'appRequesters.city', 'server.data', 'toto']);
           await wrapper.vm.$nextTick();
         });
 
@@ -194,6 +203,7 @@ describe('Variable Input', () => {
             [
               '{{ appRequesters.view }}',
               '{{ appRequesters.city }}',
+              '<< server.data >>',
               // toto is a simple string not a variable so keep it unchanged
               'toto',
             ],

--- a/ui/tests/unit/variable-tag.spec.ts
+++ b/ui/tests/unit/variable-tag.spec.ts
@@ -141,7 +141,7 @@ describe('Variable Tag', () => {
     it('should compute the variable identifier', () => {
       expect((wrapper as any).vm.variableIdentifier).toBe('appRequesters.date.month');
     });
-  
+
     it('should compute the variable', () => {
       expect((wrapper as any).vm.variable).toStrictEqual({
         category: 'App variables',
@@ -151,15 +151,15 @@ describe('Variable Tag', () => {
         trusted: true,
       });
     });
-  
+
     it('should compute the variable value', () => {
       expect((wrapper as any).vm.variableValue).toBe('Apr');
     });
 
-  it('should display the tag label', () => {
-    const name = wrapper.find('.widget-variable__tag-name');
-    expect(name.exists()).toBe(true);
-    expect(name.text()).toBe('date.month');
-  });
+    it('should display the tag label', () => {
+      const name = wrapper.find('.widget-variable__tag-name');
+      expect(name.exists()).toBe(true);
+      expect(name.text()).toBe('date.month');
+    });
   });
 });

--- a/ui/tests/unit/variable-tag.spec.ts
+++ b/ui/tests/unit/variable-tag.spec.ts
@@ -17,6 +17,7 @@ describe('Variable Tag', () => {
       propsData: {
         value: '{{ appRequesters.view }}',
         variableDelimiters: { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '<<', end: '>>' },
         availableVariables: [
           {
             category: 'App variables',
@@ -29,6 +30,7 @@ describe('Variable Tag', () => {
             label: 'date.month',
             identifier: 'appRequesters.date.month',
             value: 'Apr',
+            trusted: true,
           },
         ],
       },
@@ -128,5 +130,36 @@ describe('Variable Tag', () => {
         expect(wrapper.find('.widget-variable__tag-name').text()).toBe('toto');
       });
     });
+  });
+
+  describe('if is trusted variable', () => {
+    beforeEach(() => {
+      wrapper.setProps({
+        value: '<< appRequesters.date.month >>',
+      });
+    });
+    it('should compute the variable identifier', () => {
+      expect((wrapper as any).vm.variableIdentifier).toBe('appRequesters.date.month');
+    });
+  
+    it('should compute the variable', () => {
+      expect((wrapper as any).vm.variable).toStrictEqual({
+        category: 'App variables',
+        label: 'date.month',
+        identifier: 'appRequesters.date.month',
+        value: 'Apr',
+        trusted: true,
+      });
+    });
+  
+    it('should compute the variable value', () => {
+      expect((wrapper as any).vm.variableValue).toBe('Apr');
+    });
+
+  it('should display the tag label', () => {
+    const name = wrapper.find('.widget-variable__tag-name');
+    expect(name.exists()).toBe(true);
+    expect(name.text()).toBe('date.month');
+  });
   });
 });

--- a/ui/tests/unit/variables.spec.ts
+++ b/ui/tests/unit/variables.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  type AvailableVariable,
   extractVariableIdentifier,
   retrieveVariable,
-  type AvailableVariable,
 } from '@/lib/variables';
 
 describe('extractVariableIdentifier', () => {
@@ -96,7 +96,9 @@ describe('retrieveVariable', () => {
     ).toBeUndefined();
   });
   it('should return undefined if variable delimiters are not attended one', () => {
-    expect(retrieveVariable('<< date.client >>', availableVariables, variableDelimiters)).toBeUndefined();
+    expect(
+      retrieveVariable('<< date.client >>', availableVariables, variableDelimiters),
+    ).toBeUndefined();
   });
   it('should return variable if variable exist in available variables', () => {
     expect(

--- a/ui/tests/unit/variables.spec.ts
+++ b/ui/tests/unit/variables.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractVariableIdentifier, retrieveVariable } from '@/lib/variables';
+import {
+  extractVariableIdentifier,
+  retrieveVariable,
+  type AvailableVariable,
+} from '@/lib/variables';
 
 describe('extractVariableIdentifier', () => {
   it('should extract simple variable names', () => {
@@ -80,19 +84,33 @@ describe('extractVariableIdentifier', () => {
 });
 
 describe('retrieveVariable', () => {
-  const availableVariables = [{ identifier: 'date', value: '', label: 'Date' }];
+  const availableVariables: AvailableVariable[] = [
+    { identifier: 'date.client', value: '', label: 'Date' },
+    { identifier: 'date.server', value: '', label: 'Trusted date variable', trusted: true },
+  ];
   const variableDelimiters = { start: '<%=', end: '%>' };
+  const trustedVariableDelimiters = { start: '{{', end: '}}' };
   it("should return undefined if variable don't exist in available variables", () => {
     expect(
       retrieveVariable('<%= croissant %>', availableVariables, variableDelimiters),
     ).toBeUndefined();
   });
   it('should return undefined if variable delimiters are not attended one', () => {
-    expect(retrieveVariable('{{ date }}', availableVariables, variableDelimiters)).toBeUndefined();
+    expect(retrieveVariable('<< date.client >>', availableVariables, variableDelimiters)).toBeUndefined();
   });
   it('should return variable if variable exist in available variables', () => {
-    expect(retrieveVariable('<%= date %>', availableVariables, variableDelimiters)).toStrictEqual(
-      availableVariables[0],
-    );
+    expect(
+      retrieveVariable('<%= date.client %>', availableVariables, variableDelimiters)?.label,
+    ).toStrictEqual('Date');
+  });
+  it('should return trusted variable if variable exist in available variables', () => {
+    expect(
+      retrieveVariable(
+        '{{ date.server }}',
+        availableVariables,
+        variableDelimiters,
+        trustedVariableDelimiters,
+      )?.label,
+    ).toStrictEqual('Trusted date variable');
   });
 });


### PR DESCRIPTION
Proposal:
We can now pass a new property to the store: trustedVariableDelimiters

In availableVariables if a variable has `trusted` property set to true, it will use trustedVariableDelimiters rather than default variableDelimiters.
This way we can use different delimiters depending on variables (useful for security purpose for example).
We can also have a list of mixed variables for example in a one of:
ex: ['<%= var1 %>', '{{ var2 }}', '<%= var3 %>']

:information_source: I choose to not update the variableDelimiters property to untrustedVariableDelimiters for now, because it allows us to be retrocompatible. For now we can totally use everything the same way as before.
We will only have to add new `trustedVariableDelimiters` to store and set `trusted` property to every needed variables since we want.

:information_source: I do'nt know if we prefer a boolean or maybe a string to define if we use trusted or untrsuted mode (may we have some more type than trusted and untrusted ?)