### PR TITLE
fix: keep empty list to make mongo steps still working as before [TCTC-6370]

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog (weaverbird python package)
 
+### Fixed
+
+- Fix[Mongo]: Keep empty list from mongo pipeline after  `weaverbird.pipeline.remove_void_conditions_from_mongo_steps()`
+  to keep steps that depends on those characteristics to still working.
+
 ## [0.34.0] - 2023-07-10
 
 ### Changed

--- a/server/src/weaverbird/pipeline/pipeline.py
+++ b/server/src/weaverbird/pipeline/pipeline.py
@@ -291,10 +291,7 @@ def _remove_empty_elements(data: Any) -> Any:
             if (cleaned := _remove_empty_elements(item)) is not None  # type: ignore[assignment]
         ]
 
-        if isinstance(data_transformed, list):
-            return data_transformed
-        else:
-            return data_transformed or None
+        return data_transformed
     else:
         return data
 

--- a/server/src/weaverbird/pipeline/pipeline.py
+++ b/server/src/weaverbird/pipeline/pipeline.py
@@ -279,6 +279,9 @@ def _remove_empty_elements(data: Any) -> Any:
                 if (cleaned := _remove_empty_elements(v)) is not None:
                     data_transformed[k] = cleaned
 
+                if cleaned == [] and k in ["$or", "$nor", "$and"]:
+                    data_transformed[k] = None
+
         if isinstance(data_transformed, list):
             return data_transformed
         else:

--- a/server/tests/test_pipeline.py
+++ b/server/tests/test_pipeline.py
@@ -285,16 +285,7 @@ def test_skip_void_parameter_from_variables_for_mongo_steps():
                 }
             }
         ]
-    ) == [
-        {
-            "$match": {
-                "$and": [{"$or": [{"property2": "value2"}]}, {"$nor": []}],
-                "$ne": None,
-                "$nor": [{"property9": {"$and": []}}],
-                "$or": [],
-            }
-        },
-    ]
+    ) == [{"$match": {"$and": [{"$or": [{"property2": "value2"}]}], "$ne": None}}]
 
     assert remove_void_conditions_from_mongo_steps(
         [

--- a/server/tests/test_pipeline.py
+++ b/server/tests/test_pipeline.py
@@ -285,7 +285,16 @@ def test_skip_void_parameter_from_variables_for_mongo_steps():
                 }
             }
         ]
-    ) == [{"$match": {"$and": [{"$or": [{"property2": "value2"}]}], "$ne": None}}]
+    ) == [
+        {
+            "$match": {
+                "$and": [{"$or": [{"property2": "value2"}]}, {"$nor": []}],
+                "$ne": None,
+                "$nor": [{"property9": {"$and": []}}],
+                "$or": [],
+            }
+        },
+    ]
 
     assert remove_void_conditions_from_mongo_steps(
         [
@@ -469,6 +478,7 @@ def test_skip_void_parameter_from_variables_for_mongo_steps():
                                         }
                                     },
                                     "initialValue": {
+                                        "a": [],  # array based key field filtering in mongo should be kept
                                         "order": 0,
                                         "prevRank": None,
                                         "prevValue": None,


### PR DESCRIPTION
## WHAT

While removing __VOID__ from mongo pipeline, we were also removing key/value with empty list or empty dict !
But after some investigations, we noticed that some steps like the `rank` needs some of it keys to be empty such as `'a':[]` or `pipeline:[]`
In this example :
```
[
            {"$match": {"domain": "cars"}},
            {"$sort": {"color": 1}},
            {"$group": {"_id": None, "_vqbArray": {"$push": "$$ROOT"}}},
            {
                "$project": {
                    "_vqbSortedArray": {
                        "$let": {
                            "vars": {
                                "reducedArrayInObj": {
                                    "$reduce": {
                                        "input": "$_vqbArray",
                                        "initialValue": {
                                            "a": [],
                                            "order": 0,
                                            "prevValue": None,
                                            "prevRank": None,
                                        },
                                        "in": {
                                            "$let": {
                                                "vars": {
                                                    "order": {
                                                        "$cond": [
                                                            {
                                                                "$ne": [
                                                                    "$$this.color",
                                                                    "$$value.prevValue",
                                                                ]
                                                            },
                                                            {"$add": ["$$value.order", 1]},
                                                            "$$value.order",
                                                        ]
                                                    },
                                                    "rank": {
                                                        "$cond": [
                                                            {
                                                                "$ne": [
                                                                    "$$this.color",
                                                                    "$$value.prevValue",
                                                                ]
                                                            },
                                                            {"$add": ["$$value.order", 1]},
                                                            "$$value.prevRank",
                                                        ]
                                                    },
                                                },
                                                "in": {
                                                    "a": {
                                                        "$concatArrays": [
                                                            "$$value.a",
                                                            [
                                                                {
                                                                    "$mergeObjects": [
                                                                        "$$this",
                                                                        {"color-rank": "$$rank"},
                                                                    ]
                                                                }
                                                            ],
                                                        ]
                                                    },
                                                    "order": "$$order",
                                                    "prevValue": "$$this.color",
                                                    "prevRank": "$$rank",
                                                },
                                            }
                                        },
                                    }
                                }
                            },
                            "in": "$$reducedArrayInObj.a",
                        }
                    }
                }
            },
            {"$unwind": "$_vqbSortedArray"},
            {"$replaceRoot": {"newRoot": "$_vqbSortedArray"}},
        ]
```

For it to work.