### PR TITLE
fix: mongo rank step (due to remove_void regression) [TCTC-6370]

### DIFF
--- a/server/src/weaverbird/pipeline/pipeline.py
+++ b/server/src/weaverbird/pipeline/pipeline.py
@@ -194,7 +194,9 @@ PipelineStepWithVariables = Annotated[
 
 VOID_REPR = "__VOID__"
 EXCLUDE_CLEANING_FOR = (
-    "$ne",  # for isnotnull (None -> null for mongo)
+    "prevValue",  # for the rank step, this need to be keep
+    "prevRank",  # for the rank step, this need to be keep
+    "$ne",  # for isnotnull (None -> null for mongo),
     "$eq",  # for isnull (None -> null for mongo)
     "pipeline",
     "localField",


### PR DESCRIPTION
## WHAT

Yet another regression introduce by the remove_void from mongo steps.

## HOW

Fixed by what caracterize the rank step (some specifics columns that needed to be None).
