### PR TITLE
fix(join-step): retrieve columns for query behind ref

### DIFF
--- a/ui/src/components/stepforms/JoinStepForm.vue
+++ b/ui/src/components/stepforms/JoinStepForm.vue
@@ -11,7 +11,7 @@
       v-model="rightPipeline"
       name="Select a dataset to join (as right dataset):"
       :options="options"
-      @input="updateRightColumnNames(rightPipeline.label)"
+      @input="updateRightColumnNames(rightPipeline.trackBy)"
       placeholder="Select a dataset"
       data-path=".rightPipeline"
       :errors="errors"
@@ -148,13 +148,13 @@ export default class JoinStepForm extends BaseStepForm<JoinStep> {
 
   @Action(VQBModule) getColumnNamesFromPipeline!: VQBActions['getColumnNamesFromPipeline'];
 
-  async updateRightColumnNames(pipelineNameOrDomain: string) {
+  async updateRightColumnNames(pipelineNameOrDomain: string | ReferenceToExternalQuery) {
     this.rightColumnNames = await this.getColumnNamesFromPipeline(pipelineNameOrDomain);
   }
 
   created() {
-    if (this.rightPipeline.label) {
-      this.updateRightColumnNames(this.rightPipeline.label);
+    if (this.rightPipeline.trackBy) {
+      this.updateRightColumnNames(this.rightPipeline.trackBy);
     }
   }
 }

--- a/ui/src/store/actions.ts
+++ b/ui/src/store/actions.ts
@@ -3,7 +3,7 @@ import Vue from 'vue';
 import type { BackendError, BackendResponse, BackendService, BackendWarning } from '@/lib/backend';
 import { addLocalUniquesToDataset, updateLocalUniquesFromDatabase } from '@/lib/dataset/helpers';
 import { pageOffset } from '@/lib/dataset/pagination';
-import type { Pipeline, PipelineStep, PipelineStepName, Reference } from '@/lib/steps';
+import type { Pipeline, PipelineStep, PipelineStepName, Reference, ReferenceToExternalQuery } from '@/lib/steps';
 import { setVariableDelimiters } from '@/lib/translators';
 import type { DataSet, VariableDelimiters, VariablesBucket } from '@/types';
 
@@ -89,7 +89,7 @@ export type VQBActions = {
   setDataset: ({ dataset }: { dataset: DataSet }) => void;
   setSelectedColumns: ({ column }: { column: string | undefined }) => void;
   toggleColumnSelection: ({ column }: { column: string }) => void;
-  getColumnNamesFromPipeline: (pipelineNameOrDomain: string) => Promise<string[] | undefined>;
+  getColumnNamesFromPipeline: (pipelineNameOrDomain: string | ReferenceToExternalQuery) => Promise<string[] | undefined>;
   loadColumnUniqueValues: ({ column }: { column: string }) => void;
   setCurrentPage: ({ pageNumber }: { pageNumber: number }) => void;
   resetPagination: () => void;


### PR DESCRIPTION
Enable to retrieve columns names for a query behind ref (before we passed domain name while we should pass reference)