### PR TITLE
fix(server/steps/append): correctly resolve pipeline with refs [TCTC-7450]

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed 
+
+- Append step now works with pipelines that contain steps with references
+
 ## [0.41.0] - 2023-12-27
 
 ### Added

--- a/server/src/weaverbird/pipeline/steps/utils/combination.py
+++ b/server/src/weaverbird/pipeline/steps/utils/combination.py
@@ -115,7 +115,7 @@ async def resolve_if_reference(
 
 async def _resolve_references_in_pipeline(
     reference_resolver: ReferenceResolver,
-    pipeline: list[PipelineStepWithRefs | PipelineStep],
+    pipeline: list["PipelineStepWithRefs | PipelineStep"],
 ) -> PipelineOrDomainName | None:
     from weaverbird.pipeline.pipeline import PipelineWithRefs, ReferenceUnresolved
 

--- a/server/src/weaverbird/pipeline/steps/utils/combination.py
+++ b/server/src/weaverbird/pipeline/steps/utils/combination.py
@@ -115,15 +115,14 @@ async def resolve_if_reference(
 
 async def _resolve_references_in_pipeline(
     reference_resolver: ReferenceResolver,
-    pipeline: list,
-):
+    pipeline: list[PipelineStepWithRefs | PipelineStep],
+) -> PipelineOrDomainName | None:
     from weaverbird.pipeline.pipeline import PipelineWithRefs, ReferenceUnresolved
 
-    if isinstance(pipeline, list):
-        # Recursively resolve any reference in sub-pipelines
-        pipeline_with_refs = PipelineWithRefs(steps=pipeline)
-        try:
-            pipeline_without_refs = await pipeline_with_refs.resolve_references(reference_resolver)
-            return pipeline_without_refs.model_dump()["steps"]
-        except ReferenceUnresolved:
-            return None  # skip
+    # Recursively resolve any reference in sub-pipelines
+    pipeline_with_refs = PipelineWithRefs(steps=pipeline)
+    try:
+        pipeline_without_refs = await pipeline_with_refs.resolve_references(reference_resolver)
+        return pipeline_without_refs.model_dump()["steps"]
+    except ReferenceUnresolved:
+        return None  # skip

--- a/server/src/weaverbird/pipeline/steps/utils/combination.py
+++ b/server/src/weaverbird/pipeline/steps/utils/combination.py
@@ -95,20 +95,35 @@ async def resolve_if_reference(
     reference_resolver: ReferenceResolver,
     pipeline_or_domain_name_or_ref: PipelineOrDomainNameOrReference,
 ) -> PipelineOrDomainName | None:
-    from weaverbird.pipeline.pipeline import PipelineWithRefs, ReferenceUnresolved
+    from weaverbird.pipeline.pipeline import ReferenceUnresolved
 
     if isinstance(pipeline_or_domain_name_or_ref, Reference):
-        pipeline_or_domain_name = await reference_resolver(pipeline_or_domain_name_or_ref)
-        if isinstance(pipeline_or_domain_name, list):
-            # Recursively resolve any reference in sub-pipelines
-            pipeline = PipelineWithRefs(steps=pipeline_or_domain_name)
+        try:
+            pipeline_or_domain_name = await reference_resolver(pipeline_or_domain_name_or_ref)
+            if isinstance(pipeline_or_domain_name, list):
+                return await _resolve_references_in_pipeline(reference_resolver, pipeline_or_domain_name)
+            else:
+                return pipeline_or_domain_name
+        except ReferenceUnresolved:
+            return None  # skip
 
-            try:
-                pipeline_without_refs = await pipeline.resolve_references(reference_resolver)
-                return pipeline_without_refs.model_dump()["steps"]
-            except ReferenceUnresolved:
-                return None  # skip
-        else:
-            return pipeline_or_domain_name
+    if isinstance(pipeline_or_domain_name_or_ref, list):
+        return await _resolve_references_in_pipeline(reference_resolver, pipeline_or_domain_name_or_ref)
     else:
         return pipeline_or_domain_name_or_ref
+
+
+async def _resolve_references_in_pipeline(
+    reference_resolver: ReferenceResolver,
+    pipeline: list,
+):
+    from weaverbird.pipeline.pipeline import PipelineWithRefs, ReferenceUnresolved
+
+    if isinstance(pipeline, list):
+        # Recursively resolve any reference in sub-pipelines
+        pipeline_with_refs = PipelineWithRefs(steps=pipeline)
+        try:
+            pipeline_without_refs = await pipeline_with_refs.resolve_references(reference_resolver)
+            return pipeline_without_refs.model_dump()["steps"]
+        except ReferenceUnresolved:
+            return None  # skip

--- a/server/tests/pipeline/test_references.py
+++ b/server/tests/pipeline/test_references.py
@@ -133,6 +133,30 @@ async def test_resolve_references_append():
 
     assert await pipeline_with_refs.resolve_references(reference_resolver) == expected
 
+    pipeline_with_refs = PipelineWithRefs(
+        steps=[
+            DomainStep(domain="source"),
+            AppendStepWithRefs(
+                pipelines=[
+                    [
+                        DomainStepWithRef(domain=Reference(uid="other_pipeline")),
+                        TextStep(new_column="text", text="Lorem ipsum"),
+                    ],
+                ]
+            ),
+        ]
+    )
+    expected = PipelineWithVariables(
+        steps=[
+            DomainStep(domain="source"),
+            AppendStepWithVariable(
+                pipelines=[[*PIPELINES_LIBRARY["other_pipeline"], TextStep(new_column="text", text="Lorem ipsum")]]
+            ),
+        ]
+    )
+
+    assert await pipeline_with_refs.resolve_references(reference_resolver) == expected
+
 
 @pytest.mark.asyncio
 async def test_resolve_references_unresolved_append():


### PR DESCRIPTION
## Description 
When providing an append step a pipeline with refs, its references are not correctly resolved. Example: 
```
           AppendStepWithRefs(
                pipelines=[
                    [
                        DomainStepWithRef(domain=Reference(uid="other_pipeline")),
                        TextStep(new_column="text", text="Lorem ipsum"),
                    ],
                ]
            )
```