### PR TITLE
fix(ui): declare css export

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.115.2] - 2024-10-08
+
 ### Fixed
 
 - Declare `./dist/style.css` export
@@ -1603,6 +1605,7 @@ TabbedRangeCalendars: keep selected tab unchanged when updated enabled calendars
 
 - Initial version, showtime!
 
+[0.115.2]: https://github.com/ToucanToco/weaverbird/compare/v0.115.1...v0.115.2
 [0.115.1]: https://github.com/ToucanToco/weaverbird/compare/v0.115.0...v0.115.1
 [0.115.0]: https://github.com/ToucanToco/weaverbird/compare/v0.114.1...v0.115.0
 [0.114.1]: https://github.com/ToucanToco/weaverbird/compare/v0.114.0...v0.114.1

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Declare `./dist/style.css` export
+
 ## [0.115.1] - 2024-09-27
 
 ### Fixed

--- a/ui/package.json
+++ b/ui/package.json
@@ -31,7 +31,8 @@
         "default": "./dist/weaverbird.js"
       },
       "require": "./dist/weaverbird.umd.cjs"
-    }
+    },
+    "./dist/style.css": "./dist/style.css"
   },
   "types": "./dist/types/types.d.ts",
   "scripts": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaverbird",
-  "version": "0.115.1",
+  "version": "0.115.2",
   "description": "A generic Visual Query Builder built in Vue.js",
   "bugs": {
     "url": "https://github.com/ToucanToco/weaverbird/issues",


### PR DESCRIPTION
While consuming the NPM package, exports needs to be defined explicitly in order to not raise errors when imported. 

See https://webpack.js.org/guides/package-exports/ and https://nodejs.org/api/packages.html#subpath-exports