### PR TITLE
fix: add case insensitive on matches/notmatches filter steps [TCTC-6338]

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog (weaverbird python package)
 
+### Changed
+
+- Fix[Mongo]: Add case insensitive on `matches/notmatches` mongo filter step.
+
 ## [0.33.0] - 2023-06-29
 
 ### Changed

--- a/server/src/weaverbird/backends/mongo_translator/steps/filter.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/filter.py
@@ -66,9 +66,9 @@ def build_match_tree(condition: Condition, parent_operator="and") -> dict:
 
     elif isinstance(condition, MatchCondition):
         if condition.operator == "matches":
-            return {condition.column: {"$regex": condition.value}}
+            return {condition.column: {"$regex": condition.value, "$options": "i"}}
         elif condition.operator == "notmatches":
-            return {condition.column: {"$not": {"$regex": condition.value}}}
+            return {condition.column: {"$not": {"$regex": condition.value, "$options": "i"}}}
 
     # dates
     elif isinstance(condition, DateBoundCondition):

--- a/server/tests/backends/mongo_translator/steps/test_filter.py
+++ b/server/tests/backends/mongo_translator/steps/test_filter.py
@@ -1,0 +1,14 @@
+# test
+
+from weaverbird.backends.mongo_translator.steps.filter import build_match_tree
+from weaverbird.pipeline.conditions import MatchCondition
+
+
+def test_build_match_tree():
+    assert build_match_tree(MatchCondition(column="test", operator="matches", value="test")) == {
+        "test": {"$options": "i", "$regex": "test"}
+    }
+
+    assert build_match_tree(MatchCondition(column="test", operator="notmatches", value="test")) == {
+        "test": {"$not": {"$options": "i", "$regex": "test"}}
+    }


### PR DESCRIPTION
## WHAT

On "Match Pattern", we want a case insensitive for mongo filter step

## HOW

By adding the "$options" "I" on filter step for mongo

## ADDITIONAL INFOS

### BEFORE
![before](https://github.com/ToucanToco/weaverbird/assets/22576758/c046e952-0f08-41f0-9841-647d1f4927ea)


### AFTER

![after](https://github.com/ToucanToco/weaverbird/assets/22576758/f0bc9dea-3ac6-40e1-8497-e3cab4b2e668)
