### PR TITLE
Remove event listeners before component unmounts

### DIFF
--- a/ui/src/components/ResizablePanels.vue
+++ b/ui/src/components/ResizablePanels.vue
@@ -21,6 +21,7 @@ import { Component } from 'vue-property-decorator';
   name: 'resizable-panels',
 })
 export default class ResizablePanels extends Vue {
+  controller = new window.AbortController();
   private ratio = 0.4;
 
   get leftPanelWidth() {
@@ -48,9 +49,19 @@ export default class ResizablePanels extends Vue {
       window.removeEventListener('blur', mouseupListener);
     };
 
-    window.addEventListener('mousemove', mousemoveListener);
-    window.addEventListener('mouseup', mouseupListener);
-    window.addEventListener('blur', mouseupListener);
+    window.addEventListener('mousemove', mousemoveListener, {
+      signal: this.controller?.signal
+    });
+    window.addEventListener('mouseup', mouseupListener, {
+      signal: this.controller?.signal
+    });
+    window.addEventListener('blur', mouseupListener, {
+      signal: this.controller?.signal
+    });
+  }
+
+  beforeDestroy() {
+    this.controller.abort();
   }
 }
 </script>

--- a/ui/src/components/stepforms/StepForm.vue
+++ b/ui/src/components/stepforms/StepForm.vue
@@ -85,6 +85,7 @@ function componentProxyBoundOn(self: Vue) {
   },
 })
 export default class BaseStepForm<StepType> extends Vue {
+  controller = new window.AbortController();
   version = version; // display the current version of the package
 
   @Prop({ type: Boolean, default: true })
@@ -139,7 +140,9 @@ export default class BaseStepForm<StepType> extends Vue {
       if ((event.metaKey || event.ctrlKey) && event.code == 'Enter') {
         this.submit();
       }
-    }) as EventListener);
+    }) as EventListener, {
+      signal: this.controller?.signal
+    });
   }
 
   /**
@@ -242,6 +245,10 @@ export default class BaseStepForm<StepType> extends Vue {
     if (errors === null) {
       this.$emit('formSaved', { ...this.editedStep });
     }
+  }
+
+  beforeDestroy() {
+    this.controller.abort();
   }
 }
 </script>


### PR DESCRIPTION
Hi! 👋 
The event listeners added in ResizablePanels and StepForm are never removed once added. Even after the component unmounts, the event handlers remain bound to the events. This would lead to an accumulation of such listeners each time a component is mounted, leading to a memory leak. This PR fixes this issue:)