### PR TITLE
chore(ui): declare types as export in package.json

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,10 @@
   "module": "./dist/weaverbird.js",
   "exports": {
     ".": {
-      "import": "./dist/weaverbird.js",
+      "import": {
+        "types": "./dist/types/types.d.ts",
+        "default": "./dist/weaverbird.js"
+      },
       "require": "./dist/weaverbird.umd.cjs"
     }
   },


### PR DESCRIPTION
This is a blocker for upgrading consumers to recent bundlers and typescript (such as vite 5)