### PR TITLE
fix(ifthenelse): dont select column name if its ifthenelse result alias (TCTC-8780)

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Pypika: don't select column name if its already `ifthenelse` step alias, which was causing an invalid column overwrite 
+
 ## [0.45.3] - 2024-06-05
 
 ### Fixed

--- a/server/src/weaverbird/backends/pypika_translator/translators/base.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/base.py
@@ -1410,7 +1410,7 @@ class SQLTranslator(ABC):
         step: "IfthenelseStep",
     ) -> StepContext:
         query = prev_step_table.select(
-            *columns,
+            *(column for column in columns if column != step.new_column),
             self._build_ifthenelse_case(
                 if_=step.condition,
                 then_=step.then,

--- a/server/tests/backends/fixtures/ifthenelse/overwrite_column_pypika.yaml
+++ b/server/tests/backends/fixtures/ifthenelse/overwrite_column_pypika.yaml
@@ -1,0 +1,46 @@
+exclude:
+- mongo
+- pandas
+step:
+  pipeline:
+    - columns:
+      - cost
+      - name
+      name: select
+    - name: ifthenelse
+      if:
+        column: cost
+        value: 2
+        operator: gt
+      newColumn: name
+      then: "'tintin'"
+      else: "'anime'"
+expected:
+  schema:
+    fields:
+    - name: name
+      type: string
+    - name: cost
+      type: number
+  data:
+    - cost: 2.8900001049
+      name: tintin
+    - cost: 2.8900001049
+      name: tintin
+    - cost: 2.2899999619
+      name: tintin
+    - cost: 2.0899999142
+      name: tintin
+    - cost: 1.5499999523
+      name: anime
+    - cost: 1.5900000334
+      name: anime
+    - cost: 2.4900000095
+      name: tintin
+    - cost: 1.6900000572
+      name: anime
+    - cost: 2.1900000572
+      name: tintin
+    - cost: 1.7899999619
+      name: anime
+  pandas_version: 1.4.0


### PR DESCRIPTION
## Why

Can generates an other column name instead of an overwrite:
![image](https://github.com/ToucanToco/weaverbird/assets/17086334/8ccf0c41-b01e-4c22-ab16-04c539b4e20a)
