### PR TITLE
feat(server): handle unresolved references TCTC-6355

### DIFF
--- a/server/src/weaverbird/pipeline/references.py
+++ b/server/src/weaverbird/pipeline/references.py
@@ -22,7 +22,7 @@ class PipelineWithRefs(BaseModel):
 
     async def resolve_references(
         self, reference_resolver: ReferenceResolver
-    ) -> PipelineWithVariables:
+    ) -> PipelineWithVariables | None:
         """
         Walk the pipeline steps and replace any reference by its corresponding pipeline.
         The sub-pipelines added should also be handled, so that they will be no references anymore in the result.
@@ -36,7 +36,13 @@ class PipelineWithRefs(BaseModel):
             )
             if isinstance(resolved_step, PipelineWithVariables):
                 resolved_steps.extend(resolved_step.steps)
-            else:
+            elif resolved_step is not None:  # None means the step should be skipped
                 resolved_steps.append(resolved_step)
 
         return PipelineWithVariables(steps=resolved_steps)
+
+
+class ReferenceUnresolved(Exception):
+    """
+    Raised when a mandatory reference is not resolved
+    """

--- a/server/src/weaverbird/pipeline/steps/append.py
+++ b/server/src/weaverbird/pipeline/steps/append.py
@@ -28,8 +28,14 @@ class AppendStepWithRefs(BaseAppendStep):
 
     async def resolve_references(
         self, reference_resolver: ReferenceResolver
-    ) -> AppendStepWithVariable:
+    ) -> AppendStepWithVariable | None:
+        resolved_pipelines = [
+            await resolve_if_reference(reference_resolver, p) for p in self.pipelines
+        ]
+        resolved_pipelines_without_nones = [p for p in resolved_pipelines if p is not None]
+        if len(resolved_pipelines_without_nones) == 0:
+            return None  # skip the step
         return AppendStepWithVariable(
             name=self.name,
-            pipelines=[await resolve_if_reference(reference_resolver, p) for p in self.pipelines],
+            pipelines=resolved_pipelines_without_nones,
         )

--- a/server/src/weaverbird/pipeline/steps/domain.py
+++ b/server/src/weaverbird/pipeline/steps/domain.py
@@ -35,6 +35,10 @@ class DomainStepWithRef(BaseDomainStep):
         resolved = await resolve_if_reference(reference_resolver, self.domain)
         if isinstance(resolved, list):
             return await PipelineWithRefs(steps=resolved).resolve_references(reference_resolver)
+        elif resolved is None:
+            from weaverbird.pipeline.references import ReferenceUnresolved
+
+            raise ReferenceUnresolved()
         else:
             return DomainStep(
                 name=self.name,

--- a/server/src/weaverbird/pipeline/steps/join.py
+++ b/server/src/weaverbird/pipeline/steps/join.py
@@ -38,7 +38,9 @@ class JoinStepWithRef(BaseJoinStep):
     ) -> JoinStepWithVariable | None:
         right_pipeline = await resolve_if_reference(reference_resolver, self.right_pipeline)
         if right_pipeline is None:
-            return None  # skip step
+            from ..references import ReferenceUnresolved
+
+            raise ReferenceUnresolved()
         return JoinStepWithVariable(
             name=self.name,
             type=self.type,

--- a/server/src/weaverbird/pipeline/steps/utils/combination.py
+++ b/server/src/weaverbird/pipeline/steps/utils/combination.py
@@ -1,4 +1,4 @@
-from typing import Any, Awaitable, Callable, Literal
+from typing import Awaitable, Callable, Literal
 
 from pydantic import BaseModel
 

--- a/server/src/weaverbird/pipeline/steps/utils/combination.py
+++ b/server/src/weaverbird/pipeline/steps/utils/combination.py
@@ -23,7 +23,7 @@ ReferenceResolver = Callable[[Reference], Awaitable[PipelineOrDomainName | None]
 async def resolve_if_reference(
     reference_resolver: ReferenceResolver,
     pipeline_or_domain_name_or_ref: PipelineOrDomainNameOrReference,
-) -> str | list[dict] | None | Any:
+) -> PipelineOrDomainName | None:
     from weaverbird.pipeline.references import PipelineWithRefs
 
     if isinstance(pipeline_or_domain_name_or_ref, Reference):

--- a/server/tests/pipeline/test_references.py
+++ b/server/tests/pipeline/test_references.py
@@ -236,7 +236,7 @@ async def test_resolve_references_unresolved_append_subpipeline_error():
 @pytest.mark.asyncio
 async def test_resolve_references_unresolved_join():
     """
-    It should skip the step if the joined pipeline is not resolved
+    It should raise an error if the joined pipeline is not resolved
     """
     pipeline_with_refs = PipelineWithRefs(
         steps=[
@@ -249,18 +249,14 @@ async def test_resolve_references_unresolved_join():
             TextStep(new_column="text", text="Lorem ipsum"),
         ]
     )
-    assert await pipeline_with_refs.resolve_references(reference_resolver) == PipelineWithVariables(
-        steps=[
-            DomainStep(domain="source"),
-            TextStep(new_column="text", text="Lorem ipsum"),
-        ]
-    )
+    with pytest.raises(ReferenceUnresolved):
+        assert await pipeline_with_refs.resolve_references(reference_resolver)
 
 
 @pytest.mark.asyncio
 async def test_resolve_references_unresolved_join_subpipeline_error():
     """
-    It should skip the step if the pipeline triggers a resolution error
+    It should raise an error if the joined pipeline raises a resolution error
     """
     pipeline_with_refs = PipelineWithRefs(
         steps=[
@@ -273,9 +269,5 @@ async def test_resolve_references_unresolved_join_subpipeline_error():
             TextStep(new_column="text", text="Lorem ipsum"),
         ]
     )
-    assert await pipeline_with_refs.resolve_references(reference_resolver) == PipelineWithVariables(
-        steps=[
-            DomainStep(domain="source"),
-            TextStep(new_column="text", text="Lorem ipsum"),
-        ]
-    )
+    with pytest.raises(ReferenceUnresolved):
+        await pipeline_with_refs.resolve_references(reference_resolver)


### PR DESCRIPTION
We need to plan the case when a reference is not returned. This cas is not OK when it's the Domain step of the main pipeline, but it's fine when it's a sub-pipeline (meaning it just should be ignored).