### PR TITLE
fix(relative-date-form): use correct delimiters depending on if variable is trusted or not [TCTC-7581]

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- RelativeDateForm: use correct delimiters depending on if date variable is trusted or not
+
 ## [0.111.1] - 2023-11-21
 
 ### Fixed

--- a/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -105,9 +105,9 @@ export default class RelativeDateForm extends Vue {
 
   set baseDate(variable: AvailableVariable | undefined) {
     // use correct delimiters depending on if the variable is trusted or not
-    const attendedVariableDelimiters = isTrustedVariable(variable) ? 
-      this.trustedVariableDelimiters : 
-      this.variableDelimiters;
+    const attendedVariableDelimiters = isTrustedVariable(variable)
+      ? this.trustedVariableDelimiters
+      : this.variableDelimiters;
     const value = `${attendedVariableDelimiters.start}${variable?.identifier}${attendedVariableDelimiters.end}`;
     this.$emit('input', { ...this.value, date: value });
   }

--- a/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/RelativeDateForm.vue
@@ -45,7 +45,7 @@ import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue'
 import InputNumberWidget from '@/components/stepforms/widgets/InputNumber.vue';
 import { DEFAULT_DURATIONS, RELATIVE_DATE_OPERATORS } from '@/lib/dates';
 import type { DurationOption, RelativeDate } from '@/lib/dates';
-import { extractVariableIdentifier } from '@/lib/variables';
+import { extractVariableIdentifier, isTrustedVariable } from '@/lib/variables';
 import type { AvailableVariable, VariableDelimiters, VariablesBucket } from '@/lib/variables';
 
 /**
@@ -104,7 +104,11 @@ export default class RelativeDateForm extends Vue {
   }
 
   set baseDate(variable: AvailableVariable | undefined) {
-    const value = `${this.variableDelimiters.start}${variable?.identifier}${this.variableDelimiters.end}`;
+    // use correct delimiters depending on if the variable is trusted or not
+    const attendedVariableDelimiters = isTrustedVariable(variable) ? 
+      this.trustedVariableDelimiters : 
+      this.variableDelimiters;
+    const value = `${attendedVariableDelimiters.start}${variable?.identifier}${attendedVariableDelimiters.end}`;
     this.$emit('input', { ...this.value, date: value });
   }
 

--- a/ui/tests/unit/custom-granularity-calendar.spec.ts
+++ b/ui/tests/unit/custom-granularity-calendar.spec.ts
@@ -56,8 +56,8 @@ describe('CustomGranularityCalendar', () => {
 
       describe('when clicking on a a month', () => {
         beforeEach(async () => {
-          const february = wrapper.findAll('.custom-granularity-calendar__option').at(1);
-          await february.trigger('click');
+          const march = wrapper.findAll('.custom-granularity-calendar__option').at(2);
+          await march.trigger('click');
         });
 
         it('should emit the selected date range', () => {
@@ -66,10 +66,10 @@ describe('CustomGranularityCalendar', () => {
           expect(emittedDate.start).toBeInstanceOf(Date);
           expect(emittedDate.end).toBeInstanceOf(Date);
           expect(emittedDate.start?.toISOString()).toStrictEqual(
-            `${currentYear}-02-01T00:00:00.000Z`,
+            `${currentYear}-03-01T00:00:00.000Z`,
           );
           expect(emittedDate.end?.toISOString()).toStrictEqual(
-            `${currentYear}-02-28T23:59:59.999Z`,
+            `${currentYear}-03-31T23:59:59.999Z`,
           );
           expect(emittedDate.duration).toBe('month');
         });

--- a/ui/tests/unit/relative-date-form-widget.spec.ts
+++ b/ui/tests/unit/relative-date-form-widget.spec.ts
@@ -28,7 +28,8 @@ describe('RelativeDate form', () => {
     beforeEach(() => {
       createWrapper({
         value: { date, quantity: 1, duration: 'month', operator: 'until' },
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         availableVariables: SAMPLE_VARIABLES,
       });
     });
@@ -58,17 +59,25 @@ describe('RelativeDate form', () => {
     });
 
     describe('when baseDate is updated', () => {
-      const selectedDateVariable = SAMPLE_VARIABLES[1];
-      beforeEach(async () => {
+      it('should emit value with updated date with delimiters', async () => {
+        const trustedVariable = { label: 'Trusted', identifier: 'trusted', trusted: true };
+        const untrustedVariable = { label: 'Untrusted', identifier: 'untrusted' };
         wrapper
           .find('.widget-relative-date-range-form__input--base-date')
-          .vm.$emit('input', selectedDateVariable);
+          .vm.$emit('input', trustedVariable);
         await wrapper.vm.$nextTick();
-      });
-      it('should emit value with updated date with delimiters', () => {
-        const newDate = `{{${selectedDateVariable.identifier}}}`;
         expect(wrapper.emitted().input[0][0]).toStrictEqual({
-          date: newDate,
+          date: '{{trusted}}', // trusted delimiters usage
+          quantity: 1,
+          duration: 'month',
+          operator: 'until',
+        });
+        wrapper
+          .find('.widget-relative-date-range-form__input--base-date')
+          .vm.$emit('input', untrustedVariable);
+        await wrapper.vm.$nextTick();
+        expect(wrapper.emitted().input[1][0]).toStrictEqual({
+          date: '<%=untrusted%>', // untrusted delimiters usage
           quantity: 1,
           duration: 'month',
           operator: 'until',


### PR DESCRIPTION
We always use untrusted delimiters in relative date form while we should adapt delimiters depending on if variable is trusted or not.

We probably forgot to update this when adding untrusted delimiters