### PR TITLE
fix: escape properly column names on GBQ [TCTC-6519]

### DIFF
--- a/server/src/weaverbird/backends/pypika_translator/translators/base.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/base.py
@@ -252,6 +252,12 @@ class SQLTranslator(ABC):
 
         return ctx
 
+    def _ensure_term_uses_wrapper(self: Self, term: Term):
+        """(ugly) monkey patch to make sure pypika term uses the right wrapper"""
+        from functools import partial
+
+        term.wrap_constant = partial(term.wrap_constant, wrapper_cls=self.VALUE_WRAPPER_CLS)
+
     def get_query_builder(
         self: Self,
         *,
@@ -967,6 +973,7 @@ class SQLTranslator(ABC):
         self: Self, condition: "SimpleCondition", prev_step_table: Table
     ) -> Criterion:
         column_field = prev_step_table[condition.column]
+        self._ensure_term_uses_wrapper(column_field)
 
         # NOTE: type ignore comments below are because of 'Expected type in class pattern; found
         # "Any"' mypy errors. Seems like mypy 0.990 does not like typing.Annotated

--- a/server/src/weaverbird/backends/pypika_translator/translators/googlebigquery.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/googlebigquery.py
@@ -67,13 +67,13 @@ class GoogleBigQueryQueryBuilder(QueryBuilder):
             dialect=SQLDialect.GOOGLEBIGQUERY, wrapper_cls=GoogleBigQueryValueWrapper, **kwargs
         )
 
-    @staticmethod
-    def wrap_constant(val, wrapper_cls=GoogleBigQueryValueWrapper):
-        return super().wrap_constant(val, wrapper_cls)
+    # @staticmethod
+    # def wrap_constant(val, wrapper_cls=GoogleBigQueryValueWrapper):
+    #     return super().wrap_constant(val, wrapper_cls)
 
-    @staticmethod
-    def wrap_json(val, wrapper_cls=GoogleBigQueryValueWrapper):
-        return super().wrap_json(val, wrapper_cls)
+    # @staticmethod
+    # def wrap_json(val, wrapper_cls=GoogleBigQueryValueWrapper):
+    #     return super().wrap_json(val, wrapper_cls)
 
 
 class GoogleBigQueryDateAdd(Function):

--- a/server/src/weaverbird/backends/pypika_translator/translators/googlebigquery.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/googlebigquery.py
@@ -46,6 +46,15 @@ class GoogleBigQueryQuery(Query):
         return GoogleBigQueryQueryBuilder(**kwargs)
 
 
+class GoogleBigQueryValueWrapper(ValueWrapper):
+    @classmethod
+    def get_formatted_value(cls, value: Any, **kwargs):
+        if isinstance(value, str):
+            value = value.replace("'", r"\'")
+            return f"'{value}'"
+        return super().get_formatted_value(value, **kwargs)
+
+
 class GoogleBigQueryQueryBuilder(QueryBuilder):
     QUOTE_CHAR = "`"
     SECONDARY_QUOTE_CHAR = "'"
@@ -54,21 +63,22 @@ class GoogleBigQueryQueryBuilder(QueryBuilder):
     QUERY_CLS = GoogleBigQueryQuery
 
     def __init__(self, **kwargs: Any) -> None:
-        super().__init__(dialect=SQLDialect.GOOGLEBIGQUERY, **kwargs)
+        super().__init__(
+            dialect=SQLDialect.GOOGLEBIGQUERY, wrapper_cls=GoogleBigQueryValueWrapper, **kwargs
+        )
+
+    @staticmethod
+    def wrap_constant(val, wrapper_cls=GoogleBigQueryValueWrapper):
+        return super().wrap_constant(val, wrapper_cls)
+
+    @staticmethod
+    def wrap_json(val, wrapper_cls=GoogleBigQueryValueWrapper):
+        return super().wrap_json(val, wrapper_cls)
 
 
 class GoogleBigQueryDateAdd(Function):
     def __init__(self, *, target_column: Field, interval: Interval) -> None:
         super().__init__("DATE_ADD", target_column, interval)
-
-
-class GoogleBigQueryValueWrapper(ValueWrapper):
-    @classmethod
-    def get_formatted_value(cls, value: Any, **kwargs):
-        if isinstance(value, str):
-            value = value.replace("'", r"\'")
-            return f"'{value}'"
-        return super().get_formatted_value(value, **kwargs)
 
 
 class GoogleBigQueryTranslator(SQLTranslator):

--- a/server/src/weaverbird/backends/pypika_translator/translators/googlebigquery.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/googlebigquery.py
@@ -67,14 +67,6 @@ class GoogleBigQueryQueryBuilder(QueryBuilder):
             dialect=SQLDialect.GOOGLEBIGQUERY, wrapper_cls=GoogleBigQueryValueWrapper, **kwargs
         )
 
-    # @staticmethod
-    # def wrap_constant(val, wrapper_cls=GoogleBigQueryValueWrapper):
-    #     return super().wrap_constant(val, wrapper_cls)
-
-    # @staticmethod
-    # def wrap_json(val, wrapper_cls=GoogleBigQueryValueWrapper):
-    #     return super().wrap_json(val, wrapper_cls)
-
 
 class GoogleBigQueryDateAdd(Function):
     def __init__(self, *, target_column: Field, interval: Interval) -> None:

--- a/server/tests/backends/sql_translator_unit_tests/test_google_big_query.py
+++ b/server/tests/backends/sql_translator_unit_tests/test_google_big_query.py
@@ -1,0 +1,27 @@
+import pytest
+
+from weaverbird.backends.pypika_translator.translators.googlebigquery import (
+    GoogleBigQueryTranslator,
+)
+from weaverbird.pipeline.steps import DomainStep, FilterStep
+
+
+@pytest.fixture
+def gbq_translator() -> GoogleBigQueryTranslator:
+    return GoogleBigQueryTranslator(tables_columns={"table": ["col1", "col2", "col3"]})
+
+
+def test_escape_names(gbq_translator: GoogleBigQueryTranslator) -> None:
+    query = gbq_translator.get_query_str(
+        steps=[
+            DomainStep(domain="table"),
+            FilterStep(
+                condition={"column": "col1", "operator": "in", "value": ["pika", "l'alcool"]}
+            ),
+        ]
+    )
+    assert query == (
+        "WITH __step_0_googlebigquerytranslator__ AS ("
+        r"SELECT `col1`,`col2`,`col3` FROM `table` WHERE `col1` IN ('pika','l\'alcool')) "
+        "SELECT `col1`,`col2`,`col3` FROM `__step_0_googlebigquerytranslator__`"
+    )


### PR DESCRIPTION
## BEFORE

<img width="699" alt="Screenshot 2023-08-07 at 22 51 04" src="https://github.com/ToucanToco/weaverbird/assets/18406791/02efa9a6-d6d0-4f4e-9554-d5ae380bdc6e">

## AFTER

Test passes ✅ 
