### PR TITLE
fix: allow to filter in/nin dates with pandas executor [TCTC-8804]

### DIFF
--- a/server/tests/backends/fixtures/filter/dates_nin.json
+++ b/server/tests/backends/fixtures/filter/dates_nin.json
@@ -1,0 +1,80 @@
+{
+  "exclude": [
+    "athena_pypika",
+    "bigquery_pypika",
+    "mysql_pypika",
+    "postgres_pypika",
+    "redshift_pypika",
+    "snowflake_pypika"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "filter",
+        "condition": {
+          "column": "CREATED",
+          "operator": "nin",
+          "value": ["2024-01-01T00:00:00.000Z"]
+        }
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "NAME",
+          "type": "string"
+        },
+        {
+          "name": "AGE",
+          "type": "integer"
+        },
+        {
+          "name": "CREATED",
+          "type": "datetime"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "NAME": "foo",
+        "AGE": 42,
+        "CREATED": "2023-01-01T00:00:00.000Z"
+      },
+      {
+        "NAME": "bar",
+        "AGE": 43,
+        "CREATED": "2024-01-01T00:00:00.000Z"
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "NAME",
+          "type": "string"
+        },
+        {
+          "name": "AGE",
+          "type": "number"
+        },
+        {
+          "name": "CREATED",
+          "type": "datetime",
+          "tz": "UTC"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "NAME": "foo",
+        "AGE": 42,
+        "CREATED": "2023-01-01T00:00:00.000Z"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Aujourd'hui on ne peut pas filtrer les dates avec l'opérateur `in` ou `nin` via l'exécuteur pandas, mais l'UI utilise ces opérateurs quand on coche/décoche directement des valeurs dans la visualisation du dataset dans youprep.

Jira card : https://toucantoco.atlassian.net/browse/TCTC-8804