### PR TITLE
fix(fromdate  mongo): mongo translator accepts custom date formats (TCTC-8511)

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Mongo: the `datefrom` step translator is more flexible and accepts custom date formats
+
 ## [0.45.0] - 2024-05-16
 
 ### Fixed

--- a/server/src/weaverbird/backends/mongo_translator/steps/fromdate.py
+++ b/server/src/weaverbird/backends/mongo_translator/steps/fromdate.py
@@ -97,7 +97,7 @@ _DATE_TAGS_MAPPING = {"%d": "$_vqbTempDay", "%B": "$_vqbTempMonth", "%b": "$_vqb
 _DATE_TAGS = ["%d", "%b", "%B", "%Y"]
 
 
-def _order_date_tag_from_format(date_format) -> list[tuple[int, str]]:
+def _order_date_tag_from_format(date_format: str) -> list[tuple[int, str]]:
     """Extracts date tag position from date format"""
     ordered_tag_pos: list[tuple[int, str]] = []
     for tag in _DATE_TAGS:
@@ -109,15 +109,18 @@ def _order_date_tag_from_format(date_format) -> list[tuple[int, str]]:
 
 
 def _extract_separators_from_date_format(date_format: str) -> dict[int, Any]:
-    """
-    date_format can be customized by the end user. Mongo doesn't support %b and %B (until v7).
+    """Extracts date tags separators from date format as a contextual dictionary
+
+    Date format can be customized by the end user. Mongo doesn't support %b and %B (until v7).
     We have to extract each date elements to have access to their position and separators in order to recreate properly
     the expected format into a concat step.
+
     Example:
     input: date_format = "Hi, %B is a wonderful month, especially the %d !"
-    output: {
-      0: { name: "$_vqbTempMonth", "prefix": "Hi, ", "suffix": "", position: 0 },
-      1: { name: "$_vqbTempDay", "prefix": " is a wonderful month, especially the ", "suffix": " !", position: 44 }
+    output:
+    {
+        0: { name: "$_vqbTempMonth", "prefix": "Hi, ", "suffix": "", position: 0 },
+        1: { name: "$_vqbTempDay", "prefix": " is a wonderful month, especially the ", "suffix": " !", position: 44 }
     }
     """
     index = 0

--- a/server/tests/backends/fixtures/fromdate/longmonth_only_custom.json
+++ b/server/tests/backends/fixtures/fromdate/longmonth_only_custom.json
@@ -1,0 +1,72 @@
+{
+  "exclude": [
+    "athena_pypika",
+    "bigquery_pypika",
+    "mysql_pypika",
+    "postgres_pypika",
+    "redshift_pypika",
+    "snowflake",
+    "snowflake_pypika"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "fromdate",
+        "column": "CREATED_DATE",
+        "format": "Created in: %B"
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "NAME",
+          "type": "string"
+        },
+        {
+          "name": "AGE",
+          "type": "integer"
+        },
+        {
+          "name": "CREATED_DATE",
+          "type": "datetime"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "NAME": "foo",
+        "AGE": 42,
+        "CREATED_DATE": "2020-03-09 00:00:00.000"
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "NAME",
+          "type": "string"
+        },
+        {
+          "name": "AGE",
+          "type": "number"
+        },
+        {
+          "name": "CREATED_DATE",
+          "type": "string"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "NAME": "foo",
+        "AGE": 42,
+        "CREATED_DATE": "Created in: March"
+      }
+    ]
+  }
+}

--- a/server/tests/backends/mongo_translator_unit_tests/test_fromdate_separators.py
+++ b/server/tests/backends/mongo_translator_unit_tests/test_fromdate_separators.py
@@ -1,0 +1,84 @@
+from server.src.weaverbird.backends.mongo_translator.steps.fromdate import _extract_separators_from_date_format
+
+_DATE_FORMAT_WITH_EXPECTED_RESULT = [
+    (
+        "%d-%b-%Y",
+        {
+            0: {
+                "name": "$_vqbTempDay",
+                "position": 0,
+                "prefix": "",
+            },
+            1: {
+                "name": "$_vqbTempMonth",
+                "position": 3,
+                "prefix": "-",
+            },
+            2: {
+                "name": "$_vqbTempYear",
+                "position": 6,
+                "prefix": "-",
+                "suffix": "",
+            },
+        },
+    ),
+    (
+        "%d %b %Y !",
+        {
+            0: {
+                "name": "$_vqbTempDay",
+                "position": 0,
+                "prefix": "",
+            },
+            1: {
+                "name": "$_vqbTempMonth",
+                "position": 3,
+                "prefix": " ",
+            },
+            2: {
+                "name": "$_vqbTempYear",
+                "position": 6,
+                "prefix": " ",
+                "suffix": " !",
+            },
+        },
+    ),
+    (
+        "%B (month) %d (day)",
+        {
+            0: {
+                "name": "$_vqbTempMonth",
+                "position": 0,
+                "prefix": "",
+            },
+            1: {
+                "name": "$_vqbTempDay",
+                "position": 11,
+                "prefix": " (month) ",
+                "suffix": " (day)",
+            },
+        },
+    ),
+    (
+        "Current date: %d/%B",
+        {
+            0: {
+                "name": "$_vqbTempDay",
+                "position": 14,
+                "prefix": "Current date: ",
+            },
+            1: {
+                "name": "$_vqbTempMonth",
+                "position": 17,
+                "prefix": "/",
+                "suffix": "",
+            },
+        },
+    ),
+    ("%B", {0: {"name": "$_vqbTempMonth", "position": 0, "prefix": "", "suffix": ""}}),
+]
+
+
+def test_separators_from_date_format():
+    for date_format, expected_result in _DATE_FORMAT_WITH_EXPECTED_RESULT:
+        assert _extract_separators_from_date_format(date_format) == expected_result


### PR DESCRIPTION
### What

Mongo fromdate translator is now more flexible and accepts custom formats like "%B foo" or "bar %b %d"

### Why

There was an error when an user was trying to use a custom format in fromdate step.

`pymongo.errors.OperationFailure: PlanExecutor error during aggregation :: caused by :: Invalid format character '%B' in format string, full error: {'ok': 0.0, 'errmsg': "PlanExecutor error during aggregation :: caused by :: Invalid format character '%B' in format string", 'code': 18536, 'codeName': 'Location18536'}`

