### PR TITLE
fix(server/pypika): Various improvements on the fromdate step TCTC-6156

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- PyPika: The `fromdate` step now has consistent formatting between all backends
+- PyPika: Postgres full months are no longer padded to 9 chars
+- PyPika: Added support for `fromdate` to Athena and Google Big Query backends
+
 ## [0.36.1] - 2023-08-22
 
 ### Fixed

--- a/server/src/weaverbird/backends/pypika_translator/operators.py
+++ b/server/src/weaverbird/backends/pypika_translator/operators.py
@@ -14,6 +14,7 @@ class RegexOp(str, Enum):
 class FromDateOp(Enum):
     DATE_FORMAT = auto()
     TO_CHAR = auto()
+    FORMAT_DATE = auto()
 
 
 class ToDateOp(Enum):

--- a/server/src/weaverbird/backends/pypika_translator/translators/athena.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/athena.py
@@ -3,7 +3,7 @@ from pypika.enums import Dialects
 from pypika.terms import Case, CustomFunction, Field, Term
 
 from weaverbird.backends.pypika_translator.dialects import SQLDialect
-from weaverbird.backends.pypika_translator.operators import RegexOp, ToDateOp
+from weaverbird.backends.pypika_translator.operators import FromDateOp, RegexOp, ToDateOp
 from weaverbird.backends.pypika_translator.translators.base import (
     DataTypeMapping,
     DateFormatMapping,
@@ -36,6 +36,7 @@ class AthenaTranslator(SQLTranslator):
     )
     REGEXP_OP = RegexOp.REGEXP_LIKE
     TO_DATE_OP = ToDateOp.DATE_PARSE
+    FROM_DATE_OP = FromDateOp.DATE_FORMAT
 
     @classmethod
     def _add_date(

--- a/server/src/weaverbird/backends/pypika_translator/translators/base.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/base.py
@@ -1200,6 +1200,8 @@ class SQLTranslator(ABC):
                 convert_fn = DateFormat
             case FromDateOp.TO_CHAR:
                 convert_fn = functions.ToChar
+            case FromDateOp.FORMAT_DATE:
+                convert_fn = FormatDate
             case _:
                 raise NotImplementedError(f"[{self.DIALECT}] doesn't have from date operator")
 
@@ -1798,6 +1800,12 @@ class CountDistinct(functions.Count):
 class DateFormat(functions.Function):
     def __init__(self, term: str | Field, date_format: str, alias: str | None = None) -> None:
         super().__init__("DATE_FORMAT", term, date_format, alias=alias)
+
+
+# Of course GBQ must have a different name AND inverted arguments
+class FormatDate(functions.Function):
+    def __init__(self, term: str | Field, date_format: str, alias: str | None = None) -> None:
+        super().__init__("FORMAT_DATE", date_format, term, alias=alias)
 
 
 class RowNumber(AnalyticFunction):

--- a/server/src/weaverbird/backends/pypika_translator/translators/googlebigquery.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/googlebigquery.py
@@ -98,7 +98,7 @@ class GoogleBigQueryTranslator(SQLTranslator):
     SUPPORT_ROW_NUMBER = True
     SUPPORT_SPLIT_PART = False
     SUPPORT_UNPIVOT = True
-    FROM_DATE_OP = FromDateOp.TO_CHAR
+    FROM_DATE_OP = FromDateOp.FORMAT_DATE
     REGEXP_OP = RegexOp.REGEXP_CONTAINS
 
     @classmethod

--- a/server/src/weaverbird/backends/pypika_translator/translators/postgresql.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/postgresql.py
@@ -36,7 +36,8 @@ class PostgreSQLTranslator(SQLTranslator):
         day_number="DD",
         month_number="MM",
         month_short="Mon",
-        month_full="Month",
+        # FM prefix prevents postgres from padding the month to 9 chars
+        month_full="FMMonth",
         year="YYYY",
     )
     SUPPORT_ROW_NUMBER = True

--- a/server/src/weaverbird/backends/pypika_translator/translators/redshift.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/redshift.py
@@ -12,7 +12,6 @@ from weaverbird.backends.pypika_translator.operators import FromDateOp, RegexOp
 from weaverbird.backends.pypika_translator.translators.base import (
     DataTypeMapping,
     DateAddWithoutUnderscore,
-    DateFormatMapping,
     SQLTranslator,
     StepContext,
 )

--- a/server/src/weaverbird/backends/pypika_translator/translators/redshift.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/redshift.py
@@ -36,14 +36,6 @@ class RedshiftTranslator(PostgreSQLTranslator):
         datetime="TIMESTAMP",
         timestamp="TIMESTAMP",
     )
-    DATE_FORMAT_MAPPING = DateFormatMapping(
-        # https://docs.aws.amazon.com/redshift/latest/dg/r_DATEFORMAT_and_TIMEFORMAT_strings.html
-        day_number="DD",
-        month_number="MM",
-        month_short="MON",
-        month_full="MON",
-        year="YYYY",
-    )
     SUPPORT_ROW_NUMBER = True
     SUPPORT_SPLIT_PART = True
     SUPPORT_UNPIVOT = True

--- a/server/tests/backends/fixtures/fromdate/day_longmonth_year_space_pypika.yaml
+++ b/server/tests/backends/fixtures/fromdate/day_longmonth_year_space_pypika.yaml
@@ -1,0 +1,42 @@
+exclude:
+- mongo
+- pandas
+- snowflake
+step:
+  pipeline:
+  - name: fromdate
+    column: brewing_date
+    format: "%d %B %Y"
+  - name: select
+    columns:
+      - name
+      - brewing_date
+expected:
+  data:
+  - brewing_date: 01 January 2022
+    name: Superstrong beer
+  - brewing_date: 02 January 2022
+    name: Ninkasi Ploploplop
+  - brewing_date: 03 January 2022
+    name: Brewdog Nanny State Alcoholvrij
+  - brewing_date: 04 January 2022
+    name: Ardwen Blonde
+  - brewing_date: 05 January 2022
+    name: "Cuv\xE9e des Trolls"
+  - brewing_date: 06 January 2022
+    name: Weihenstephan Hefe Weizen Alcoholarm
+  - brewing_date: 07 January 2022
+    name: Bellfield Lawless Village IPA
+  - brewing_date: 08 January 2022
+    name: Pauwel Kwak
+  - brewing_date: 09 January 2022
+    name: Brasserie De Sutter Brin de Folie
+  - brewing_date: 10 January 2022
+    name: Brugse Zot blonde
+  schema:
+    fields:
+    - name: name
+      type: string
+    - name: brewing_date
+      type: string
+    pandas_version: 1.4.0

--- a/server/tests/backends/fixtures/fromdate/day_shortmonth_year_dash_pypika.yaml
+++ b/server/tests/backends/fixtures/fromdate/day_shortmonth_year_dash_pypika.yaml
@@ -1,0 +1,42 @@
+exclude:
+- mongo
+- pandas
+- snowflake
+step:
+  pipeline:
+  - name: fromdate
+    column: brewing_date
+    format: '%d-%b-%Y'
+  - name: select
+    columns:
+      - name
+      - brewing_date
+expected:
+  data:
+  - brewing_date: 01-Jan-2022
+    name: Superstrong beer
+  - brewing_date: 02-Jan-2022
+    name: Ninkasi Ploploplop
+  - brewing_date: 03-Jan-2022
+    name: Brewdog Nanny State Alcoholvrij
+  - brewing_date: 04-Jan-2022
+    name: Ardwen Blonde
+  - brewing_date: 05-Jan-2022
+    name: "Cuv\xE9e des Trolls"
+  - brewing_date: 06-Jan-2022
+    name: Weihenstephan Hefe Weizen Alcoholarm
+  - brewing_date: 07-Jan-2022
+    name: Bellfield Lawless Village IPA
+  - brewing_date: 08-Jan-2022
+    name: Pauwel Kwak
+  - brewing_date: 09-Jan-2022
+    name: Brasserie De Sutter Brin de Folie
+  - brewing_date: 10-Jan-2022
+    name: Brugse Zot blonde
+  schema:
+    fields:
+    - name: name
+      type: string
+    - name: brewing_date
+      type: string
+    pandas_version: 1.4.0

--- a/server/tests/backends/fixtures/fromdate/day_shortmonth_year_space_pypika.yaml
+++ b/server/tests/backends/fixtures/fromdate/day_shortmonth_year_space_pypika.yaml
@@ -1,0 +1,43 @@
+exclude:
+- mongo
+- pandas
+- snowflake
+step:
+  pipeline:
+  - name: fromdate
+    column: brewing_date
+    format: '%d %b %Y'
+  - name: select
+    columns:
+      - name
+      - brewing_date
+expected:
+  data:
+  - brewing_date: 01 Jan 2022
+    name: Superstrong beer
+  - brewing_date: 02 Jan 2022
+    name: Ninkasi Ploploplop
+  - brewing_date: 03 Jan 2022
+    name: Brewdog Nanny State Alcoholvrij
+  - brewing_date: 04 Jan 2022
+    name: Ardwen Blonde
+  - brewing_date: 05 Jan 2022
+    name: "Cuv\xE9e des Trolls"
+  - brewing_date: 06 Jan 2022
+    name: Weihenstephan Hefe Weizen Alcoholarm
+  - brewing_date: 07 Jan 2022
+    name: Bellfield Lawless Village IPA
+  - brewing_date: 08 Jan 2022
+    name: Pauwel Kwak
+  - brewing_date: 09 Jan 2022
+    name: Brasserie De Sutter Brin de Folie
+  - brewing_date: 10 Jan 2022
+    name: Brugse Zot blonde
+  schema:
+    fields:
+    - name: name
+      type: string
+    - name: brewing_date
+      type: string
+    pandas_version: 1.4.0
+

--- a/server/tests/backends/fixtures/fromdate/longmonth_year_space_pypika.yaml
+++ b/server/tests/backends/fixtures/fromdate/longmonth_year_space_pypika.yaml
@@ -1,0 +1,42 @@
+exclude:
+- mongo
+- pandas
+- snowflake
+step:
+  pipeline:
+  - name: fromdate
+    column: brewing_date
+    format: '%B %Y'
+  - name: select
+    columns:
+      - name
+      - brewing_date
+expected:
+  data:
+  - brewing_date: January 2022
+    name: Superstrong beer
+  - brewing_date: January 2022
+    name: Ninkasi Ploploplop
+  - brewing_date: January 2022
+    name: Brewdog Nanny State Alcoholvrij
+  - brewing_date: January 2022
+    name: Ardwen Blonde
+  - brewing_date: January 2022
+    name: "Cuv\xE9e des Trolls"
+  - brewing_date: January 2022
+    name: Weihenstephan Hefe Weizen Alcoholarm
+  - brewing_date: January 2022
+    name: Bellfield Lawless Village IPA
+  - brewing_date: January 2022
+    name: Pauwel Kwak
+  - brewing_date: January 2022
+    name: Brasserie De Sutter Brin de Folie
+  - brewing_date: January 2022
+    name: Brugse Zot blonde
+  schema:
+    fields:
+    - name: name
+      type: string
+    - name: brewing_date
+      type: string
+    pandas_version: 1.4.0

--- a/server/tests/backends/fixtures/fromdate/shortmonth_year_dash_pypika.yaml
+++ b/server/tests/backends/fixtures/fromdate/shortmonth_year_dash_pypika.yaml
@@ -1,0 +1,42 @@
+exclude:
+- mongo
+- pandas
+- snowflake
+step:
+  pipeline:
+  - name: fromdate
+    column: brewing_date
+    format: '%b-%Y'
+  - name: select
+    columns:
+      - name
+      - brewing_date
+expected:
+  data:
+  - brewing_date: Jan-2022
+    name: Superstrong beer
+  - brewing_date: Jan-2022
+    name: Ninkasi Ploploplop
+  - brewing_date: Jan-2022
+    name: Brewdog Nanny State Alcoholvrij
+  - brewing_date: Jan-2022
+    name: Ardwen Blonde
+  - brewing_date: Jan-2022
+    name: "Cuv\xE9e des Trolls"
+  - brewing_date: Jan-2022
+    name: Weihenstephan Hefe Weizen Alcoholarm
+  - brewing_date: Jan-2022
+    name: Bellfield Lawless Village IPA
+  - brewing_date: Jan-2022
+    name: Pauwel Kwak
+  - brewing_date: Jan-2022
+    name: Brasserie De Sutter Brin de Folie
+  - brewing_date: Jan-2022
+    name: Brugse Zot blonde
+  schema:
+    fields:
+    - name: name
+      type: string
+    - name: brewing_date
+      type: string
+    pandas_version: 1.4.0

--- a/server/tests/backends/fixtures/fromdate/simple_pypika.yaml
+++ b/server/tests/backends/fixtures/fromdate/simple_pypika.yaml
@@ -1,0 +1,42 @@
+exclude:
+- mongo
+- pandas
+- snowflake
+step:
+  pipeline:
+  - name: fromdate
+    column: brewing_date
+    format: '%Y-%m-%d'
+  - name: select
+    columns:
+      - name
+      - brewing_date
+expected:
+  data:
+  - brewing_date: '2022-01-01'
+    name: Superstrong beer
+  - brewing_date: '2022-01-02'
+    name: Ninkasi Ploploplop
+  - brewing_date: '2022-01-03'
+    name: Brewdog Nanny State Alcoholvrij
+  - brewing_date: '2022-01-04'
+    name: Ardwen Blonde
+  - brewing_date: '2022-01-05'
+    name: "Cuvée des Trolls"
+  - brewing_date: '2022-01-06'
+    name: Weihenstephan Hefe Weizen Alcoholarm
+  - brewing_date: '2022-01-07'
+    name: Bellfield Lawless Village IPA
+  - brewing_date: '2022-01-08'
+    name: Pauwel Kwak
+  - brewing_date: '2022-01-09'
+    name: Brasserie De Sutter Brin de Folie
+  - brewing_date: '2022-01-10'
+    name: Brugse Zot blonde
+  schema:
+    fields:
+    - name: name
+      type: string
+    - name: brewing_date
+      type: string
+    pandas_version: 1.4.0

--- a/server/tests/backends/sql_translator_unit_tests/test_adapt_date_format.py
+++ b/server/tests/backends/sql_translator_unit_tests/test_adapt_date_format.py
@@ -16,7 +16,7 @@ from weaverbird.backends.pypika_translator.translators import (
         ("%Y-%m-%d", "YYYY-MM-DD"),
         ("%d/%m/%Y", "DD/MM/YYYY"),
         ("%d %b %Y", "DD Mon YYYY"),
-        ("%d %B %Y", "DD Month YYYY"),
+        ("%d %B %Y", "DD FMMonth YYYY"),
     ],
 )
 def test_adapt_date_format_postgresql(input: str, expected: str):
@@ -54,8 +54,8 @@ def test_adapt_date_format_gbq(input: str, expected: str):
     [
         ("%Y-%m-%d", "YYYY-MM-DD"),
         ("%d/%m/%Y", "DD/MM/YYYY"),
-        ("%d %b %Y", "DD MON YYYY"),
-        ("%d %B %Y", "DD MON YYYY"),
+        ("%d %b %Y", "DD Mon YYYY"),
+        ("%d %B %Y", "DD FMMonth YYYY"),
     ],
 )
 def test_adapt_date_format_redshift(input: str, expected: str):


### PR DESCRIPTION
Work items:

* Duplicated all existing fixtures for PyPika translators. Ensure formattings are the same across all
  PyPika backends.

* Postgres: Do not pad Months to 9 chars

* Athena: Set FROM_DATE_OP to an existing function

* GBQ: Implement a FORMAT_DATE function (neither DATE_FORMAT nor TO_CHAR are supported)

* Redshift: Make formatting consistent with other backends