### PR TITLE
fix(server): correctly generate one parent and one child row even if labels are the same TCTC-8331 

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Pandas: Waterfall step: generate one parent and one child row even if labels are the same (instead of two parent rows)
+
 ## [0.42.2] - 2024-03-12
 
 ### Fixed

--- a/server/src/weaverbird/backends/pandas_executor/steps/waterfall.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/waterfall.py
@@ -4,6 +4,7 @@ from typing import Any
 import numpy
 import pandas as pd
 from pandas import DataFrame
+
 from weaverbird.backends.pandas_executor.types import DomainRetriever, PipelineExecutor
 from weaverbird.pipeline.steps.waterfall import (
     GROUP_WATERFALL_COLUMN,
@@ -216,9 +217,7 @@ def _compute_parents_and_children(step: WaterfallStep, merged_df: DataFrame) -> 
         result_df[_VQB_SORT_ORDER] = 2
     else:
         result_df[GROUP_WATERFALL_COLUMN] = merged_df[step.parentsColumn]
-        result_df[_VQB_SORT_ORDER] = numpy.where(
-            result_df[TYPE_WATERFALL_COLUMN] == "parent", 2, 1
-        )
+        result_df[_VQB_SORT_ORDER] = numpy.where(result_df[TYPE_WATERFALL_COLUMN] == "parent", 2, 1)
 
     result_df[step.valueColumn] = merged_df[RESULT_COLUMN]
     return result_df

--- a/server/tests/backends/fixtures/waterfall/with_backfill.yaml
+++ b/server/tests/backends/fixtures/waterfall/with_backfill.yaml
@@ -259,6 +259,11 @@ input:
     country: Germany
     month: 01 April 2023
     price: 65076
+  # Only element with the same name as the group
+  - account: England
+    country: England
+    month: 01 January 2023
+    price: 123456
   schema:
     fields:
     - name: account
@@ -275,7 +280,7 @@ expected:
   - GROUP_waterfall: 01 January 2023
     LABEL_waterfall: 01 January 2023
     TYPE_waterfall: null
-    price: 119907
+    price: 243363
   - GROUP_waterfall: Germany
     LABEL_waterfall: Fermentum Industries
     TYPE_waterfall: child
@@ -296,6 +301,10 @@ expected:
     LABEL_waterfall: Dignissim Maecenas Foundation
     TYPE_waterfall: child
     price: -62202
+  - GROUP_waterfall: England
+    LABEL_waterfall: England
+    TYPE_waterfall: child
+    price: -123456
   - GROUP_waterfall: Germany
     LABEL_waterfall: Germany
     TYPE_waterfall: parent
@@ -304,6 +313,10 @@ expected:
     LABEL_waterfall: France
     TYPE_waterfall: parent
     price: -78287
+  - GROUP_waterfall: England
+    LABEL_waterfall: England
+    TYPE_waterfall: parent
+    price: -123456
   - GROUP_waterfall: 01 December 2023
     LABEL_waterfall: 01 December 2023
     TYPE_waterfall: null


### PR DESCRIPTION
Mongo and pandas waterfall steps had slightly different behaviors when handling rows that have the same value for group and label.
Fixes this difference in favor of producing one parent row and one child row.