### PR TITLE
fix(filter-condition): display all variables for date component not only date type once [TCTC-7312]

### DIFF
--- a/ui/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/ui/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -210,18 +210,8 @@ export default defineComponent({
       }
     },
 
-    dateAvailableVariables(): VariablesBucket | undefined {
-      // keep only date variables
-      return this.availableVariables?.filter((v) => v.value instanceof Date);
-    },
-
     availableVariablesForInputWidget(): VariablesBucket | undefined {
-      switch (this.inputWidget) {
-        case NewDateInput:
-          return this.dateAvailableVariables;
-        default:
-          return this.availableVariables;
-      }
+      return this.availableVariables;
     },
 
     availableOperators(): Readonly<OperatorOption[]> {

--- a/ui/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/ui/tests/unit/filter-simple-condition-widget.spec.ts
@@ -335,15 +335,6 @@ describe('Widget FilterSimpleCondition', () => {
       expect(operators).toStrictEqual(['from', 'until', 'isnull', 'notnull']);
     });
 
-    it('should filter available variables to keep only date once', () => {
-      createWrapper(shallowMount);
-      const variables = wrapper
-        .find('.filterValue')
-        .props()
-        .availableVariables.map((v: any) => v.label);
-      expect(variables).toStrictEqual(['Date category', 'Date not in date category']);
-    });
-
     it('should use the widget accordingly when changing the operator', async () => {
       createWrapper(mount);
       // from operator (from mount)


### PR DESCRIPTION
Display all variables, not only date once for date column in filter editor.

Before:
![before](https://github.com/ToucanToco/weaverbird/assets/59559689/d031150b-8336-4583-b825-056fd67a04ee)


After:
![after](https://github.com/ToucanToco/weaverbird/assets/59559689/5e0858c5-9ff1-4825-a820-a194b374151d)


Test : 
https://weaverbird-playground-pr-1953.onrender.com/