### PR TITLE
chore(ui): remove engine

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -113,8 +113,5 @@
     "vue-tsc": "^1.0.9",
     "vuedraggable": "^2.24.3",
     "vuejs-paginate": "^2.1.0"
-  },
-  "engines": {
-    "node": ">=18 <19"
   }
 }


### PR DESCRIPTION
The engine field is used to specify which node version should be used to _use_ the package, not to _build_ it.
Once built, the engine required is actually a browser :joy:

I removed this field, so that dependent packages could choose which node version they should use. They will use the pre-built js files from weaverbird anyway, without the need to build them again.