### PR TITLE
fix: GBQ DATE_ADD function doesnt support timestamps (TCTC-8784)

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+ - Pypika GoogleBigQuery: cast field as `DATETIME` in `DATE_ADD` method 
+
 ## [0.45.4] - 2024-06-12
 
 ### Fixed

--- a/server/src/weaverbird/backends/pypika_translator/translators/googlebigquery.py
+++ b/server/src/weaverbird/backends/pypika_translator/translators/googlebigquery.py
@@ -87,7 +87,7 @@ class GoogleBigQueryQueryBuilder(QueryBuilder):
 
 class GoogleBigQueryDateAdd(Function):
     def __init__(self, *, target_column: Field, interval: Interval) -> None:
-        super().__init__("DATE_ADD", target_column, interval)
+        super().__init__("DATE_ADD", functions.Cast(target_column, "DATETIME"), interval)
 
 
 class GoogleBigQueryTranslator(SQLTranslator):

--- a/server/tests/backends/fixtures/dateextract/google_big_query_datetimes.yaml
+++ b/server/tests/backends/fixtures/dateextract/google_big_query_datetimes.yaml
@@ -1,0 +1,90 @@
+exclude:
+  - pandas
+  - mongo
+  - athena_pypika
+  - mysql_pypika
+  - postgres_pypika
+  - redshift_pypika
+  - snowflake
+  - snowflake_pypika
+step:
+  pipeline:
+    - name: customsql
+    # Set brewing_date as DATETIME type
+      query: "SELECT `price_per_l`,`alcohol_degree`,`name`,`cost`,`beer_kind`,`volume_ml`,`nullable_name`, CAST(`brewing_date` AS DATETIME) AS `brewing_date` FROM `beers.beers_tiny` WHERE beer_kind = 'Blonde'"
+    # First day of previous month
+    - name: dateextract
+      column: brewing_date
+      dateInfo: [ "firstDayOfPreviousMonth" ]
+      newColumns: [ "prev_month_date" ]
+    # Previous ISO week
+    - name: dateextract
+      column: brewing_date
+      dateInfo: [ "previousIsoWeek" ]
+      newColumns: [ "prev_iso_week_date" ]
+    # First day of previous ISO week
+    - name: dateextract
+      column: brewing_date
+      dateInfo: [ "firstDayOfPreviousIsoWeek" ]
+      newColumns: [ "first_day_prev_iso_week_date" ]
+
+expected:
+  data:
+  - price_per_l: 0.070
+    alcohol_degree: 8.930645
+    name: Cuvée des Trolls
+    cost: 1.55
+    beer_kind: Blonde
+    volume_ml: 250.0
+    brewing_date: "2022-01-05 00:00:00+00:00"
+    nullable_name: ~
+    prev_month_date: "2021-12-01 00:00:00"
+    prev_iso_week_date: 52
+    first_day_prev_iso_week_date: "2021-12-27 00:00:00"
+  - price_per_l: 0.065
+    alcohol_degree: 7.747466
+    name: Brasserie De Sutter Brin de Folie
+    cost: 2.19
+    beer_kind: Blonde
+    volume_ml: 330.0
+    brewing_date: "2022-01-09 00:00:00+00:00"
+    nullable_name: ~
+    prev_month_date: "2021-12-01 00:00:00"
+    prev_iso_week_date: 52
+    first_day_prev_iso_week_date: "2021-12-27 00:00:00"
+  - price_per_l: 0.060
+    alcohol_degree: 8.749609
+    name: Brugse Zot blonde
+    cost: 1.79
+    beer_kind: Blonde
+    volume_ml: 330.0
+    brewing_date: "2022-01-10 00:00:00+00:00"
+    nullable_name: Brugse Zot blonde
+    prev_month_date: "2021-12-01 00:00:00"
+    prev_iso_week_date: 1
+    first_day_prev_iso_week_date: "2022-01-03 00:00:00"
+  schema:
+    fields:
+    - name: price_per_l
+      type: number
+    - name: alcohol_degree
+      type: number
+    - name: name
+      type: string
+    - name: cost
+      type: number
+    - name: beer_kind
+      type: string
+    - name: volume_ml
+      type: number
+    - name: nullable_name
+      type: string
+    - name: brewing_date
+      type: datetime
+    - name: prev_month_date
+      type: datetime
+    - name: prev_iso_week_date
+      type: number
+    - name: first_day_prev_iso_week_date
+      type: datetime
+    pandas_version: 1.4.0

--- a/server/tests/backends/fixtures/dateextract/google_big_query_datetimes.yaml
+++ b/server/tests/backends/fixtures/dateextract/google_big_query_datetimes.yaml
@@ -8,10 +8,13 @@ exclude:
   - snowflake
   - snowflake_pypika
 step:
+  table_columns:
+  - name
+  - brewing_date
   pipeline:
     - name: customsql
     # Set brewing_date as DATETIME type
-      query: "SELECT `price_per_l`,`alcohol_degree`,`name`,`cost`,`beer_kind`,`volume_ml`,`nullable_name`, CAST(`brewing_date` AS DATETIME) AS `brewing_date` FROM `beers.beers_tiny` WHERE beer_kind = 'Blonde'"
+      query: "SELECT `name`, CAST(`brewing_date` AS DATETIME) AS `brewing_date` FROM `beers.beers_tiny` WHERE beer_kind = 'Blonde'"
     # First day of previous month
     - name: dateextract
       column: brewing_date
@@ -30,54 +33,24 @@ step:
 
 expected:
   data:
-  - price_per_l: 0.070
-    alcohol_degree: 8.930645
-    name: Cuvée des Trolls
-    cost: 1.55
-    beer_kind: Blonde
-    volume_ml: 250.0
+  - name: Cuvée des Trolls
     brewing_date: "2022-01-05 00:00:00+00:00"
-    nullable_name: ~
     prev_month_date: "2021-12-01 00:00:00"
     prev_iso_week_date: 52
     first_day_prev_iso_week_date: "2021-12-27 00:00:00"
-  - price_per_l: 0.065
-    alcohol_degree: 7.747466
-    name: Brasserie De Sutter Brin de Folie
-    cost: 2.19
-    beer_kind: Blonde
-    volume_ml: 330.0
+  - name: Brasserie De Sutter Brin de Folie
     brewing_date: "2022-01-09 00:00:00+00:00"
-    nullable_name: ~
     prev_month_date: "2021-12-01 00:00:00"
     prev_iso_week_date: 52
     first_day_prev_iso_week_date: "2021-12-27 00:00:00"
-  - price_per_l: 0.060
-    alcohol_degree: 8.749609
-    name: Brugse Zot blonde
-    cost: 1.79
-    beer_kind: Blonde
-    volume_ml: 330.0
+  - name: Brugse Zot blonde
     brewing_date: "2022-01-10 00:00:00+00:00"
-    nullable_name: Brugse Zot blonde
     prev_month_date: "2021-12-01 00:00:00"
     prev_iso_week_date: 1
     first_day_prev_iso_week_date: "2022-01-03 00:00:00"
   schema:
     fields:
-    - name: price_per_l
-      type: number
-    - name: alcohol_degree
-      type: number
     - name: name
-      type: string
-    - name: cost
-      type: number
-    - name: beer_kind
-      type: string
-    - name: volume_ml
-      type: number
-    - name: nullable_name
       type: string
     - name: brewing_date
       type: datetime

--- a/server/tests/backends/fixtures/dateextract/google_big_query_timestamps.yaml
+++ b/server/tests/backends/fixtures/dateextract/google_big_query_timestamps.yaml
@@ -8,10 +8,13 @@ exclude:
   - snowflake
   - snowflake_pypika
 step:
+  table_columns:
+    - name
+    - brewing_date
   pipeline:
     - name: customsql
     # Set brewing_date as TIMESTAMP type
-      query: "SELECT `price_per_l`,`alcohol_degree`,`name`,`cost`,`beer_kind`,`volume_ml`,`nullable_name`, CAST(`brewing_date` AS TIMESTAMP) AS `brewing_date` FROM `beers.beers_tiny` WHERE beer_kind = 'Blonde'"
+      query: "SELECT `name`, CAST(`brewing_date` AS TIMESTAMP) AS `brewing_date` FROM `beers.beers_tiny` WHERE beer_kind = 'Blonde'"
     # First day of previous month
     - name: dateextract
       column: brewing_date
@@ -30,54 +33,24 @@ step:
 
 expected:
   data:
-  - price_per_l: 0.070
-    alcohol_degree: 8.930645
-    name: Cuvée des Trolls
-    cost: 1.55
-    beer_kind: Blonde
-    volume_ml: 250.0
+  - name: Cuvée des Trolls
     brewing_date: "2022-01-05 00:00:00+00:00"
-    nullable_name: ~
     prev_month_date: "2021-12-01 00:00:00"
     prev_iso_week_date: 52
     first_day_prev_iso_week_date: "2021-12-27 00:00:00"
-  - price_per_l: 0.065
-    alcohol_degree: 7.747466
-    name: Brasserie De Sutter Brin de Folie
-    cost: 2.19
-    beer_kind: Blonde
-    volume_ml: 330.0
+  - name: Brasserie De Sutter Brin de Folie
     brewing_date: "2022-01-09 00:00:00+00:00"
-    nullable_name: ~
     prev_month_date: "2021-12-01 00:00:00"
     prev_iso_week_date: 52
     first_day_prev_iso_week_date: "2021-12-27 00:00:00"
-  - price_per_l: 0.060
-    alcohol_degree: 8.749609
-    name: Brugse Zot blonde
-    cost: 1.79
-    beer_kind: Blonde
-    volume_ml: 330.0
+  - name: Brugse Zot blonde
     brewing_date: "2022-01-10 00:00:00+00:00"
-    nullable_name: Brugse Zot blonde
     prev_month_date: "2021-12-01 00:00:00"
     prev_iso_week_date: 1
     first_day_prev_iso_week_date: "2022-01-03 00:00:00"
   schema:
     fields:
-    - name: price_per_l
-      type: number
-    - name: alcohol_degree
-      type: number
     - name: name
-      type: string
-    - name: cost
-      type: number
-    - name: beer_kind
-      type: string
-    - name: volume_ml
-      type: number
-    - name: nullable_name
       type: string
     - name: brewing_date
       type: datetime

--- a/server/tests/backends/fixtures/dateextract/google_big_query_timestamps.yaml
+++ b/server/tests/backends/fixtures/dateextract/google_big_query_timestamps.yaml
@@ -1,0 +1,90 @@
+exclude:
+  - pandas
+  - mongo
+  - athena_pypika
+  - mysql_pypika
+  - postgres_pypika
+  - redshift_pypika
+  - snowflake
+  - snowflake_pypika
+step:
+  pipeline:
+    - name: customsql
+    # Set brewing_date as TIMESTAMP type
+      query: "SELECT `price_per_l`,`alcohol_degree`,`name`,`cost`,`beer_kind`,`volume_ml`,`nullable_name`, CAST(`brewing_date` AS TIMESTAMP) AS `brewing_date` FROM `beers.beers_tiny` WHERE beer_kind = 'Blonde'"
+    # First day of previous month
+    - name: dateextract
+      column: brewing_date
+      dateInfo: [ "firstDayOfPreviousMonth" ]
+      newColumns: [ "prev_month_date" ]
+    # Previous ISO week
+    - name: dateextract
+      column: brewing_date
+      dateInfo: [ "previousIsoWeek" ]
+      newColumns: [ "prev_iso_week_date" ]
+    # First day of previous ISO week
+    - name: dateextract
+      column: brewing_date
+      dateInfo: [ "firstDayOfPreviousIsoWeek" ]
+      newColumns: [ "first_day_prev_iso_week_date" ]
+
+expected:
+  data:
+  - price_per_l: 0.070
+    alcohol_degree: 8.930645
+    name: Cuvée des Trolls
+    cost: 1.55
+    beer_kind: Blonde
+    volume_ml: 250.0
+    brewing_date: "2022-01-05 00:00:00+00:00"
+    nullable_name: ~
+    prev_month_date: "2021-12-01 00:00:00"
+    prev_iso_week_date: 52
+    first_day_prev_iso_week_date: "2021-12-27 00:00:00"
+  - price_per_l: 0.065
+    alcohol_degree: 7.747466
+    name: Brasserie De Sutter Brin de Folie
+    cost: 2.19
+    beer_kind: Blonde
+    volume_ml: 330.0
+    brewing_date: "2022-01-09 00:00:00+00:00"
+    nullable_name: ~
+    prev_month_date: "2021-12-01 00:00:00"
+    prev_iso_week_date: 52
+    first_day_prev_iso_week_date: "2021-12-27 00:00:00"
+  - price_per_l: 0.060
+    alcohol_degree: 8.749609
+    name: Brugse Zot blonde
+    cost: 1.79
+    beer_kind: Blonde
+    volume_ml: 330.0
+    brewing_date: "2022-01-10 00:00:00+00:00"
+    nullable_name: Brugse Zot blonde
+    prev_month_date: "2021-12-01 00:00:00"
+    prev_iso_week_date: 1
+    first_day_prev_iso_week_date: "2022-01-03 00:00:00"
+  schema:
+    fields:
+    - name: price_per_l
+      type: number
+    - name: alcohol_degree
+      type: number
+    - name: name
+      type: string
+    - name: cost
+      type: number
+    - name: beer_kind
+      type: string
+    - name: volume_ml
+      type: number
+    - name: nullable_name
+      type: string
+    - name: brewing_date
+      type: datetime
+    - name: prev_month_date
+      type: datetime
+    - name: prev_iso_week_date
+      type: number
+    - name: first_day_prev_iso_week_date
+      type: datetime
+    pandas_version: 1.4.0

--- a/server/tests/backends/sql_translator_integration_tests/test_sql_bigquery_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_bigquery_translator_steps.py
@@ -58,15 +58,17 @@ def test_bigquery_translator_pipeline(
 
     if pipeline_spec["step"]["pipeline"][0]["name"] == "customsql":
         steps = pipeline_spec["step"]["pipeline"]
+        table_columns = pipeline_spec["step"].get("table_columns", _BEERS_TABLE_COLUMNS)
     else:
         steps = [{"name": "domain", "domain": "beers_tiny"}] + pipeline_spec["step"]["pipeline"]
+        table_columns = _BEERS_TABLE_COLUMNS
 
     pipeline = PipelineWithVariables(steps=steps).render(available_variables, nosql_apply_parameters_to_query)
 
     query = translate_pipeline(
         sql_dialect=SQLDialect.GOOGLEBIGQUERY,
         pipeline=pipeline,
-        tables_columns={"beers_tiny": _BEERS_TABLE_COLUMNS},
+        tables_columns={"beers_tiny": table_columns},
         db_schema="beers",
     )
     expected = pd.read_json(json.dumps(pipeline_spec["expected"]), orient="table")

--- a/server/tests/backends/sql_translator_integration_tests/test_sql_bigquery_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_bigquery_translator_steps.py
@@ -71,5 +71,4 @@ def test_bigquery_translator_pipeline(
     )
     expected = pd.read_json(json.dumps(pipeline_spec["expected"]), orient="table")
     result = bigquery_client.query(query).result().to_dataframe()
-
     assert_dataframes_equals(expected, result)

--- a/server/tests/backends/sql_translator_integration_tests/test_sql_bigquery_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_bigquery_translator_steps.py
@@ -56,7 +56,11 @@ def test_bigquery_translator_pipeline(
 ):
     pipeline_spec = get_spec_from_json_fixture(case_id, case_spec_file)
 
-    steps = [{"name": "domain", "domain": "beers_tiny"}] + pipeline_spec["step"]["pipeline"]
+    if pipeline_spec["step"]["pipeline"][0]["name"] == "customsql":
+        steps = pipeline_spec["step"]["pipeline"]
+    else:
+        steps = [{"name": "domain", "domain": "beers_tiny"}] + pipeline_spec["step"]["pipeline"]
+
     pipeline = PipelineWithVariables(steps=steps).render(available_variables, nosql_apply_parameters_to_query)
 
     query = translate_pipeline(
@@ -67,4 +71,5 @@ def test_bigquery_translator_pipeline(
     )
     expected = pd.read_json(json.dumps(pipeline_spec["expected"]), orient="table")
     result = bigquery_client.query(query).result().to_dataframe()
+
     assert_dataframes_equals(expected, result)


### PR DESCRIPTION
## What
 - Cast field to datetime in DATE_ADD google big query method
 
 ## Why
  - Raises error in `dateextract` step : 
  `BadRequest('DATE_ADD does not support the WEEK date part when the argument is TIMESTAMP type at [1:318]')`