### PR TITLE
feat: avoid filter step having __VOID__ in it (AND, OR or simple condition) recursivelly [TCTC-5480, TCTC-6102]

### DIFF
--- a/server/src/weaverbird/pipeline/pipeline.py
+++ b/server/src/weaverbird/pipeline/pipeline.py
@@ -2,6 +2,17 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, Field
 
+from weaverbird.pipeline.conditions import (
+    ComparisonCondition,
+    Condition,
+    ConditionComboAnd,
+    ConditionComboOr,
+    DateBoundCondition,
+    InclusionCondition,
+    MatchCondition,
+    NullCondition,
+    SimpleCondition,
+)
 from weaverbird.pipeline.steps.hierarchy import HierarchyStep
 
 from .steps import (
@@ -184,13 +195,58 @@ PipelineStepWithVariables = Annotated[
 ]
 
 
+def _remove_void_condition_steps(
+    variables: dict[str, Any], steps: list[PipelineStepWithVariables | PipelineStep]
+) -> tuple[dict[str, Any], list[PipelineStepWithVariables | PipelineStep]]:
+    void_var_keys = {k for k, v in variables.items() if v == "__VOID__"}
+    variables = {k: v for k, v in variables.items() if v != "__VOID__"}
+
+    def is_not_null_and_value_is_void(condition: Condition):
+        if not isinstance(condition, (NullCondition, ConditionComboAnd, ConditionComboOr)):
+            for vv in void_var_keys:
+                if isinstance(condition.value, str) and condition.value == "{{ " + vv + " }}":
+                    return True
+        return False
+
+    # We only choose to loop on filter step like
+    filter_steps = [s for s in steps if isinstance(s, (FilterStep, FilterStepWithVariables))]
+    for step in filter_steps:
+        if isinstance(
+            step.condition,
+            (
+                ComparisonCondition,
+                InclusionCondition,
+                NullCondition,
+                MatchCondition,
+                DateBoundCondition,
+            ),
+        ):
+            if is_not_null_and_value_is_void(step.condition):
+                steps.remove(step)
+        elif isinstance(step.condition, (ConditionComboAnd, ConditionComboOr)):
+            if isinstance(step.condition, ConditionComboOr):
+                for cond in step.condition.or_:
+                    if is_not_null_and_value_is_void(cond):
+                        step.condition.or_.remove(cond)
+            else:
+                for cond in step.condition.and_:
+                    if is_not_null_and_value_is_void(cond):
+                        step.condition.and_.remove(cond)
+
+    return variables, steps
+
+
 class PipelineWithVariables(BaseModel):
     steps: list[PipelineStepWithVariables | PipelineStep]
 
     def render(self, variables: dict[str, Any], renderer) -> Pipeline:
         # TODO it must be more efficient to render the full pipeline once
+
+        # We clean __VOID__ variable like.
+        # This will also clean the pipeline steps containing those variables
+        cleaned_variables, cleaned_steps = _remove_void_condition_steps(variables, self.steps)
         steps_rendered = [
-            step.render(variables, renderer) if hasattr(step, "render") else step  # type: ignore
-            for step in self.steps
+            step.render(cleaned_variables, renderer) if hasattr(step, "render") else step  # type: ignore
+            for step in cleaned_steps
         ]
         return Pipeline(steps=steps_rendered)

--- a/server/src/weaverbird/pipeline/pipeline.py
+++ b/server/src/weaverbird/pipeline/pipeline.py
@@ -209,16 +209,31 @@ def remove_void_conditions_from_filter_steps(
             ]
             for key in keys_to_remove:
                 del obj[key]  # remove condition if void is found
+
             for v in obj.values():
                 _remove_void_value_elements(v)
+
+            if "condition" in obj:
+                if ("and_" in obj["condition"] and obj["condition"]["and_"] == []) or (
+                    "or_" in obj["condition"] and obj["condition"]["or_"] == []
+                ):
+                    del obj["condition"]
+
         elif isinstance(obj, list):
             indices_to_remove = [
                 i for i, v in enumerate(obj) if isinstance(v, dict) and _contains_void_as_value(v)
             ]
+
             for index in sorted(indices_to_remove, reverse=True):
                 del obj[index]
             for v in obj:
                 _remove_void_value_elements(v)
+
+            for index, v in enumerate(obj):
+                if "or_" in v and v["or_"] == []:
+                    del obj[index]
+                if "and_" in v and v["and_"] == []:
+                    del obj[index]
 
     final_steps = []
     for step in steps:

--- a/server/src/weaverbird/pipeline/pipeline.py
+++ b/server/src/weaverbird/pipeline/pipeline.py
@@ -11,7 +11,6 @@ from weaverbird.pipeline.conditions import (
     InclusionCondition,
     MatchCondition,
     NullCondition,
-    SimpleCondition,
 )
 from weaverbird.pipeline.steps.hierarchy import HierarchyStep
 

--- a/server/src/weaverbird/pipeline/pipeline.py
+++ b/server/src/weaverbird/pipeline/pipeline.py
@@ -197,8 +197,8 @@ def remove_void_conditions_from_filter_steps(
     def _contains_void_as_value(value: dict) -> bool:
         return any(
             [
-                value.get("value") in ("__VOID__",),
-                value.get("column") in ("__VOID__",),
+                value.get("value") == "__VOID__",
+                value.get("column") == "__VOID__",
             ]
         )
 

--- a/server/tests/test_pipeline.py
+++ b/server/tests/test_pipeline.py
@@ -1,14 +1,12 @@
 import glob
 import json
-import re
 from copy import deepcopy
 from datetime import datetime
 
 import pytest
-from jinja2 import Environment
 from jinja2.nativetypes import NativeEnvironment
 from pydantic import BaseModel
-from toucan_connectors.common import RE_PARAM, is_jinja_alone, nosql_apply_parameters_to_query
+from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from weaverbird.pipeline.pipeline import Pipeline, PipelineWithVariables
 from weaverbird.pipeline.steps import DomainStep, RollupStep
@@ -31,17 +29,7 @@ def jinja_renderer(query: dict | list[dict] | tuple | str, parameters: dict):
     elif isinstance(query, tuple):
         return tuple(jinja_renderer(value, parameters) for value in deepcopy(query))
     elif isinstance(query, str):
-        # Replace param templating with jinja templating:
-        query = re.sub(RE_PARAM, r"{{ \g<1> }}", query)
-
-        # Add quotes to string parameters to keep type if not complex
-        clean_p = deepcopy(parameters)
-        if is_jinja_alone(query):
-            env = NativeEnvironment()
-        else:
-            env = Environment()
-
-        return env.from_string(query).render(clean_p)
+        return NativeEnvironment().from_string(query).render(parameters)
     else:
         return query
 

--- a/server/tests/test_pipeline.py
+++ b/server/tests/test_pipeline.py
@@ -16,6 +16,7 @@ from weaverbird.pipeline.pipeline import Pipeline, PipelineWithVariables
 from weaverbird.pipeline.steps import DomainStep, RollupStep
 from weaverbird.pipeline.steps.aggregate import Aggregation
 from weaverbird.pipeline.steps.filter import FilterStep
+from weaverbird.pipeline.steps.top import TopStep
 
 
 class Case(BaseModel):
@@ -149,11 +150,17 @@ def test_skip_void_parameter_from_variables():
             ],
         ),
     )
+
+    void_top_step = TopStep(name="top", rank_on="{{ __front_var_5__ }}", sort="asc", limit=3)
+    none_void_top_step = TopStep(name="top", rank_on="{{ __front_var_6__ }}", sort="asc", limit=3)
+
     steps = [
         {"domain": "foobar", "name": "domain"},
+        void_top_step,
         void_step,
         composed_filter_step_or_,
         simple_filter_step,
+        none_void_top_step,
         composed_filter_step_and_,
     ]
     variables = {
@@ -162,6 +169,8 @@ def test_skip_void_parameter_from_variables():
         "__front_var_2__": "__VOID__",
         "__front_var_3__": "TEST TEST",
         "__front_var_4__": "__VOID__",
+        "__front_var_5__": "__VOID__",
+        "__front_var_6__": "VALUE",
     }
 
     pipeline_with_variables = PipelineWithVariables(steps=steps)
@@ -180,6 +189,7 @@ def test_skip_void_parameter_from_variables():
             },
         },
         {"name": "filter", "condition": {"column": "colB", "operator": "eq", "value": 32}},
+        {"name": "top", "groups": [], "rank_on": "VALUE", "sort": "asc", "limit": 3},
         {
             "name": "filter",
             "condition": {

--- a/server/tests/test_pipeline.py
+++ b/server/tests/test_pipeline.py
@@ -1,13 +1,21 @@
 import glob
 import json
+from datetime import datetime
 
 import pytest
 from pydantic import BaseModel
 from toucan_connectors.common import nosql_apply_parameters_to_query
 
+from weaverbird.pipeline.conditions import (
+    ComparisonCondition,
+    ConditionComboAnd,
+    ConditionComboOr,
+    DateBoundCondition,
+)
 from weaverbird.pipeline.pipeline import Pipeline, PipelineWithVariables
 from weaverbird.pipeline.steps import DomainStep, RollupStep
 from weaverbird.pipeline.steps.aggregate import Aggregation
+from weaverbird.pipeline.steps.filter import FilterStep
 
 
 class Case(BaseModel):
@@ -82,3 +90,106 @@ def test_to_dict():
     }
     assert actual_dict == expected_dict
     assert pipeline == Pipeline(**pipeline.dict())
+
+
+def test_skip_void_parameter_from_variables():
+    void_step = FilterStep(
+        name="filter",
+        condition=ComparisonCondition(
+            column="colA",
+            operator="ge",
+            value="{{ __front_var_0__ }}",
+        ),
+    )
+
+    simple_filter_step = FilterStep(
+        name="filter",
+        condition=ComparisonCondition(
+            column="colB",
+            operator="eq",
+            value="{{ __front_var_1__ }}",
+        ),
+    )
+
+    composed_filter_step_and_ = FilterStep(
+        condition=ConditionComboAnd(
+            and_=[
+                ComparisonCondition(
+                    column="colC",
+                    operator="gt",
+                    value="{{ __front_var_2__ }}",
+                ),
+                DateBoundCondition(
+                    column="Transaction_date",
+                    operator="until",
+                    value=datetime(2009, 1, 3),  # naive
+                ),
+            ]
+        )
+    )
+
+    composed_filter_step_or_ = FilterStep(
+        condition=ConditionComboOr(
+            or_=[
+                ComparisonCondition(
+                    column="colA",
+                    operator="eq",
+                    value="{{ __front_var_3__ }}",
+                ),
+                ComparisonCondition(
+                    column="colX",
+                    operator="lt",
+                    value="{{ __front_var_4__ }}",
+                ),
+                ComparisonCondition(
+                    column="colA",
+                    operator="eq",
+                    value="toto",
+                ),
+            ],
+        ),
+    )
+    steps = [
+        {"domain": "foobar", "name": "domain"},
+        void_step,
+        composed_filter_step_or_,
+        simple_filter_step,
+        composed_filter_step_and_,
+    ]
+    variables = {
+        "__front_var_0__": "__VOID__",
+        "__front_var_1__": 32,
+        "__front_var_2__": "__VOID__",
+        "__front_var_3__": "TEST TEST",
+        "__front_var_4__": "__VOID__",
+    }
+
+    pipeline_with_variables = PipelineWithVariables(steps=steps)
+    pipeline = pipeline_with_variables.render(variables, renderer=nosql_apply_parameters_to_query)
+
+    # It should not have been rendered:
+    assert pipeline.steps == [
+        {"name": "domain", "domain": "foobar"},
+        {
+            "name": "filter",
+            "condition": {
+                "or_": [
+                    {"column": "colA", "operator": "eq", "value": "TEST TEST"},
+                    {"column": "colA", "operator": "eq", "value": "toto"},
+                ]
+            },
+        },
+        {"name": "filter", "condition": {"column": "colB", "operator": "eq", "value": 32}},
+        {
+            "name": "filter",
+            "condition": {
+                "and_": [
+                    {
+                        "column": "Transaction_date",
+                        "operator": "until",
+                        "value": datetime(2009, 1, 3, 0, 0),
+                    },
+                ]
+            },
+        },
+    ]

--- a/server/tests/test_pipeline.py
+++ b/server/tests/test_pipeline.py
@@ -137,6 +137,19 @@ def test_skip_void_parameter_from_variables():
                                                 },
                                             ]
                                         },
+                                        {
+                                            "column": "colP",
+                                            "operator": "in",
+                                            "value": [
+                                                "__VOID__",
+                                                "{{ __front_var_11__ }}",
+                                            ],
+                                        },
+                                        {
+                                            "column": "colQ",
+                                            "operator": "nin",
+                                            "value": [False, "{{ __front_var_10__ }}"],
+                                        },
                                     ]
                                 },
                             ]
@@ -175,6 +188,8 @@ def test_skip_void_parameter_from_variables():
         "__front_var_7__": "TOTO",
         "__front_var_8__": "__VOID__",
         "__front_var_9__": "__VOID__",
+        "__front_var_10__": "__VOID__",
+        "__front_var_11__": True,
     }
 
     pipeline_with_variables = PipelineWithVariables(steps=steps)
@@ -182,8 +197,9 @@ def test_skip_void_parameter_from_variables():
 
     # will render the with no __VOID__ in step, whatever the depth
     assert [s.dict() for s in pipeline.steps] == [
-        {"domain": "foobar", "name": "domain"},
+        {"name": "domain", "domain": "foobar"},
         {
+            "name": "filter",
             "condition": {
                 "or_": [
                     {"column": "colE", "operator": "eq", "value": "TEST TEST"},
@@ -194,21 +210,26 @@ def test_skip_void_parameter_from_variables():
                                 "or_": [
                                     {"column": "colI", "operator": "eq", "value": "toto"},
                                     {"column": "colJ", "operator": "eq", "value": "TOTO"},
+                                    {
+                                        "or_": [
+                                            {"column": "colP", "operator": "in", "value": [True]},
+                                            {"column": "colQ", "operator": "nin", "value": [False]},
+                                        ]
+                                    },
                                 ]
                             },
                         ]
                     },
                 ]
             },
-            "name": "filter",
         },
-        {"condition": {"column": "colB", "operator": "eq", "value": 32}, "name": "filter"},
+        {"name": "filter", "condition": {"column": "colB", "operator": "eq", "value": 32}},
         {
+            "name": "filter",
             "condition": {
                 "and_": [
                     {"column": "ColD", "operator": "until", "value": datetime(2009, 1, 3, 0, 0)}
                 ]
             },
-            "name": "filter",
         },
     ]

--- a/server/tests/test_pipeline.py
+++ b/server/tests/test_pipeline.py
@@ -124,10 +124,34 @@ def test_skip_void_parameter_from_variables():
                                     "operator": "eq",
                                     "value": "{{ __front_var_7__ }}",
                                 },
+                                {
+                                    "or_": [
+                                        {"column": "colM", "operator": "gt", "value": "__VOID__"},
+                                        {"column": "colN", "operator": "le", "value": "__VOID__"},
+                                        {
+                                            "and_": [
+                                                {
+                                                    "column": "colO",
+                                                    "operator": "eq",
+                                                    "value": "__VOID__",
+                                                },
+                                            ]
+                                        },
+                                    ]
+                                },
                             ]
                         },
                     ]
                 },
+            ]
+        },
+    }
+    composed_filter_step_and_all_voids = {
+        "name": "filter",
+        "condition": {
+            "and_": [
+                {"column": "colK", "operator": "gt", "value": "{{ __front_var_8__ }}"},
+                {"column": "colL", "operator": "le", "value": "{{ __front_var_9__ }}"},
             ]
         },
     }
@@ -138,6 +162,7 @@ def test_skip_void_parameter_from_variables():
         composed_filter_step_or_and_,
         simple_filter_step,
         composed_filter_step_and_,
+        composed_filter_step_and_all_voids,
     ]
     variables = {
         "__front_var_0__": "__VOID__",
@@ -148,6 +173,8 @@ def test_skip_void_parameter_from_variables():
         "__front_var_5__": "__VOID__",
         "__front_var_6__": "VALUE",
         "__front_var_7__": "TOTO",
+        "__front_var_8__": "__VOID__",
+        "__front_var_9__": "__VOID__",
     }
 
     pipeline_with_variables = PipelineWithVariables(steps=steps)


### PR DESCRIPTION
## WHAT

This is a POC for skipping considering a filter step that may contain as value "__VOID__" to be able to still,
on an AND, OR, or simple filter condition type.

## WHY

Resolves: TCTC-5480