### PR TITLE
feat(nativeSQL): we want to cast to integer a column resulting from a date extract

### DIFF
--- a/server/src/weaverbird/backends/pypika_translator/translators/base.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/base.py
@@ -3,7 +3,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import cache
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, get_args
 
 from dateutil import parser as dateutil_parser
 from pypika import (
@@ -753,15 +753,18 @@ class SQLTranslator(ABC):
         columns: list[str],
         step: "DateExtractStep",
     ) -> StepContext:
+        from weaverbird.pipeline.steps.date_extract import TIMESTAMP_DATE_PARTS
+
         date_col: Field = Table(prev_step_name)[step.column]
         extracted_dates: list[LiteralValue] = []
 
         for date_info, new_column_name in zip(step.date_info, step.new_columns):
-            extracted_dates.append(
-                self._get_date_extract_func(date_unit=date_info, target_column=date_col).as_(
-                    new_column_name
-                )
-            )
+            col_field = self._get_date_extract_func(date_unit=date_info, target_column=date_col)
+
+            if date_info not in get_args(TIMESTAMP_DATE_PARTS):
+                col_field = functions.Cast(col_field, self.DATA_TYPE_MAPPING.integer)
+
+            extracted_dates.append(col_field.as_(new_column_name))
         query: "Selectable" = self.QUERY_CLS.from_(prev_step_name).select(
             *columns, *extracted_dates
         )

--- a/server/tests/backends/sql_translator_unit_tests/test_base_translator.py
+++ b/server/tests/backends/sql_translator_unit_tests/test_base_translator.py
@@ -790,9 +790,12 @@ def test_dateextract(base_translator: BaseTranslator, default_step_kwargs: dict[
 
     expected_query = Query.from_(previous_step).select(
         *selected_columns,
-        functions.Extract(
-            field=functions.Cast(Field(column), base_translator.DATA_TYPE_MAPPING.timestamp),
-            date_part=operation,
+        functions.Cast(
+            functions.Extract(
+                field=functions.Cast(Field(column), base_translator.DATA_TYPE_MAPPING.timestamp),
+                date_part=operation,
+            ),
+            base_translator.DATA_TYPE_MAPPING.integer,
         ).as_(new_column_name),
     )
 

--- a/server/tests/backends/sql_translator_unit_tests/test_snowflake_translator.py
+++ b/server/tests/backends/sql_translator_unit_tests/test_snowflake_translator.py
@@ -121,9 +121,27 @@ def test_date_extract_extract_kw(
     )
     expected_query = Query.from_(previous_step).select(
         *[prev_table.field(col) for col in selected_columns],
-        Extract("year", Cast(prev_table.brewing_date, "timestamp")).as_("brewing_year"),
-        Extract("month", Cast(prev_table.brewing_date, "timestamp")).as_("brewing_month"),
-        Extract("day", Cast(prev_table.brewing_date, "timestamp")).as_("brewing_day"),
+        Cast(
+            Extract(
+                "year",
+                Cast(prev_table.brewing_date, snowflake_translator.DATA_TYPE_MAPPING.timestamp),
+            ),
+            snowflake_translator.DATA_TYPE_MAPPING.integer,
+        ).as_("brewing_year"),
+        Cast(
+            Extract(
+                "month",
+                Cast(prev_table.brewing_date, snowflake_translator.DATA_TYPE_MAPPING.timestamp),
+            ),
+            snowflake_translator.DATA_TYPE_MAPPING.integer,
+        ).as_("brewing_month"),
+        Cast(
+            Extract(
+                "day",
+                Cast(prev_table.brewing_date, snowflake_translator.DATA_TYPE_MAPPING.timestamp),
+            ),
+            snowflake_translator.DATA_TYPE_MAPPING.integer,
+        ).as_("brewing_day"),
     )
     assert ctx.selectable.get_sql(quote_char='"') == expected_query.get_sql(quote_char='"')
 
@@ -145,7 +163,10 @@ def test_date_extract_func(
     )
     expected_query = Query.from_(previous_step).select(
         *[prev_table.field(col) for col in selected_columns],
-        Extract("week", prev_table.brewing_date).as_("brewing_week"),
+        Cast(
+            Extract("week", prev_table.brewing_date),
+            snowflake_translator.DATA_TYPE_MAPPING.integer,
+        ).as_("brewing_week"),
     )
     assert ctx.selectable.get_sql(quote_char='"') == expected_query.get_sql(quote_char='"')
 


### PR DESCRIPTION
We need to cast to integer all "date extraction" like we did here for pandas executor : https://github.com/ToucanToco/weaverbird/pull/1777

### BEFORE
![before0](https://github.com/ToucanToco/weaverbird/assets/22576758/4ad44ece-7093-4895-8be5-0ae9e55d26c3)


### AFTER
![after](https://github.com/ToucanToco/weaverbird/assets/22576758/3e510be9-3f66-4822-bb92-83f83e34d95d)



## NOTE

This will be backported on master