### PR TITLE
fix(pandas): handle out of bounds dates in filter from/until [TCTC-8867]

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+ - Pandas: when filtering dates with from/until, filtering before 1677 and/or after 2262 now ignores the filter
+   instead of crashing.
+
 ## [0.45.5] - 2024-06-17
 
 ### Fixed

--- a/server/src/weaverbird/backends/pandas_executor/steps/utils/condition.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/utils/condition.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from numpy.ma import logical_and, logical_or
 from pandas import DataFrame, Series, Timestamp
 from pandas import to_datetime as pd_to_datetime
+from pandas.errors import OutOfBoundsDatetime
 from pandas.tseries.offsets import DateOffset
 
 from weaverbird.backends.pandas_executor.steps.utils.dates import evaluate_relative_date
@@ -70,7 +71,12 @@ def apply_condition(condition: Condition, df: DataFrame) -> Series:
         else:
             raise NotImplementedError
 
-        value = _date_bound_condition_to_tz_aware_timestamp(condition.value)
+        try:
+            value = _date_bound_condition_to_tz_aware_timestamp(condition.value)
+        except OutOfBoundsDatetime:
+            # we're probably filtering dates using a too wide date range (eg: from year 1000 to 9999),
+            # let's assume it should return all lines unfiltered (except the null ones)
+            return df[condition.column].notnull()
 
         # Remove time info from the column to filter on. Using utc=True to ensure we have time-aware
         # objects. Since we're only using this for comparison, the input column is not modified,

--- a/server/src/weaverbird/backends/pandas_executor/steps/utils/condition.py
+++ b/server/src/weaverbird/backends/pandas_executor/steps/utils/condition.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import UTC, datetime
 
 from numpy.ma import logical_and, logical_or
@@ -74,6 +75,9 @@ def apply_condition(condition: Condition, df: DataFrame) -> Series:
         try:
             value = _date_bound_condition_to_tz_aware_timestamp(condition.value)
         except OutOfBoundsDatetime:
+            logging.getLogger(__name__).warning(
+                f"filtering dates {condition.operator} {condition.value} is out of bound: ignoring"
+            )
             # we're probably filtering dates using a too wide date range (eg: from year 1000 to 9999),
             # let's assume it should return all lines unfiltered (except the null ones)
             return df[condition.column].notnull()

--- a/server/tests/backends/fixtures/filter/dates_from_until_too_wide.json
+++ b/server/tests/backends/fixtures/filter/dates_from_until_too_wide.json
@@ -1,0 +1,89 @@
+{
+  "exclude": [
+    "athena_pypika",
+    "bigquery_pypika",
+    "mysql_pypika",
+    "postgres_pypika",
+    "redshift_pypika",
+    "snowflake_pypika"
+  ],
+  "step": {
+    "pipeline": [
+      {
+        "name": "filter",
+        "condition": {
+          "and": [
+            {
+              "column": "CREATED",
+              "operator": "from",
+              "value": "0023-02-01T00:00:00.000Z"
+            },
+            {
+              "column": "CREATED",
+              "operator": "until",
+              "value": "9923-02-01T00:00:00.000Z"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "input": {
+    "schema": {
+      "fields": [
+        {
+          "name": "NAME",
+          "type": "string"
+        },
+        {
+          "name": "AGE",
+          "type": "integer"
+        },
+        {
+          "name": "CREATED",
+          "type": "datetime"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "NAME": "foo",
+        "AGE": 42,
+        "CREATED": "2023-01-01T00:00:00.000Z"
+      },
+      {
+        "NAME": "bar",
+        "AGE": 43,
+        "CREATED": null
+      }
+    ]
+  },
+  "expected": {
+    "schema": {
+      "fields": [
+        {
+          "name": "NAME",
+          "type": "string"
+        },
+        {
+          "name": "AGE",
+          "type": "number"
+        },
+        {
+          "name": "CREATED",
+          "type": "datetime",
+          "tz": "UTC"
+        }
+      ],
+      "pandas_version": "0.20.0"
+    },
+    "data": [
+      {
+        "NAME": "foo",
+        "AGE": 42,
+        "CREATED": "2023-01-01T00:00:00.000Z"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Ces dates "ouf of bounds" arrivent par exemple quand on sélectionne "all dates" dans un filtre (ça génère from year 1000 to year 9999)
(en attendant un meilleur fix qui consisterait à envoyer des `__void__` pour ces variables)

jira card: https://toucantoco.atlassian.net/browse/TCTC-8867