### PR TITLE
fix(server): only support strings in quotes in formulas TCTC-8504

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Formula: removed support for unquoted strings that are not valid column names
+
 ## [0.44.2] - 2024-05-15
 
 ### Fixed

--- a/server/src/weaverbird/backends/pandas_executor/steps/utils/formula.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/utils/formula.py
@@ -5,7 +5,6 @@ from pandas import DataFrame, Series
 
 from weaverbird.pipeline.formula_ast.eval import FormulaParser
 from weaverbird.pipeline.formula_ast.types import ColumnName, Expression, Operation, Operator
-from weaverbird.pipeline.formula_ast.utils import unquote_string
 
 _OP_MAP = {
     Operator.ADD: operator.add,
@@ -27,14 +26,8 @@ def _eval_expression(df: DataFrame, expr: Expression) -> Series:
         return _eval_operation(df, expr)
     elif isinstance(expr, ColumnName):
         return df[expr.name]
-    elif isinstance(expr, str):
-        # Unquote the string. No need to escape quotes in it, as it will be used as is by pandas
-        expr = unquote_string(expr, escape_quotes=False)
     return Series(expr, index=df.index)
 
 
 def eval_formula(df: DataFrame, formula: str) -> Series:
-    try:
-        return _eval_expression(df, FormulaParser(formula).parse())
-    except SyntaxError:  # The formula is actually a badly formatted string
-        return _eval_expression(df, formula)
+    return _eval_expression(df, FormulaParser(formula).parse())

--- a/server/src/weaverbird/backends/pypika_translator/utils/formula.py
+++ b/server/src/weaverbird/backends/pypika_translator/utils/formula.py
@@ -7,7 +7,6 @@ from pypika.terms import Term
 
 from weaverbird.pipeline.formula_ast.eval import FormulaParser
 from weaverbird.pipeline.formula_ast.types import ColumnName, Expression, Operation, Operator
-from weaverbird.pipeline.formula_ast.utils import unquote_string
 
 if TYPE_CHECKING:
     from weaverbird.backends.pypika_translator.translators.base import FromTable
@@ -36,9 +35,6 @@ def _eval_expression(expr: Expression, table: Table) -> Term:
         return _eval_operation(expr, table)
     elif isinstance(expr, ColumnName):
         return table[expr.name]
-    elif isinstance(expr, str):
-        # unquoting
-        expr = unquote_string(expr)
     return Term.wrap_constant(expr)
 
 

--- a/server/src/weaverbird/pipeline/formula_ast/eval.py
+++ b/server/src/weaverbird/pipeline/formula_ast/eval.py
@@ -3,8 +3,6 @@ import tokenize
 from collections.abc import Generator, Iterator
 from io import BytesIO
 
-from weaverbird.pipeline.formula_ast.utils import unquote_string
-
 from . import types
 
 
@@ -45,14 +43,6 @@ class FormulaParser:
         self._formula = formula
         self._columns: dict[str, str] = {}
 
-    @staticmethod
-    def sanitize_string(s: str) -> str:
-        """Unquotes strings, escapes single quotes and wraps them in single quotes"""
-        # Removing outer quotes and escaping inner quotes:
-        unquoted = unquote_string(s, escape_quotes=True)
-        # Wrapping the entire thing in single quotes
-        return f"'{unquoted}'"
-
     def _iterate_tokens(self, tokens: Iterator[tokenize.TokenInfo]) -> Generator[str, None, None]:
         """This function iterates over tokens, sanitizes and yields them."""
 
@@ -88,11 +78,8 @@ class FormulaParser:
             ):
                 # Those are whitespace tokens we don't care about, so not yielding them
                 continue
-            elif token.type == tokenize.STRING:
-                # In case we have a string literal, we sanitize it
-                yield self.sanitize_string(token.string)
             elif token.type == tokenize.OP and token.string == "[":
-                # Square brackets are delimiters for column names, so here we read everyhting until
+                # Square brackets are delimiters for column names, so here we read everything until
                 # the closing bracket
                 yield parse_col_name(token)
             else:
@@ -166,8 +153,7 @@ class FormulaParser:
                 return types.Operation(left=self._parse_expr(left), right=self._parse_expr(right), operator=operator)
             # Constant: number, string literal or boolean
             case ast.Constant(value=value):
-                # bool is a subtype of int
-                if isinstance(value, int | float | str):
+                if isinstance(value, bool | int | float | str):
                     return value
                 else:
                     raise UnsupportedConstant(f"Unsupported constant '{expr}' of type {type(value)}")

--- a/server/tests/backends/fixtures/ifthenelse/quotes.json
+++ b/server/tests/backends/fixtures/ifthenelse/quotes.json
@@ -17,8 +17,8 @@
           "operator": "gt"
         },
         "newColumn": "COND",
-        "then": "\"tin'tin\"",
-        "else": "some ' stuff with \" annoying 'quotes'"
+        "then": "'tintin'",
+        "else": "\"some ' stuff with \\\" annoying 'quotes'\""
       }
     ]
   },
@@ -80,7 +80,7 @@
         "NAME": "foo",
         "AGE": 42,
         "SCORE": 100,
-        "COND": "tin'tin"
+        "COND": "tintin"
       },
       {
         "NAME": "bar",

--- a/server/tests/backends/fixtures/ifthenelse/quotes_pypika.yaml
+++ b/server/tests/backends/fixtures/ifthenelse/quotes_pypika.yaml
@@ -19,7 +19,7 @@
         },
         "newColumn": "cond",
         "then": "'tintin'",
-        "else": "some ' stuff with \" annoying 'quotes'"
+        "else": "\"some ' stuff with \\\" annoying 'quotes'\""
       }
     ]
   },

--- a/server/tests/steps/test_formula.py
+++ b/server/tests/steps/test_formula.py
@@ -29,7 +29,16 @@ def test_formula(sample_df: DataFrame):
     assert_dataframes_equals(df_result, expected_result)
 
 
-@pytest.mark.parametrize("bad_expression", ["", 'print("hello")', "import re", "x = colA * 2"])
+@pytest.mark.parametrize("formula,constant", [("\"Some 'text'\"", "Some 'text'"), ("true", True), ("12.34", 12.34)])
+def test_formula_constant(sample_df: DataFrame, formula: str, constant):
+    step = FormulaStep(name="formula", new_column="z", formula=formula)
+    df_result = execute_formula(step, sample_df)
+
+    expected_result = sample_df.assign(z=[constant, constant])
+    assert_dataframes_equals(df_result, expected_result)
+
+
+@pytest.mark.parametrize("bad_expression", ["", 'print("hello")', "import re", "x = colA * 2", "invalid columns"])
 def test_bad_formula(sample_df: DataFrame, bad_expression):
     bad_step = FormulaStep(name="formula", new_column="z", formula=bad_expression)
     with pytest.raises(Exception):  # noqa: B017


### PR DESCRIPTION
Specially useful for ifthenelse
Breaking, but should be safer for the future
Also, corresponds to the behavior explained in UI