### PR TITLE
fix(server/pypika): fix _id method

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Pypika: Fixed a rare bug in the `append` step, where several different pipelines could have identical step names, causing the
+  generated query to be invalid.
+
 ## [0.43.0] - 2024-05-06
 
 ### Added

--- a/server/src/weaverbird/backends/pypika_translator/translators/base.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/base.py
@@ -2,8 +2,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from functools import cache
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast, get_args
+from uuid import uuid4
 
 from dateutil import parser as dateutil_parser
 from pypika import (
@@ -207,20 +207,20 @@ class SQLTranslator(ABC):
         self._known_instances: dict[int, str] = known_instances or {}
         self._step_count = 0
         self._source_rows_subset = source_rows_subset
+        self.__id = uuid4().int
 
     def __init_subclass__(cls) -> None:
         ALL_TRANSLATORS[cls.DIALECT] = cls
 
-    @cache  # noqa: B019
     def _id(self: Self) -> str:
-        if id(self) in self._known_instances:
-            return self._known_instances[id(self)]
+        if self.__id in self._known_instances:
+            return self._known_instances[self.__id]
         if len(self._known_instances.keys()) == 0:
-            id_ = self._known_instances[id(self)] = self.__class__.__name__.lower()
+            id_ = self._known_instances[self.__id] = self.__class__.__name__.lower()
             return id_
         else:
             id_ = self.__class__.__name__.lower() + str(len(self._known_instances.keys()))
-            self._known_instances[id(self)] = id_
+            self._known_instances[self.__id] = id_
             return id_
 
     def _step_name(self: Self) -> str:

--- a/server/tests/backends/sql_translator_unit_tests/conftest.py
+++ b/server/tests/backends/sql_translator_unit_tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from pypika import Query
 from pypika.queries import QueryBuilder
 from weaverbird.backends.pypika_translator.dialects import SQLDialect
-from weaverbird.backends.pypika_translator.translators.base import SQLTranslator
+from weaverbird.backends.pypika_translator.translators.base import DataTypeMapping, SQLTranslator
 
 
 @pytest.fixture
@@ -12,29 +12,27 @@ def default_step_kwargs() -> dict[str, Any]:
     return {"builder": QueryBuilder(), "prev_step_table": "previous_with"}
 
 
+class Dummy(SQLTranslator):
+    QUERY_CLS = Query
+    DIALECT = SQLDialect.MYSQL
+    DATA_TYPE_MAPPING = DataTypeMapping(
+        boolean="BOOLEAN",
+        date="DATE",
+        float="FLOAT",
+        integer="INTEGER",
+        text="TEXT",
+        datetime="DATETIME",
+        timestamp="TIMESTAMP",
+    )
+
+    @classmethod
+    def _interval_to_seconds(cls, value):
+        """Converts an INTERVAL SQL type to a duration in seconds"""
+
+
 @pytest.fixture
 def translator() -> SQLTranslator:
-    class DummyTranslator(SQLTranslator):
-        QUERY_CLS = Query
-        DIALECT = SQLDialect.MYSQL
-        known_instances = {}
-
-        def _id(self) -> str:
-            if id(self) in DummyTranslator.known_instances:
-                return DummyTranslator.known_instances[id(self)]
-            if len(DummyTranslator.known_instances.keys()) == 0:
-                DummyTranslator.known_instances[id(self)] = "dummy"
-                return "dummy"
-            else:
-                id_ = "dummy" + str(len(DummyTranslator.known_instances.keys()))
-                DummyTranslator.known_instances[id(self)] = id_
-                return id_
-
-        @classmethod
-        def _interval_to_seconds(cls, value):
-            """Converts an INTERVAL SQL type to a duration in seconds"""
-
-    return DummyTranslator(
+    return Dummy(
         tables_columns={
             "beers_tiny": [
                 "price_per_l",


### PR DESCRIPTION
The _id method appears to be flaky: it relies on the id() built-in, which must return a unique identifier for an object. In CPython, this is the object's address.

This causes an issue in the `append` method of the PyPika translator when several pipelines are appended: an instance of the translator class is created everytime we need to process a pipeline. We assume the id of every instance to be unique to generate unique human-readable step names in CTEs.

However, when multiple pipelines are appended, an instance might be garbage-collected between two iterations of the for-loop, which can resulting in the next instance (or the one after that) to be allocated in the address as the garbage-collected one. This results in both instances having the same id, and thus generating the same step names.

This issue is fixed by generating a unique id in the classe's __init__ method, and rely on this id rather than the object's pythonic id when generating step names.