### PR TITLE
fix(server/mongo): evolution step filters on all index columns

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog (weaverbird python package)
 
-## [0.42.0] - 2024-01-31
+## Unreleased
 
-### Changed
+### Fixed
+
+- Mongo: Fixed the `evolution` step when several index columns are used. The generated pipeline now filters on all of them
+  rather than just the last one.
+
+## [0.42.0] - 2024-01-31
 
 - Remove `PipelineWithRefs`. Instead, support method `resolve_references` on types `Pipeline` and `PipelineWithVariables`.
 

--- a/server/src/weaverbird/backends/mongo_translator/steps/evolution.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/evolution.py
@@ -76,8 +76,7 @@ def translate_evolution(step: EvolutionStep) -> list[MongoStep]:
                         "cond": {
                             "$and": [
                                 {"$eq": ["$_VQB_DATE_PREV", f"$$item.{step.date_col}"]},
-                                # FIXME: this is a bug
-                                {"$eq": [f"${col}", f"$$item.{col}"] for col in step.index_columns},  # noqa: B035
+                                *({"$eq": [f"${col}", f"$$item.{col}"]} for col in step.index_columns),
                             ],
                         },
                     },

--- a/server/tests/backends/mongo_translator/steps/test_evolution.py
+++ b/server/tests/backends/mongo_translator/steps/test_evolution.py
@@ -1,0 +1,75 @@
+from weaverbird.backends.mongo_translator.steps.evolution import translate_evolution
+from weaverbird.pipeline.steps.evolution import EvolutionStep
+
+
+def test_translate_evolution() -> None:
+    step = EvolutionStep(
+        dateCol="foo",
+        valueCol="bar",
+        evolutionFormat="abs",
+        evolutionType="vsLastDay",
+        indexColumns=["a", "b", "c"],
+    )
+
+    assert translate_evolution(step) == [
+        {"$addFields": {"_VQB_DATE_PREV": {"$dateSubtract": {"amount": 1, "startDate": "$foo", "unit": "week"}}}},
+        {
+            "$facet": {
+                "_VQB_COPIES_ARRAY": [{"$group": {"_VQB_ALL_DOCS": {"$push": "$$ROOT"}, "_id": None}}],
+                "_VQB_ORIGINALS": [{"$project": {"_id": 0}}],
+            }
+        },
+        {"$unwind": "$_VQB_ORIGINALS"},
+        {
+            "$project": {
+                "_VQB_ORIGINALS": {
+                    "$mergeObjects": [
+                        "$_VQB_ORIGINALS",
+                        {"$arrayElemAt": ["$_VQB_COPIES_ARRAY", 0]},
+                    ]
+                }
+            }
+        },
+        {"$replaceRoot": {"newRoot": "$_VQB_ORIGINALS"}},
+        {
+            "$addFields": {
+                "_VQB_ALL_DOCS": {
+                    "$filter": {
+                        "as": "item",
+                        "cond": {
+                            "$and": [
+                                {"$eq": ["$_VQB_DATE_PREV", "$$item.foo"]},
+                                {"$eq": ["$a", "$$item.a"]},
+                                {"$eq": ["$b", "$$item.b"]},
+                                {"$eq": ["$c", "$$item.c"]},
+                            ]
+                        },
+                        "input": "$_VQB_ALL_DOCS",
+                    }
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "_VQB_VALUE_PREV": {
+                    "$cond": [
+                        {"$gt": [{"$size": "$_VQB_ALL_DOCS.bar"}, 1]},
+                        "Error",
+                        {"$arrayElemAt": ["$_VQB_ALL_DOCS.bar", 0]},
+                    ]
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "bar_EVOL_ABS": {
+                    "$cond": [
+                        {"$eq": ["$_VQB_VALUE_PREV", "Error"]},
+                        "Error: More than one previous " "date found for the specified " "index columns",
+                        {"$subtract": ["$bar", "$_VQB_VALUE_PREV"]},
+                    ]
+                }
+            }
+        },
+        {"$project": {"_VQB_ALL_DOCS": 0, "_VQB_DATE_PREV": 0, "_VQB_VALUE_PREV": 0}},
+    ]


### PR DESCRIPTION
Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>
(cherry picked from commit 1fb6f9429c262c4da225b34716b9d6f05ff210db)