### PR TITLE
fix(step-form-component): handle reactivity for selected column

### DIFF
--- a/ui/src/components/stepforms/StepFormComponent.vue
+++ b/ui/src/components/stepforms/StepFormComponent.vue
@@ -1,6 +1,6 @@
 <template>
   <component
-    key="stepForm"
+    :key="`${name}__${selectedColumn}`"
     :is="formComponent"
     ref="step"
     :translator="translator"
@@ -25,7 +25,7 @@
 </template>
 <script lang="ts">
 import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
+import { Component, Prop, Watch } from 'vue-property-decorator';
 import type { PipelineStep, PipelineStepName, ReferenceToExternalQuery } from '@/lib/steps';
 import StepFormsComponents from './index';
 import { VariableDelimiters, VariablesBucket } from '@/types';
@@ -116,6 +116,11 @@ export default class StepFormComponent extends Vue {
     if (!!column && column !== this.selectedColumns[0]) {
       this.selectedColumns = [column];
     }
+  }
+
+  @Watch('selectedColumn')
+  onSelectedColumnChanged() {
+    this.setSelectedColumns({ column: this.selectedColumn })
   }
 }
 </script>

--- a/ui/src/components/stepforms/StepFormComponent.vue
+++ b/ui/src/components/stepforms/StepFormComponent.vue
@@ -120,7 +120,7 @@ export default class StepFormComponent extends Vue {
 
   @Watch('selectedColumn')
   onSelectedColumnChanged() {
-    this.setSelectedColumns({ column: this.selectedColumn })
+    this.setSelectedColumns({ column: this.selectedColumn });
   }
 }
 </script>


### PR DESCRIPTION
I missed reactivity for selected column in weaverbird data viewer migration, it results to selected column not working as expected in migrated code

Watch update state value
Key update form component (because it not watch anything, it only apply state on init based on selected column so we need a full refresh)