### PR TITLE
fix(pypika translator): cannot select null in filterstep with operators in / nin / eq / ne [TCTC-7943]

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - A `FilterStepWithVariables` can now contain an `InclusionConditionWithVariables`
+- Pypika translators: allow (de)selecting NULL in FilterStep with operators in / nin / eq / ne
 
 ## [0.42.1] - 2024-03-05
 

--- a/server/src/weaverbird/backends/pypika_translator/translators/base.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/base.py
@@ -973,6 +973,13 @@ class SQLTranslator(ABC):
             case ComparisonCondition():  # type:ignore[misc]
                 import operator
 
+                # Handle special case of checking (in)equality to NULL
+                if condition.value is None:
+                    if condition.operator == "eq":
+                        return column_field.isnull()
+                    elif condition.operator == "ne":
+                        return column_field.isnotnull()
+
                 op = getattr(operator, condition.operator)
                 return op(column_field, condition.value)
 

--- a/server/src/weaverbird/pipeline/steps/filter.py
+++ b/server/src/weaverbird/pipeline/steps/filter.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Any, Literal
 
 from weaverbird.pipeline.steps.utils.base import BaseStep
 from weaverbird.pipeline.steps.utils.render_variables import StepWithVariablesMixin
@@ -13,3 +13,8 @@ class FilterStep(BaseStep):
 
 class FilterStepWithVariables(FilterStep, StepWithVariablesMixin):
     condition: ConditionWithVariables  # type:ignore[assignment]
+
+    def model_dump(self, *, exclude_none: bool = False, **kwargs) -> dict[str, Any]:
+        # we don't want to drop fields with value=None like:
+        #     {'column': 'nullable_name', 'operator': 'eq', 'value': None}
+        return super().model_dump(exclude_none=exclude_none, **kwargs)

--- a/server/tests/backends/fixtures/filter/eq_with_null_pypika.yaml
+++ b/server/tests/backends/fixtures/filter/eq_with_null_pypika.yaml
@@ -1,0 +1,24 @@
+exclude:
+- mongo
+- pandas
+- snowflake
+step:
+  pipeline:
+  - condition:
+      column: nullable_name
+      operator: eq
+      value: null
+    name: filter
+  - columns:
+    - name
+    name: select
+expected:
+  data:
+  - name: Superstrong beer
+  - name: "Cuv\xE9e des Trolls"
+  - name: Brasserie De Sutter Brin de Folie
+  schema:
+    fields:
+    - name: name
+      type: string
+    pandas_version: 1.4.0

--- a/server/tests/backends/fixtures/filter/isin_with_null_pypika.yaml
+++ b/server/tests/backends/fixtures/filter/isin_with_null_pypika.yaml
@@ -1,0 +1,25 @@
+exclude:
+- mongo
+- pandas
+- snowflake
+step:
+  pipeline:
+  - condition:
+      column: nullable_name
+      operator: in
+      value: [null, "Pauwel Kwak"]
+    name: filter
+  - columns:
+    - name
+    name: select
+expected:
+  data:
+  - name: Superstrong beer
+  - name: "Cuv\xE9e des Trolls"
+  - name: Pauwel Kwak
+  - name: Brasserie De Sutter Brin de Folie
+  schema:
+    fields:
+    - name: name
+      type: string
+    pandas_version: 1.4.0


### PR DESCRIPTION
### in / nin

```sql
WHERE column IN (NULL, "foo", "bar")
```
does not work. Replace it with

```sql
WHERE column IS NULL OR column IN ("foo", "bar")
```

### eq / ne

```sql
WHERE column=NULL
```
does not work. Replace it with

```sql
WHERE column IS NULL
```