### PR TITLE
feat(labeller): enable to override retrieveDomainName by passing a custom method to store state

### DIFF
--- a/ui/src/components/Step.vue
+++ b/ui/src/components/Step.vue
@@ -68,11 +68,11 @@ import { Component, Prop } from 'vue-property-decorator';
 
 import FAIcon from '@/components/FAIcon.vue';
 import {
+  retrieveDomainName,
   humanReadableLabel,
   labelWithReadeableVariables,
-  retrieveDomainName,
 } from '@/lib/labeller';
-import type { PipelineStep, ReferenceToExternalQuery } from '@/lib/steps';
+import type { PipelineStep, Reference } from '@/lib/steps';
 import type { VariableDelimiters } from '@/lib/variables';
 import { State, Getter } from 'pinia-class';
 import { VQBModule } from '@/store';
@@ -88,6 +88,7 @@ import PreviewSourceSubset from './PreviewSourceSubset.vue';
 })
 export default class Step extends Vue {
   @State(VQBModule) availableDomains!: { name: string; uid: string }[];
+  @State(VQBModule) customRetrieveDomainName?: (domain: Reference) => string;
 
   @Prop(Boolean)
   readonly isFirst!: boolean;
@@ -135,9 +136,10 @@ export default class Step extends Vue {
 
   get stepName(): string {
     // enable to retrieve the related name of a query referenced behind an uid
-    return humanReadableLabel(this.step, (domain: string | ReferenceToExternalQuery) =>
-      retrieveDomainName(domain, this.availableDomains),
-    );
+    return humanReadableLabel(this.step, (domain: Reference) => {
+      const customDomainName = this.customRetrieveDomainName?.(domain);
+      return customDomainName ?? retrieveDomainName(domain, this.availableDomains);
+    });
   }
 
   get canConfigurePreviewSourceSubset(): boolean {

--- a/ui/src/store/actions.ts
+++ b/ui/src/store/actions.ts
@@ -3,7 +3,7 @@ import Vue from 'vue';
 import type { BackendError, BackendResponse, BackendService, BackendWarning } from '@/lib/backend';
 import { addLocalUniquesToDataset, updateLocalUniquesFromDatabase } from '@/lib/dataset/helpers';
 import { pageOffset } from '@/lib/dataset/pagination';
-import type { Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
+import type { Pipeline, PipelineStep, PipelineStepName, Reference } from '@/lib/steps';
 import { setVariableDelimiters } from '@/lib/translators';
 import type { DataSet, VariableDelimiters, VariablesBucket } from '@/types';
 
@@ -56,6 +56,11 @@ export type VQBActions = {
     unjoinableDomains,
   }: {
     unjoinableDomains: { name: string; uid: string }[];
+  }) => void;
+  setCustomRetrieveDomainName: ({
+    customRetrieveDomainName,
+  }: {
+    customRetrieveDomainName: (domain: Reference) => string;
   }) => void;
   setCurrentPipelineName: ({ name }: { name: string }) => void;
   setPipeline: ({ pipeline }: { pipeline: Pipeline }) => void;
@@ -143,6 +148,9 @@ const actions: PiniaActionAdaptor<VQBActions, VQBStore> = {
   },
   setUnjoinableDomains({ unjoinableDomains }) {
     this.unjoinableDomains = unjoinableDomains;
+  },
+  setCustomRetrieveDomainName({ customRetrieveDomainName }) {
+    this.customRetrieveDomainName = customRetrieveDomainName;
   },
   setCurrentPipelineName({ name }) {
     this.currentPipelineName = name;

--- a/ui/src/store/state.ts
+++ b/ui/src/store/state.ts
@@ -4,7 +4,7 @@
 import type { BackendError, BackendService, BackendWarning } from '@/lib/backend';
 import { UnsetBackendService } from '@/lib/backend';
 import type { DataSet } from '@/lib/dataset';
-import type { Pipeline, PipelineStepName } from '@/lib/steps';
+import type { Pipeline, PipelineStepName, Reference } from '@/lib/steps';
 import type { InterpolateFunction, ScopeContext } from '@/lib/templating';
 import type { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 
@@ -29,6 +29,7 @@ export interface VQBState {
 
   domains: string[];
   availableDomains: { name: string; uid: string }[];
+  customRetrieveDomainName?: (domain: Reference) => string;
   unjoinableDomains?: { name: string; uid: string }[];
   pipelines: { [name: string]: Pipeline };
 
@@ -107,6 +108,8 @@ export function emptyState(): VQBState {
     backendService: UnsetBackendService,
     interpolateFunc: (x: string | any[], _context: ScopeContext) => x,
     featureFlags: undefined,
+    // we enable to override retrieveDomainName method to handle names provided by any other source than availableDomains
+    customRetrieveDomainName: undefined,
   };
 }
 

--- a/ui/tests/unit/step.spec.ts
+++ b/ui/tests/unit/step.spec.ts
@@ -162,6 +162,39 @@ describe('Step.vue', () => {
     ]);
   });
 
+  it('should retrieveDomainName for step label (with custom retrieveDomainName method)', () => {
+    const customRetrieveDomainNameStub = vi.fn().mockReturnValue('plop');
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'GoT' },
+      { name: 'replace', searchColumn: 'characters', toReplace: [['Snow', 'Targaryen']] },
+      { name: 'rename', toRename: [['region', 'kingdom']] },
+      { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
+    ];
+    setupMockStore(
+      buildStateWithOnePipeline(pipeline, {
+        availableDomains: [{ uid: '1', name: 'Query 1' }],
+        customRetrieveDomainName: customRetrieveDomainNameStub,
+      }),
+    );
+    const wrapper = shallowMount(Step, {
+      propsData: {
+        key: 0,
+        isActive: true,
+        isLastActive: true,
+        isDisabled: false,
+        isFirst: true,
+        isLast: true,
+        step: { name: 'domain', domain: { uid: '1', type: 'ref' } },
+        indexInPipeline: 0,
+        variableDelimiters: { start: '{{ ', end: ' }}' },
+      },
+      pinia,
+      localVue,
+    });
+    expect(customRetrieveDomainNameStub).toHaveBeenCalledWith({ uid: '1', type: 'ref' });
+    expect(wrapper.find('.query-pipeline-step__name').text()).toBe('Source: "plop"');
+  });
+
   it('should toggle the edit mode when clicking on the edit icon and emit editStep', () => {
     const pipeline: Pipeline = [
       { name: 'domain', domain: 'GoT' },

--- a/ui/tests/unit/store.spec.ts
+++ b/ui/tests/unit/store.spec.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { BackendService } from '@/lib/backend';
 import type { DataSet } from '@/lib/dataset';
-import type { Pipeline } from '@/lib/steps';
+import type { Pipeline, Reference } from '@/lib/steps';
 import { formatError } from '@/store/actions';
 import { currentPipeline, emptyState } from '@/store/state';
 
@@ -592,6 +592,18 @@ describe('mutation tests', () => {
     expect(store.availableDomains).toEqual([]);
     store.setAvailableDomains({ availableDomains: [{ uid: '1', name: 'Query 1' }] });
     expect(store.availableDomains).toEqual([{ uid: '1', name: 'Query 1' }]);
+  });
+
+  it('sets customRetrieveDomainName function', () => {
+    const customRetrieveDomainName = (
+      _domain: Reference,
+      _availableDomains: { name: string; uid: string }[],
+    ) => 'plop';
+    const state = buildState({});
+    const store = setupMockStore(state);
+    expect(store.customRetrieveDomainName).toEqual(undefined);
+    store.setCustomRetrieveDomainName({ customRetrieveDomainName: customRetrieveDomainName });
+    expect(store.customRetrieveDomainName).toEqual(customRetrieveDomainName);
   });
 
   it('sets unjoinableDomains list', () => {


### PR DESCRIPTION
In some cases, the domain name can refers to something else than one of the available datasets provided to weaverbird. To enable to display correct name for used source, we enable to override labeller default method using a 'customRetrieveDomainName' method from store state.