### PR TITLE
fix(sql): if then else step can accept numerical values

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix[PyPika]: ithenelse step supports numerical values
+- Fix[PyPika]: `ifthenelse` step supports numerical values
 
 ### Changed
 

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog (weaverbird python package)
 
+## Unreleased
+
+### Fixed
+
+- Fix[PyPika]: ithenelse step supports numerical values
+
 ### Changed
 
 ## [0.35.3] - 2023-08-10

--- a/server/src/weaverbird/backends/pypika_translator/translators/base.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/base.py
@@ -1251,7 +1251,7 @@ class SQLTranslator(ABC):
                 return case_.else_(else_value)
             except (json.JSONDecodeError, TypeError):
                 # the value is a formula or a string literal that can't be parsed
-                else_value = formula_to_term(else_, table)  # type: ignore
+                else_value = formula_to_term(else_, table)
                 return case_.else_(else_value)
 
     def ifthenelse(

--- a/server/src/weaverbird/backends/pypika_translator/utils/formula.py
+++ b/server/src/weaverbird/backends/pypika_translator/utils/formula.py
@@ -1,4 +1,5 @@
 import operator
+from typing import Any
 
 from pypika import Table
 from pypika.functions import NullIf
@@ -37,8 +38,11 @@ def _eval_expression(expr: Expression, table: Table) -> Term:
     return Term.wrap_constant(expr)
 
 
-def formula_to_term(formula: str, table: Table) -> Term:
+def formula_to_term(formula: Any, table: Table) -> Term:
     try:
         return _eval_expression(FormulaParser(formula).parse(), table)
-    except SyntaxError:  # Can happen in case formula is actually a string literal
+    except (
+        SyntaxError,
+        AttributeError,
+    ):  # Can happen in case formula is actually a string literal or a number
         return Term.wrap_constant(formula)

--- a/server/tests/backends/fixtures/ifthenelse/number_values.json
+++ b/server/tests/backends/fixtures/ifthenelse/number_values.json
@@ -1,0 +1,93 @@
+{
+  "exclude": [
+    "athena_pypika",
+    "bigquery_pypika",
+    "mysql_pypika",
+    "postgres_pypika",
+    "redshift_pypika",
+    "snowflake_pypika"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "ifthenelse",
+        "if": {
+          "column": "AGE",
+          "value": 20,
+          "operator": "gt"
+        },
+        "newColumn": "COND",
+        "then": 1,
+        "else": 0
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "NAME",
+          "type": "string"
+        },
+        {
+          "name": "AGE",
+          "type": "integer"
+        },
+        {
+          "name": "SCORE",
+          "type": "integer"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "NAME": "foo",
+        "AGE": 42,
+        "SCORE": 100
+      },
+      {
+        "NAME": "bar",
+        "AGE": 20,
+        "SCORE": 200
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "NAME",
+          "type": "string"
+        },
+        {
+          "name": "AGE",
+          "type": "number"
+        },
+        {
+          "name": "SCORE",
+          "type": "integer"
+        },
+        {
+          "name": "COND",
+          "type": "string"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "NAME": "foo",
+        "AGE": 42,
+        "SCORE": 100,
+        "COND": 1
+      },
+      {
+        "NAME": "bar",
+        "AGE": 20,
+        "SCORE": 200,
+        "COND": 0
+      }
+    ]
+  }
+}

--- a/server/tests/backends/fixtures/ifthenelse/number_values_pypika.json
+++ b/server/tests/backends/fixtures/ifthenelse/number_values_pypika.json
@@ -1,0 +1,177 @@
+{
+  "exclude": [
+    "mongo",
+    "pandas",
+    "snowflake"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "ifthenelse",
+        "if": {
+          "column": "cost",
+          "value": 2,
+          "operator": "gt"
+        },
+        "newColumn": "cond",
+        "then": 1,
+        "else": 0
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "price_per_l",
+          "type": "number"
+        },
+        {
+          "name": "alcohol_degree",
+          "type": "number"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "cost",
+          "type": "number"
+        },
+        {
+          "name": "beer_kind",
+          "type": "string"
+        },
+        {
+          "name": "volume_ml",
+          "type": "number"
+        },
+        {
+          "name": "brewing_date",
+          "type": "datetime"
+        },
+        {
+          "name": "nullable_name",
+          "type": "string"
+        },
+        {
+          "name": "cond",
+          "type": "string"
+        }
+      ],
+      "pandas_version": "1.4.0"
+    },
+    "data": [
+      {
+        "price_per_l": 0.1599999964,
+        "alcohol_degree": 13.5,
+        "name": "Superstrong beer",
+        "cost": 2.8900001049,
+        "beer_kind": "Triple",
+        "volume_ml": 330.0,
+        "brewing_date": "2022-01-01",
+        "nullable_name": null,
+        "cond": 1
+      },
+      {
+        "price_per_l": 0.0540000014,
+        "alcohol_degree": 4.8773770332,
+        "name": "Ninkasi Ploploplop",
+        "cost": 2.8900001049,
+        "beer_kind": "India Pale Ale",
+        "volume_ml": 330.0,
+        "brewing_date": "2022-01-02",
+        "nullable_name": "Ninkasi Ploploplop",
+        "cond": 1
+      },
+      {
+        "price_per_l": 0.0049999999,
+        "alcohol_degree": 0.5699344873,
+        "name": "Brewdog Nanny State Alcoholvrij",
+        "cost": 2.2899999619,
+        "beer_kind": "Sans alcool",
+        "volume_ml": 330.0,
+        "brewing_date": "2022-01-03",
+        "nullable_name": "Brewdog Nanny State Alcoholvrij",
+        "cond": 1
+      },
+      {
+        "price_per_l": 0.0560000017,
+        "alcohol_degree": 6.9941053391,
+        "name": "Ardwen Blonde",
+        "cost": 2.0899999142,
+        "beer_kind": "Best-sellers",
+        "volume_ml": 330.0,
+        "brewing_date": "2022-01-04",
+        "nullable_name": "Ardwen Blonde",
+        "cond": 1
+      },
+      {
+        "price_per_l": 0.0700000003,
+        "alcohol_degree": 8.930644989,
+        "name": "Cuv\u00e9e des Trolls",
+        "cost": 1.5499999523,
+        "beer_kind": "Blonde",
+        "volume_ml": 250.0,
+        "brewing_date": "2022-01-05",
+        "nullable_name": null,
+        "cond": 0
+      },
+      {
+        "price_per_l": 0.0049999999,
+        "alcohol_degree": 1.2437106371,
+        "name": "Weihenstephan Hefe Weizen Alcoholarm",
+        "cost": 1.5900000334,
+        "beer_kind": "Blanche & Weizen",
+        "volume_ml": 500.0,
+        "brewing_date": "2022-01-06",
+        "nullable_name": "Weihenstephan Hefe Weizen Alcoholarm",
+        "cond": 0
+      },
+      {
+        "price_per_l": 0.0450000018,
+        "alcohol_degree": 4.7174096107,
+        "name": "Bellfield Lawless Village IPA",
+        "cost": 2.4900000095,
+        "beer_kind": "India Pale Ale",
+        "volume_ml": 330.0,
+        "brewing_date": "2022-01-07",
+        "nullable_name": "Bellfield Lawless Village IPA",
+        "cond": 1
+      },
+      {
+        "price_per_l": 0.0839999989,
+        "alcohol_degree": 12.9742717743,
+        "name": "Pauwel Kwak",
+        "cost": 1.6900000572,
+        "beer_kind": "Belge blonde forte & Golden Ale",
+        "volume_ml": 330.0,
+        "brewing_date": "2022-01-08",
+        "nullable_name": "Pauwel Kwak",
+        "cond": 0
+      },
+      {
+        "price_per_l": 0.0649999976,
+        "alcohol_degree": 7.7474656105,
+        "name": "Brasserie De Sutter Brin de Folie",
+        "cost": 2.1900000572,
+        "beer_kind": "Blonde",
+        "volume_ml": 330.0,
+        "brewing_date": "2022-01-09",
+        "nullable_name": null,
+        "cond": 1
+      },
+      {
+        "price_per_l": 0.0599999987,
+        "alcohol_degree": 8.7496089935,
+        "name": "Brugse Zot blonde",
+        "cost": 1.7899999619,
+        "beer_kind": "Blonde",
+        "volume_ml": 330.0,
+        "brewing_date": "2022-01-10",
+        "nullable_name": "Brugse Zot blonde",
+        "cond": 0
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I noticed that ifthenelse steps with numbers as results were not accepted by the Pypika translators with the following errors: `('Could not translate parameters to a SQL query', AttributeError("'int' object has no attribute 'encode'"))``

Example of such a step:
```js
{
  name: 'ifthenelse',
  if: { column: 'order', operator: 'eq', value: 'first' },
  then: 0,
  else: {
    if: { column: 'order', operator: 'eq', value: 'second' },
    then: 1,
    else: {
      if: { column: 'order', operator: 'eq', value: 'third' },
      then: 2,
      else: 3,
    },
  },
  newColumn: 'order',
}
```