### PR TITLE
fix(steps): remove custom and custom sql deprecated steps from action menu [TCTC-7178]

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- ActionMenu: remove deprecated Custom and Custom Sql step from action menu 
+
 ## [0.111.3] - 2024-03-11
 
 ### Fixed

--- a/ui/src/components/constants.ts
+++ b/ui/src/components/constants.ts
@@ -36,8 +36,6 @@ export const ACTION_CATEGORIES: ActionCategories = {
     { name: 'text', label: 'Add text column' },
     { name: 'formula', label: 'Add formula column' },
     { name: 'ifthenelse', label: 'Add conditional column' },
-    { name: 'custom', label: 'Add custom step' },
-    { name: 'customsql', label: 'Add custom sql step' },
   ],
   filter: [
     { name: 'delete', label: 'Delete columns' },

--- a/ui/tests/unit/action-toolbar-button.spec.ts
+++ b/ui/tests/unit/action-toolbar-button.spec.ts
@@ -174,7 +174,7 @@ describe('ActionToolbarButton active', () => {
 
     const actionsWrappers = wrapper.findAll('.action-menu__option');
     const actionsIsDisabled = actionsWrappers.wrappers.map((w) => w.props().isDisabled);
-    expect(actionsIsDisabled).toEqual([false, false, false, true, true]);
+    expect(actionsIsDisabled).toEqual([false, false, false]);
   });
 
   it('should instantiate a Date button with the right list of actions', () => {

--- a/ui/tests/unit/action-toolbar-button.spec.ts
+++ b/ui/tests/unit/action-toolbar-button.spec.ts
@@ -105,8 +105,6 @@ describe('ActionToolbarButton active', () => {
       'Add text column',
       'Add formula column',
       'Add conditional column',
-      'Add custom step',
-      'Add custom sql step',
     ]);
   });
 


### PR DESCRIPTION
We remove the deprecated 'Custom sql' and 'Custom' steps from action menu.
It won't be usable anymore with hybrid pipeline

:information_source: We don't remove steps code and pipeline listing because we may have migrated apps with custom steps so we want them to be removed before cleaning the code
The customs steps are still accessible (to be deleted) if a step has been created earlier but app builder won't be able to create new ones