### PR TITLE
fix(date-inputs): use correct variables delimiters for default variables [TCTC-8076]

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- DateForms: use correct delimiters for default date variables
+
 ## [0.111.2] - 2024-01-10
 
 ### Fixed

--- a/ui/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -387,7 +387,7 @@ export default class DateRangeInput extends Vue {
       }
       return this.variableDelimiters;
     };
-    
+
     const delimiters = retrieveVariableDelimiters(value);
     if (!delimiters) return value;
     return `${delimiters.start}${value}${delimiters.end}`;

--- a/ui/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/DateRangeInput.vue
@@ -127,6 +127,7 @@ import t, { LocaleIdentifier } from '@/lib/internationalization';
 import {
   AvailableVariable,
   extractVariableIdentifier,
+  isTrustedVariable,
   VariableDelimiters,
   VariablesBucket,
 } from '@/lib/variables';
@@ -374,8 +375,26 @@ export default class DateRangeInput extends Vue {
     this.isEditorOpened = false;
   }
 
+  setVariableDelimiters(value: string): string {
+    const retrieveVariableDelimiters = (
+      variableIdentifier: string,
+    ): VariableDelimiters | undefined => {
+      const variable = this.availableVariables.find((v) => v.identifier === variableIdentifier);
+      if (!variable) {
+        return; // if variable is unfound we don't want to display any delimiters
+      } else if (isTrustedVariable(variable)) {
+        return this.trustedVariableDelimiters;
+      }
+      return this.variableDelimiters;
+    };
+    
+    const delimiters = retrieveVariableDelimiters(value);
+    if (!delimiters) return value;
+    return `${delimiters.start}${value}${delimiters.end}`;
+  }
+
   selectVariable(value: string): void {
-    const variableWithDelimiters = `${this.variableDelimiters.start}${value}${this.variableDelimiters.end}`;
+    const variableWithDelimiters = this.setVariableDelimiters(value);
     this.$emit('input', variableWithDelimiters);
     this.closeEditor();
   }

--- a/ui/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
+++ b/ui/src/components/stepforms/widgets/DateComponents/NewDateInput.vue
@@ -295,7 +295,7 @@ export default class NewDateInput extends Vue {
       }
       return this.variableDelimiters;
     };
-    
+
     const delimiters = retrieveVariableDelimiters(value);
     if (!delimiters) return value;
     return `${delimiters.start}${value}${delimiters.end}`;

--- a/ui/tests/unit/date-range-input.spec.ts
+++ b/ui/tests/unit/date-range-input.spec.ts
@@ -16,41 +16,49 @@ const SAMPLE_VARIABLES = [
     identifier: 'dates.last_7_days',
     label: 'Last 7 days',
     value: '',
+    trusted: true,
   },
   {
     identifier: 'dates.last_14_days',
     label: 'Last 14 days',
     value: { start: new Date(2020, 11), end: new Date(2020, 11) },
+    trusted: true,
   },
   {
     identifier: 'dates.last_30_days',
     label: 'Last 30 days',
     value: '',
+    trusted: true,
   },
   {
     identifier: 'dates.last_3_months',
     label: 'Last 3 Months',
     value: '',
+    trusted: true,
   },
   {
     identifier: 'dates.last_12_months',
     label: 'Last 12 Months',
     value: '',
+    trusted: true,
   },
   {
     identifier: 'dates.month_to_date',
     label: 'Month to date',
     value: '',
+    trusted: true,
   },
   {
     identifier: 'dates.quarter_to_date',
     label: 'Quarter to date',
     value: '',
+    trusted: true,
   },
   {
     identifier: 'dates.all_time',
     label: 'All time',
     value: '',
+    trusted: true,
   },
 ];
 
@@ -59,16 +67,19 @@ const RELATIVE_SAMPLE_VARIABLES = [
     label: 'Today',
     identifier: 'today',
     value: new Date(2020, 11),
+    trusted: true,
   },
   {
     label: 'Last month',
     identifier: 'last_month',
     value: '',
+    trusted: true,
   },
   {
     label: 'Last year',
     identifier: 'last_year',
     value: '',
+    trusted: true,
   },
 ];
 
@@ -90,7 +101,8 @@ describe('Date range input', () => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
         relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters:  { start: '{{', end: '}}' },
         value: 'anythingnotokay',
       });
     });
@@ -202,7 +214,8 @@ describe('Date range input', () => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
         relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters:  { start: '{{', end: '}}' },
       });
     });
 
@@ -285,7 +298,8 @@ describe('Date range input', () => {
         createWrapper({
           availableVariables: SAMPLE_VARIABLES,
           relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
-          variableDelimiters: { start: '{{', end: '}}' },
+          variableDelimiters: { start: '<%=', end: '%>' },
+          trustedVariableDelimiters:  { start: '{{', end: '}}' },
           value: initialValue,
         });
         await wrapper.setProps({
@@ -351,7 +365,8 @@ describe('Date range input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters:  { start: '{{', end: '}}' },
         value: `{{${selectedVariable.identifier}}}`,
       });
     });
@@ -372,7 +387,8 @@ describe('Date range input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters:  { start: '{{', end: '}}' },
         value,
       });
     });
@@ -420,7 +436,8 @@ describe('Date range input', () => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
         relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters:  { start: '{{', end: '}}' },
         value,
       });
     });
@@ -449,7 +466,8 @@ describe('Date range input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters:  { start: '{{', end: '}}' },
         enableRelativeDate: false,
       });
     });
@@ -468,7 +486,8 @@ describe('Date range input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters:  { start: '{{', end: '}}' },
         enableCustom: false,
       });
     });
@@ -484,7 +503,8 @@ describe('Date range input', () => {
     beforeEach(async () => {
       createWrapper({
         availableVariables: [{ label: 'Hidden', identifier: 'hidden', category: 'hidden' }],
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters:  { start: '{{', end: '}}' },
       });
       wrapper.find('.widget-date-input__container').trigger('click');
       await wrapper.vm.$nextTick();
@@ -505,7 +525,8 @@ describe('Date range input', () => {
           { label: 'Available', identifier: 'available' },
         ],
         bounds: '{{hidden}}', // hidden variables can be used as variable reference for bounds or presets
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters:  { start: '{{', end: '}}' },
       });
       wrapper.find('.widget-date-input__container').trigger('click');
       await wrapper.vm.$nextTick();
@@ -528,7 +549,8 @@ describe('Date range input', () => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
         relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters:  { start: '{{', end: '}}' },
         value: { start: new Date('2020/2/1'), end: new Date('2020/3/1') },
         bounds,
       });
@@ -573,7 +595,8 @@ describe('Date range input', () => {
         createWrapper({
           availableVariables: SAMPLE_VARIABLES,
           relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
-          variableDelimiters: { start: '{{', end: '}}' },
+          variableDelimiters: { start: '<%=', end: '%>' },
+          trustedVariableDelimiters:  { start: '{{', end: '}}' },
           compactMode: true,
         });
       });
@@ -602,7 +625,8 @@ describe('Date range input', () => {
       beforeEach(() => {
         createWrapper({
           availableVariables: SAMPLE_VARIABLES,
-          variableDelimiters: { start: '{{', end: '}}' },
+          variableDelimiters: { start: '<%=', end: '%>' },
+          trustedVariableDelimiters:  { start: '{{', end: '}}' },
           value: { start: new Date(), end: new Date(1) },
           compactMode: true,
         });
@@ -624,7 +648,8 @@ describe('Date range input', () => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
         relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters:  { start: '{{', end: '}}' },
         hidePlaceholder: true,
       });
     });

--- a/ui/tests/unit/date-range-input.spec.ts
+++ b/ui/tests/unit/date-range-input.spec.ts
@@ -102,7 +102,7 @@ describe('Date range input', () => {
         availableVariables: SAMPLE_VARIABLES,
         relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '<%=', end: '%>' },
-        trustedVariableDelimiters:  { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         value: 'anythingnotokay',
       });
     });
@@ -215,7 +215,7 @@ describe('Date range input', () => {
         availableVariables: SAMPLE_VARIABLES,
         relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '<%=', end: '%>' },
-        trustedVariableDelimiters:  { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
       });
     });
 
@@ -299,7 +299,7 @@ describe('Date range input', () => {
           availableVariables: SAMPLE_VARIABLES,
           relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
           variableDelimiters: { start: '<%=', end: '%>' },
-          trustedVariableDelimiters:  { start: '{{', end: '}}' },
+          trustedVariableDelimiters: { start: '{{', end: '}}' },
           value: initialValue,
         });
         await wrapper.setProps({
@@ -366,7 +366,7 @@ describe('Date range input', () => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
         variableDelimiters: { start: '<%=', end: '%>' },
-        trustedVariableDelimiters:  { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         value: `{{${selectedVariable.identifier}}}`,
       });
     });
@@ -388,7 +388,7 @@ describe('Date range input', () => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
         variableDelimiters: { start: '<%=', end: '%>' },
-        trustedVariableDelimiters:  { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         value,
       });
     });
@@ -437,7 +437,7 @@ describe('Date range input', () => {
         availableVariables: SAMPLE_VARIABLES,
         relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '<%=', end: '%>' },
-        trustedVariableDelimiters:  { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         value,
       });
     });
@@ -467,7 +467,7 @@ describe('Date range input', () => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
         variableDelimiters: { start: '<%=', end: '%>' },
-        trustedVariableDelimiters:  { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         enableRelativeDate: false,
       });
     });
@@ -487,7 +487,7 @@ describe('Date range input', () => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
         variableDelimiters: { start: '<%=', end: '%>' },
-        trustedVariableDelimiters:  { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         enableCustom: false,
       });
     });
@@ -504,7 +504,7 @@ describe('Date range input', () => {
       createWrapper({
         availableVariables: [{ label: 'Hidden', identifier: 'hidden', category: 'hidden' }],
         variableDelimiters: { start: '<%=', end: '%>' },
-        trustedVariableDelimiters:  { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
       });
       wrapper.find('.widget-date-input__container').trigger('click');
       await wrapper.vm.$nextTick();
@@ -526,7 +526,7 @@ describe('Date range input', () => {
         ],
         bounds: '{{hidden}}', // hidden variables can be used as variable reference for bounds or presets
         variableDelimiters: { start: '<%=', end: '%>' },
-        trustedVariableDelimiters:  { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
       });
       wrapper.find('.widget-date-input__container').trigger('click');
       await wrapper.vm.$nextTick();
@@ -550,7 +550,7 @@ describe('Date range input', () => {
         availableVariables: SAMPLE_VARIABLES,
         relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '<%=', end: '%>' },
-        trustedVariableDelimiters:  { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         value: { start: new Date('2020/2/1'), end: new Date('2020/3/1') },
         bounds,
       });
@@ -596,7 +596,7 @@ describe('Date range input', () => {
           availableVariables: SAMPLE_VARIABLES,
           relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
           variableDelimiters: { start: '<%=', end: '%>' },
-          trustedVariableDelimiters:  { start: '{{', end: '}}' },
+          trustedVariableDelimiters: { start: '{{', end: '}}' },
           compactMode: true,
         });
       });
@@ -626,7 +626,7 @@ describe('Date range input', () => {
         createWrapper({
           availableVariables: SAMPLE_VARIABLES,
           variableDelimiters: { start: '<%=', end: '%>' },
-          trustedVariableDelimiters:  { start: '{{', end: '}}' },
+          trustedVariableDelimiters: { start: '{{', end: '}}' },
           value: { start: new Date(), end: new Date(1) },
           compactMode: true,
         });
@@ -649,7 +649,7 @@ describe('Date range input', () => {
         availableVariables: SAMPLE_VARIABLES,
         relativeAvailableVariables: RELATIVE_SAMPLE_VARIABLES,
         variableDelimiters: { start: '<%=', end: '%>' },
-        trustedVariableDelimiters:  { start: '{{', end: '}}' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         hidePlaceholder: true,
       });
     });

--- a/ui/tests/unit/date-range-input.spec.ts
+++ b/ui/tests/unit/date-range-input.spec.ts
@@ -52,7 +52,6 @@ const SAMPLE_VARIABLES = [
     identifier: 'dates.quarter_to_date',
     label: 'Quarter to date',
     value: '',
-    trusted: true,
   },
   {
     identifier: 'dates.all_time',
@@ -171,16 +170,26 @@ describe('Date range input', () => {
       });
     });
 
-    describe('when selecting a variable in CustomVariableList', () => {
-      const selectedVariable = SAMPLE_VARIABLES[1].identifier;
-      beforeEach(async () => {
-        wrapper.find('CustomVariableList-stub').vm.$emit('input', selectedVariable);
+    describe('when choosing a variable', () => {
+      it('should emit the new value with correct delimiters (trusted variable)', async () => {
+        wrapper.find('CustomVariableList-stub').vm.$emit('input', 'dates.last_7_days');
         await wrapper.vm.$nextTick();
+        expect(wrapper.emitted('input')).toHaveLength(1);
+        expect(wrapper.emitted('input')[0]).toEqual(['{{dates.last_7_days}}']);
+        expect(wrapper.find('popover-stub').props().visible).toBe(false);
       });
-      it('should emit the selected variable identifier with delimiters', () => {
-        expect(wrapper.emitted().input[0][0]).toBe(`{{${selectedVariable}}}`);
+      it('should emit the new value with correct delimiters (untrusted variable)', async () => {
+        wrapper.find('CustomVariableList-stub').vm.$emit('input', 'dates.quarter_to_date');
+        await wrapper.vm.$nextTick();
+        expect(wrapper.emitted('input')).toHaveLength(1);
+        expect(wrapper.emitted('input')[0]).toEqual(['<%=dates.quarter_to_date%>']);
+        expect(wrapper.find('popover-stub').props().visible).toBe(false);
       });
-      it('should hide editor', () => {
+      it('should emit the correct value (undefined variable)', async () => {
+        wrapper.find('CustomVariableList-stub').vm.$emit('input', 'noop');
+        await wrapper.vm.$nextTick();
+        expect(wrapper.emitted('input')).toHaveLength(1);
+        expect(wrapper.emitted('input')[0]).toEqual(['noop']);
         expect(wrapper.find('popover-stub').props().visible).toBe(false);
       });
     });

--- a/ui/tests/unit/new-date-input.spec.ts
+++ b/ui/tests/unit/new-date-input.spec.ts
@@ -16,6 +16,7 @@ const RELATIVE_SAMPLE_VARIABLES = [
     label: 'Today',
     identifier: 'today',
     value: new Date(2020, 11),
+    trusted: true,
   },
 ];
 
@@ -23,34 +24,42 @@ const SAMPLE_VARIABLES = [
   {
     identifier: 'dates.last_7_days',
     label: 'Last 7 days',
+    trusted: true,
   },
   {
     identifier: 'dates.last_14_days',
     label: 'Last 14 days',
+    trusted: true,
   },
   {
     identifier: 'dates.last_30_days',
     label: 'Last 30 days',
+    trusted: true,
   },
   {
     identifier: 'dates.last_3_months',
     label: 'Last 3 Months',
+    trusted: true,
   },
   {
     identifier: 'dates.last_12_months',
     label: 'Last 12 Months',
+    trusted: true,
   },
   {
     identifier: 'dates.month_to_date',
     label: 'Month to date',
+    trusted: true,
   },
   {
     identifier: 'dates.quarter_to_date',
     label: 'Quarter to date',
+    trusted: true,
   },
   {
     identifier: 'dates.all_time',
     label: 'All time',
+    trusted: true,
   },
   ...RELATIVE_SAMPLE_VARIABLES,
 ];
@@ -74,7 +83,8 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         value: 'anythingnotokay',
       });
     });
@@ -184,7 +194,7 @@ describe('Date input', () => {
 
       it('should emit the new value with delimiters', () => {
         expect(wrapper.emitted('input')).toHaveLength(1);
-        expect(wrapper.emitted('input')[0]).toEqual(['{{ Test }}']);
+        expect(wrapper.emitted('input')[0]).toEqual(['<%= Test %>']);
       });
       it('should send analytics event', () => {
         expect(sendAnalyticsSpy).toHaveBeenCalledWith({
@@ -199,7 +209,8 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
       });
     });
 
@@ -346,7 +357,8 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         value: `{{${selectedVariable.identifier}}}`,
       });
     });
@@ -366,7 +378,8 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         value: advancedVariable,
       });
     });
@@ -405,7 +418,8 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         value,
       });
     });
@@ -438,7 +452,8 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         value,
       });
     });
@@ -459,7 +474,8 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         enableCustom: false,
       });
     });
@@ -475,7 +491,8 @@ describe('Date input', () => {
     beforeEach(async () => {
       createWrapper({
         availableVariables: [],
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
       });
       wrapper.find('.widget-date-input__container').trigger('click');
       await wrapper.vm.$nextTick();
@@ -493,7 +510,8 @@ describe('Date input', () => {
     beforeEach(() => {
       createWrapper({
         availableVariables: SAMPLE_VARIABLES,
-        variableDelimiters: { start: '{{', end: '}}' },
+        variableDelimiters: { start: '<%=', end: '%>' },
+        trustedVariableDelimiters: { start: '{{', end: '}}' },
         bounds,
         value: new Date('2020/2/1'),
       });

--- a/ui/tests/unit/new-date-input.spec.ts
+++ b/ui/tests/unit/new-date-input.spec.ts
@@ -54,7 +54,6 @@ const SAMPLE_VARIABLES = [
   {
     identifier: 'dates.quarter_to_date',
     label: 'Quarter to date',
-    trusted: true,
   },
   {
     identifier: 'dates.all_time',
@@ -172,6 +171,27 @@ describe('Date input', () => {
 
       it('should open the advanced variable modal', () => {
         expect(wrapper.find('AdvancedVariableModal-stub').props().isOpened).toBe(true);
+      });
+    });
+
+    describe('when choosing a variable', () => {
+      it('should emit the new value with correct delimiters (trusted variable)', async () => {
+        wrapper.find('CustomVariableList-stub').vm.$emit('input', 'dates.last_7_days');
+        await wrapper.vm.$nextTick();
+        expect(wrapper.emitted('input')).toHaveLength(1);
+        expect(wrapper.emitted('input')[0]).toEqual(['{{dates.last_7_days}}']);
+      });
+      it('should emit the new value with correct delimiters (untrusted variable)', async () => {
+        wrapper.find('CustomVariableList-stub').vm.$emit('input', 'dates.quarter_to_date');
+        await wrapper.vm.$nextTick();
+        expect(wrapper.emitted('input')).toHaveLength(1);
+        expect(wrapper.emitted('input')[0]).toEqual(['<%=dates.quarter_to_date%>']);
+      });
+      it('should emit the correct value (undefined variable)', async () => {
+        wrapper.find('CustomVariableList-stub').vm.$emit('input', 'noop');
+        await wrapper.vm.$nextTick();
+        expect(wrapper.emitted('input')).toHaveLength(1);
+        expect(wrapper.emitted('input')[0]).toEqual(['noop']);
       });
     });
 


### PR DESCRIPTION
In a previous PR: https://github.com/ToucanToco/weaverbird/pull/1988, we updated the delimiters for relative variables but we forgot to do it for default variables (TODAY, YESTERDAY), picked in variables list not in relative date form.
We add logic to retrieve correct delimiters depending on if the variable is trusted or not.
