### PR TITLE
fix: keep None/null on $ne and $eq direct value to fix isnull/isnotnull filter step condition for mongo [TCTC-6339]

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 
 - Fix[Mongo]: Add case insensitive on `matches/notmatches` mongo filter step.
+- Fix[Mongo]: ignore `$ne` and `$eq` when removing `__VOID__` values from a mongo pipeline to keep mongo filter steps for `isnull` and `isnotnull`.
 
 ## [0.33.0] - 2023-06-29
 

--- a/server/src/weaverbird/pipeline/pipeline.py
+++ b/server/src/weaverbird/pipeline/pipeline.py
@@ -194,6 +194,8 @@ PipelineStepWithVariables = Annotated[
 
 VOID_REPR = "__VOID__"
 EXCLUDE_CLEANING_FOR = (
+    "$ne",  # for isnotnull (None -> null for mongo)
+    "$eq",  # for isnull (None -> null for mongo)
     "pipeline",
     "localField",
     "foreignField",
@@ -371,7 +373,8 @@ def _sanitize_query_matches(query: dict | list[dict]) -> Any:
 def remove_void_conditions_from_mongo_steps(
     mongo_steps: dict | list[dict],
 ) -> dict | list[dict]:
-    return _sanitize_query_matches(_clean_mongo_steps(mongo_steps) or [])
+    mongo_query = _sanitize_query_matches(_clean_mongo_steps(mongo_steps) or [])
+    return mongo_query
 
 
 # TODO move to a dedicated variables module

--- a/server/src/weaverbird/pipeline/pipeline.py
+++ b/server/src/weaverbird/pipeline/pipeline.py
@@ -373,8 +373,7 @@ def _sanitize_query_matches(query: dict | list[dict]) -> Any:
 def remove_void_conditions_from_mongo_steps(
     mongo_steps: dict | list[dict],
 ) -> dict | list[dict]:
-    mongo_query = _sanitize_query_matches(_clean_mongo_steps(mongo_steps) or [])
-    return mongo_query
+    return _sanitize_query_matches(_clean_mongo_steps(mongo_steps) or [])
 
 
 # TODO move to a dedicated variables module

--- a/server/tests/test_pipeline.py
+++ b/server/tests/test_pipeline.py
@@ -265,6 +265,7 @@ def test_skip_void_parameter_from_variables_for_mongo_steps():
         [
             {
                 "$match": {
+                    "$ne": None,
                     "$and": [
                         {"$or": [{"property2": "value2"}, {"property3": {}}]},
                         {"$nor": [{"property4": {}}, {"property5": {}}]},
@@ -284,11 +285,15 @@ def test_skip_void_parameter_from_variables_for_mongo_steps():
                 }
             }
         ]
-    ) == [{"$match": {"$and": [{"$or": [{"property2": "value2"}]}]}}]
+    ) == [{"$match": {"$and": [{"$or": [{"property2": "value2"}]}], "$ne": None}}]
 
     assert remove_void_conditions_from_mongo_steps(
         [
-            {"$match": {}},
+            {
+                "$match": {
+                    "$eq": None,
+                }
+            },
             {"$group": {"_id": None, "_vqbPipelineInline": {"$push": "$$ROOT"}}},
             {
                 "$lookup": {
@@ -309,7 +314,7 @@ def test_skip_void_parameter_from_variables_for_mongo_steps():
             {"$project": {"_id": 0}},
         ]
     ) == [
-        {"$match": {}},
+        {"$match": {"$eq": None}},
         {"$group": {"_id": None, "_vqbPipelineInline": {"$push": "$$ROOT"}}},
         {"$lookup": {"as": "_vqbPipelineToAppend_0", "from": "slide_data-append", "pipeline": []}},
         {


### PR DESCRIPTION
## WHAT

While cleaning `__VOID__` from a mongo pipeline, we introduced a regression [HERE](https://github.com/ToucanToco/weaverbird/pull/1797) because we were removing also normal/casual `$ne/$eq` direct isnull/isnotnull values from filter condition,.


## HOW
This PR is to isolate those specific cases and adapt the test for the fix.

## ADDITIONAL INFOS

### BEFORE
![before](https://github.com/ToucanToco/weaverbird/assets/22576758/6179b7d3-5d9f-4fd0-b1bc-185eb9b84b9a)


### AFTER

![after](https://github.com/ToucanToco/weaverbird/assets/22576758/2c1f68b0-be9e-40f8-8258-416e98c83ff2)


