### PR TITLE
fix(step-form-component): provide step form defaults and preselect column if necessary in complex steps [TCTC-9437]

### DIFF
--- a/ui/src/components/stepforms/StepFormComponent.vue
+++ b/ui/src/components/stepforms/StepFormComponent.vue
@@ -5,6 +5,7 @@
     ref="step"
     :translator="translator"
     :initialStepValue="initialStepValue"
+    :stepFormDefaults="stepFormDefaults"
     :isStepCreation="isStepCreation"
     :columnTypes="columnTypes"
     :backendError="backendError"
@@ -89,6 +90,10 @@ export default class StepFormComponent extends Vue {
     pipelineNameOrDomain: string | ReferenceToExternalQuery,
   ) => Promise<string[] | undefined>;
 
+  // some complex steps use selectedColumns to preselect column (rename, filter...)
+  @Prop({})
+  selectedColumn?: string;
+
   get isStepCreation() {
     return this.initialStepValue === undefined;
   }
@@ -105,7 +110,7 @@ export default class StepFormComponent extends Vue {
     this.$emit('formSaved', step);
   }
 
-  selectedColumns: string[] = [];
+  selectedColumns: string[] = this.selectedColumn ? [this.selectedColumn] : [];
 
   setSelectedColumns({ column }: { column: string | undefined }) {
     if (!!column && column !== this.selectedColumns[0]) {

--- a/ui/src/components/stepforms/StoreStepFormComponent.vue
+++ b/ui/src/components/stepforms/StoreStepFormComponent.vue
@@ -5,6 +5,7 @@
     ref="step"
     :translator="translator"
     :initialStepValue="initialStepValue"
+    :stepFormDefaults="stepFormDefaults"
     :isStepCreation="isStepCreation"
     :columnTypes="columnTypes"
     :backendError="backendError"

--- a/ui/stories/StepForm.stories.ts
+++ b/ui/stories/StepForm.stories.ts
@@ -127,7 +127,7 @@ export const Edition: StoryObj<StepFormComponent> = {
     variables: VARIABLES,
     initialStepValue: {
       text: 'Text value',
-      newColumn: 'a'
+      newColumn: 'a',
     },
     interpolateFunc: (a) => a,
     getColumnNamesFromPipeline: () => Promise.resolve(['c', 'd']),
@@ -158,7 +158,7 @@ export const WithDefaults: StoryObj<StepFormComponent> = {
     variableDelimiters: { start: '<%=', end: '%>' },
     trustedVariableDelimiters: { start: '{{', end: '}}' },
     stepFormDefaults: {
-      newColumn: 'd'
+      newColumn: 'd',
     },
     variables: VARIABLES,
     interpolateFunc: (a) => a,

--- a/ui/stories/StepForm.stories.ts
+++ b/ui/stories/StepForm.stories.ts
@@ -105,3 +105,98 @@ export const Default: StoryObj<StepFormComponent> = {
     },
   },
 };
+
+export const Edition: StoryObj<StepFormComponent> = {
+  render: (args, { argTypes }) => ({
+    components: { StepFormComponent },
+    props: Object.keys(argTypes),
+    template: '<StepFormComponent v-bind="$props" @formSaved="onFormSaved" @back="onBack" />',
+    methods: {
+      onFormSaved: action('formSaved'),
+      onBack: action('back'),
+    },
+  }),
+  args: {
+    name: 'text',
+    availableDomains: [{ name: 'other_domain', uid: 'other_domain' }],
+    unjoinableDomains: [],
+    columnTypes: { a: 'string', b: 'boolean' },
+    availableVariables: SAMPLE_VARIABLES,
+    variableDelimiters: { start: '<%=', end: '%>' },
+    trustedVariableDelimiters: { start: '{{', end: '}}' },
+    variables: VARIABLES,
+    initialStepValue: {
+      text: 'Text value',
+      newColumn: 'a'
+    },
+    interpolateFunc: (a) => a,
+    getColumnNamesFromPipeline: () => Promise.resolve(['c', 'd']),
+  },
+  argTypes: {
+    name: {
+      disable: true,
+    },
+  },
+};
+
+export const WithDefaults: StoryObj<StepFormComponent> = {
+  render: (args, { argTypes }) => ({
+    components: { StepFormComponent },
+    props: Object.keys(argTypes),
+    template: '<StepFormComponent v-bind="$props" @formSaved="onFormSaved" @back="onBack" />',
+    methods: {
+      onFormSaved: action('formSaved'),
+      onBack: action('back'),
+    },
+  }),
+  args: {
+    name: 'text',
+    availableDomains: [{ name: 'other_domain', uid: 'other_domain' }],
+    unjoinableDomains: [],
+    columnTypes: { a: 'string', b: 'boolean' },
+    availableVariables: SAMPLE_VARIABLES,
+    variableDelimiters: { start: '<%=', end: '%>' },
+    trustedVariableDelimiters: { start: '{{', end: '}}' },
+    stepFormDefaults: {
+      newColumn: 'd'
+    },
+    variables: VARIABLES,
+    interpolateFunc: (a) => a,
+    getColumnNamesFromPipeline: () => Promise.resolve(['c', 'd']),
+  },
+  argTypes: {
+    name: {
+      disable: true,
+    },
+  },
+};
+
+export const WithPreselectedColumn: StoryObj<StepFormComponent> = {
+  render: (args, { argTypes }) => ({
+    components: { StepFormComponent },
+    props: Object.keys(argTypes),
+    template: '<StepFormComponent v-bind="$props" @formSaved="onFormSaved" @back="onBack" />',
+    methods: {
+      onFormSaved: action('formSaved'),
+      onBack: action('back'),
+    },
+  }),
+  args: {
+    name: 'filter',
+    availableDomains: [{ name: 'other_domain', uid: 'other_domain' }],
+    unjoinableDomains: [],
+    columnTypes: { a: 'string', b: 'boolean' },
+    availableVariables: SAMPLE_VARIABLES,
+    variableDelimiters: { start: '<%=', end: '%>' },
+    trustedVariableDelimiters: { start: '{{', end: '}}' },
+    selectedColumn: 'a',
+    variables: VARIABLES,
+    interpolateFunc: (a) => a,
+    getColumnNamesFromPipeline: () => Promise.resolve(['c', 'd']),
+  },
+  argTypes: {
+    name: {
+      disable: true,
+    },
+  },
+};


### PR DESCRIPTION
Form was not working as expected with defaults values (partial config), due to missing props propagation
We also need to add a selectedColumn property because some complex steps (filter, rename...) preselect column not based on defaults but on selectedColumns logic