### PR TITLE
fix(ui): remove relative date filtering feature flag and related code [TCTC-6755]

### DIFF
--- a/playground/dist/app.js
+++ b/playground/dist/app.js
@@ -770,10 +770,6 @@ async function buildVueApp() {
         // based on lodash templates (ERB syntax)
         interpolateFunc: (value, context) => exampleInterpolateFunc(value, context),
         variables: VARIABLES,
-
-        featureFlags: {
-          RELATIVE_DATE_FILTERING: args.get('RELATIVE_DATE_FILTERING') || 'disable',
-        },
       };
       if (TRANSLATOR === 'pandas') {
         registrationOpts.pipelines.pipelineDepartements = [

--- a/ui/Playground.vue
+++ b/ui/Playground.vue
@@ -808,10 +808,6 @@ export default defineComponent({
       // based on lodash templates (ERB syntax)
       interpolateFunc: (value, context) => exampleInterpolateFunc(value, context),
       variables: VARIABLES,
-
-      featureFlags: {
-        RELATIVE_DATE_FILTERING: (args.get('RELATIVE_DATE_FILTERING') as 'enable' | 'disable') || 'disable',
-      },
     };
     if (TRANSLATOR === 'pandas') {
       registrationOpts.pipelines.pipelineDepartements = [

--- a/ui/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/ui/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -210,10 +210,6 @@ export default defineComponent({
       }
     },
 
-    enableRelativeDateFiltering(): boolean {
-      return this.featureFlags?.RELATIVE_DATE_FILTERING === 'enable';
-    },
-
     dateAvailableVariables(): VariablesBucket | undefined {
       // keep only date variables
       return this.availableVariables?.filter((v) => v.value instanceof Date);
@@ -229,7 +225,7 @@ export default defineComponent({
     },
 
     availableOperators(): Readonly<OperatorOption[]> {
-      if (this.hasDateSelectedColumn && this.enableRelativeDateFiltering) {
+      if (this.hasDateSelectedColumn) {
         return dateOperators;
       }
       return baseOperators;
@@ -254,15 +250,7 @@ export default defineComponent({
     },
 
     inputWidget(): VueConstructor<Vue> | undefined {
-      const widget = this.operator.inputWidget;
-      if (
-        this.hasDateSelectedColumn &&
-        widget === InputTextWidget &&
-        !this.enableRelativeDateFiltering
-      ) {
-        return InputDateWidget;
-      }
-      return widget;
+      return this.operator.inputWidget;
     },
   },
 
@@ -311,12 +299,8 @@ export default defineComponent({
         updatedValue.value = keepCurrentValueIfArrayType(updatedValue.value, []);
       } else if (updatedValue.operator === 'isnull' || updatedValue.operator === 'notnull') {
         updatedValue.value = null;
-      } else if (this.hasDateSelectedColumn && this.enableRelativeDateFiltering) {
-        updatedValue.value = keepCurrentValueIfCompatibleRelativeDate(updatedValue.value, '');
       } else if (this.hasDateSelectedColumn) {
-        // when using date widget, we need value to be a valid date
-        // null as date will become "01/01/1970" as default value for input
-        updatedValue.value = keepCurrentValueIfCompatibleDate(updatedValue.value, null);
+        updatedValue.value = keepCurrentValueIfCompatibleRelativeDate(updatedValue.value, '');
       } else {
         updatedValue.value = keepCurrentValueIfCompatibleType(updatedValue.value, '');
       }

--- a/ui/src/store/state.ts
+++ b/ui/src/store/state.ts
@@ -63,7 +63,6 @@ export interface VQBState {
   stepFormDefaults?: object;
 
   featureFlags?: {
-    RELATIVE_DATE_FILTERING?: 'enable' | 'disable';
     [k: string]: boolean | string | undefined;
   };
 }

--- a/ui/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/ui/tests/unit/filter-simple-condition-widget.spec.ts
@@ -420,7 +420,7 @@ describe('Widget FilterSimpleCondition', () => {
 
   describe('date column and date (using an invalid operator)', () => {
     let wrapper: Wrapper<FilterSimpleConditionWidget>;
-    const createWrapper = (operator: string, isRelativeDateEnabled = false) => {
+    const createWrapper = (operator: string) => {
       setupMockStore({
         dataset: {
           headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
@@ -441,7 +441,7 @@ describe('Widget FilterSimpleCondition', () => {
     };
 
     it('should transform an invalid "le" operator when relative date are enabled', async () => {
-      createWrapper('le', true);
+      createWrapper('le');
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted().input).toHaveLength(1);
       // should emit new value with 'until' operator replacing invalid 'le' operator
@@ -451,7 +451,7 @@ describe('Widget FilterSimpleCondition', () => {
     });
 
     it('should transform an invalid "lt" operator when relative date are enabled', async () => {
-      createWrapper('lt', true);
+      createWrapper('lt');
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted().input).toHaveLength(1);
       // should emit new value with 'until' operator replacing invalid 'lt' operator
@@ -461,7 +461,7 @@ describe('Widget FilterSimpleCondition', () => {
     });
 
     it('should transform an invalid "ge" operator when relative date are enabled', async () => {
-      createWrapper('ge', true);
+      createWrapper('ge');
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted().input).toHaveLength(1);
       // should emit new value with 'from' operator replacing invalid 'ge' operator
@@ -471,7 +471,7 @@ describe('Widget FilterSimpleCondition', () => {
     });
 
     it('should transform an invalid "gt" operator when relative date are enabled', async () => {
-      createWrapper('gt', true);
+      createWrapper('gt');
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted().input).toHaveLength(1);
       // should emit new value with 'from' operator replacing invalid 'gt' operator
@@ -481,7 +481,7 @@ describe('Widget FilterSimpleCondition', () => {
     });
 
     it('should fallback to first available operator when selected operator is invalid and relative date are enabled', async () => {
-      createWrapper('eq', true);
+      createWrapper('eq');
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted().input).toHaveLength(1);
       expect(wrapper.emitted().input[0]).toEqual([
@@ -490,7 +490,7 @@ describe('Widget FilterSimpleCondition', () => {
     });
 
     it('should keep valid operator unchanged', async () => {
-      createWrapper('isnull', true);
+      createWrapper('isnull');
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted().input).toBeUndefined();
     });

--- a/ui/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/ui/tests/unit/filter-simple-condition-widget.spec.ts
@@ -440,7 +440,7 @@ describe('Widget FilterSimpleCondition', () => {
       });
     };
 
-    it('should transform an invalid "le" operator when relative date are enabled', async () => {
+    it('should transform an invalid "le" operator', async () => {
       createWrapper('le');
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted().input).toHaveLength(1);
@@ -450,7 +450,7 @@ describe('Widget FilterSimpleCondition', () => {
       ]);
     });
 
-    it('should transform an invalid "lt" operator when relative date are enabled', async () => {
+    it('should transform an invalid "lt" operator', async () => {
       createWrapper('lt');
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted().input).toHaveLength(1);
@@ -460,7 +460,7 @@ describe('Widget FilterSimpleCondition', () => {
       ]);
     });
 
-    it('should transform an invalid "ge" operator when relative date are enabled', async () => {
+    it('should transform an invalid "ge" operator', async () => {
       createWrapper('ge');
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted().input).toHaveLength(1);
@@ -470,7 +470,7 @@ describe('Widget FilterSimpleCondition', () => {
       ]);
     });
 
-    it('should transform an invalid "gt" operator when relative date are enabled', async () => {
+    it('should transform an invalid "gt" operator', async () => {
       createWrapper('gt');
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted().input).toHaveLength(1);
@@ -480,7 +480,7 @@ describe('Widget FilterSimpleCondition', () => {
       ]);
     });
 
-    it('should fallback to first available operator when selected operator is invalid and relative date are enabled', async () => {
+    it('should fallback to first available operator when selected operator is invalid', async () => {
       createWrapper('eq');
       await wrapper.vm.$nextTick();
       expect(wrapper.emitted().input).toHaveLength(1);


### PR DESCRIPTION
## What
- Removing the `RELATIVE_DATE_FILTERING` feature flag that was only used in the `FIlterSimpleCondition` component and was preventing the display of the right operators when having a `dateTime` column selected. 
- Remove related code since this was the only place where the FF was used.