### PR TITLE
fix(ui): allow typing column name where it was forgotten TCTC-9216

### DIFF
--- a/ui/src/components/stepforms/ArgmaxStepForm.vue
+++ b/ui/src/components/stepforms/ArgmaxStepForm.vue
@@ -16,7 +16,6 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :trusted-variable-delimiters="trustedVariableDelimiters"
-      :allowCustom="true"
     />
     <MultiselectWidget
       class="groupbyColumnsInput"
@@ -29,6 +28,7 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :trusted-variable-delimiters="trustedVariableDelimiters"
+      :allowCustom="true"
     />
     <StepFormButtonbar />
   </div>

--- a/ui/src/components/stepforms/HierarchyStepForm.vue
+++ b/ui/src/components/stepforms/HierarchyStepForm.vue
@@ -22,6 +22,7 @@
       :automatic-new-field="false"
       data-path=".hierarchy"
       :errors="errors"
+      :componentProps="{ allowCustom: true }"
     />
     <CheckboxWidget label="Include null values in results" v-model="editedStep.includeNulls" />
     <StepFormButtonbar />

--- a/ui/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/ui/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -15,6 +15,7 @@
         placeholder="Column"
         :data-path="`${dataPath}.column`"
         :errors="errors"
+        :allowCustom="true"
       />
     </div>
     <div

--- a/ui/src/components/stepforms/widgets/SortColumn.vue
+++ b/ui/src/components/stepforms/widgets/SortColumn.vue
@@ -9,6 +9,7 @@
       placeholder="Enter a column"
       :data-path="`${dataPath}[0]`"
       :errors="errors"
+      :allowCustom="true"
     />
     <AutocompleteWidget
       class="sortOrderInput"

--- a/ui/src/components/stepforms/widgets/TotalDimensions.vue
+++ b/ui/src/components/stepforms/widgets/TotalDimensions.vue
@@ -10,6 +10,7 @@
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :trusted-variable-delimiters="trustedVariableDelimiters"
+      :allowCustom="true"
     />
     <InputTextWidget
       class="widget-totals__total-rows-label"


### PR DESCRIPTION
In #2229 , I forgot some widgets where we also need to be able to type column names