### PR TITLE
fix(variable-input): always display variable input

### DIFF
--- a/ui/src/components/stepforms/widgets/Autocomplete.vue
+++ b/ui/src/components/stepforms/widgets/Autocomplete.vue
@@ -15,10 +15,10 @@
     >
       <multiselect
         :value="value"
-        :class="{ 
-          'widget-autocomplete__multiselect--with-example': withExample, 
-          'multiselect--with-variables': availableVariables
-          }"
+        :class="{
+          'widget-autocomplete__multiselect--with-example': withExample,
+          'multiselect--with-variables': availableVariables,
+        }"
         :options="options"
         :placeholder="placeholder"
         :allow-empty="false"

--- a/ui/src/components/stepforms/widgets/Autocomplete.vue
+++ b/ui/src/components/stepforms/widgets/Autocomplete.vue
@@ -15,7 +15,10 @@
     >
       <multiselect
         :value="value"
-        :class="{ 'widget-autocomplete__multiselect--with-example': withExample }"
+        :class="{ 
+          'widget-autocomplete__multiselect--with-example': withExample, 
+          'multiselect--with-variables': availableVariables
+          }"
         :options="options"
         :placeholder="placeholder"
         :allow-empty="false"
@@ -203,6 +206,10 @@ export default class AutocompleteWidget extends FormWidget {
 .widget-autocomplete__container .multiselect__content-wrapper {
   min-width: 100%;
   width: auto;
+}
+
+.multiselect--with-variables .multiselect__single {
+  padding-right: 28px;
 }
 
 .multiselect__single,

--- a/ui/src/components/stepforms/widgets/InputDate.vue
+++ b/ui/src/components/stepforms/widgets/InputDate.vue
@@ -18,7 +18,7 @@
         ref="input"
         class="widget-input-date"
         :class="{
-          'widget-input--with-variables': availableVariables
+          'widget-input--with-variables': availableVariables,
         }"
         :placeholder="placeholder"
         type="date"

--- a/ui/src/components/stepforms/widgets/InputDate.vue
+++ b/ui/src/components/stepforms/widgets/InputDate.vue
@@ -17,6 +17,9 @@
       <input
         ref="input"
         class="widget-input-date"
+        :class="{
+          'widget-input--with-variables': availableVariables
+        }"
         :placeholder="placeholder"
         type="date"
         :value="parsedValue"
@@ -121,5 +124,10 @@ export default class InputDateWidget extends FormWidget {
   &:hover {
     color: $active-color;
   }
+}
+
+.widget-input--with-variables {
+  padding-right: 35px;
+  text-overflow: ellipsis;
 }
 </style>

--- a/ui/src/components/stepforms/widgets/InputNumber.vue
+++ b/ui/src/components/stepforms/widgets/InputNumber.vue
@@ -88,7 +88,7 @@ export default class InputNumberWidget extends FormWidget {
     return {
       'widget-input-number': true,
       'widget-input-number--focused': this.isFocused,
-      'widget-input--with-variables': !!this.availableVariables
+      'widget-input--with-variables': !!this.availableVariables,
     };
   }
 

--- a/ui/src/components/stepforms/widgets/InputNumber.vue
+++ b/ui/src/components/stepforms/widgets/InputNumber.vue
@@ -88,6 +88,7 @@ export default class InputNumberWidget extends FormWidget {
     return {
       'widget-input-number': true,
       'widget-input-number--focused': this.isFocused,
+      'widget-input--with-variables': !!this.availableVariables
     };
   }
 
@@ -140,5 +141,10 @@ export default class InputNumberWidget extends FormWidget {
   &:hover {
     color: $active-color;
   }
+}
+
+.widget-input--with-variables {
+  padding-right: 35px;
+  text-overflow: ellipsis;
 }
 </style>

--- a/ui/src/components/stepforms/widgets/InputText.vue
+++ b/ui/src/components/stepforms/widgets/InputText.vue
@@ -18,7 +18,7 @@
         ref="input"
         class="widget-input-text"
         :class="{
-          'widget-input--with-variables': availableVariables
+          'widget-input--with-variables': availableVariables,
         }"
         data-cy="weaverbird-input-text"
         :placeholder="placeholder"

--- a/ui/src/components/stepforms/widgets/InputText.vue
+++ b/ui/src/components/stepforms/widgets/InputText.vue
@@ -17,6 +17,9 @@
       <input
         ref="input"
         class="widget-input-text"
+        :class="{
+          'widget-input--with-variables': availableVariables
+        }"
         data-cy="weaverbird-input-text"
         :placeholder="placeholder"
         type="text"
@@ -115,5 +118,10 @@ export default class InputTextWidget extends FormWidget {
   &:hover {
     color: $active-color;
   }
+}
+
+.widget-input--with-variables {
+  padding-right: 35px;
+  text-overflow: ellipsis;
 }
 </style>

--- a/ui/src/components/stepforms/widgets/MultiInputText.vue
+++ b/ui/src/components/stepforms/widgets/MultiInputText.vue
@@ -12,9 +12,9 @@
     >
       <multiselect
         class="widget-multiinputtext__multiselect"
-        :class="{ 
-          'widget-multiinputtext__multiselect--big': isMultiselectBig, 
-          'multiselect--with-variables': availableVariables 
+        :class="{
+          'widget-multiinputtext__multiselect--big': isMultiselectBig,
+          'multiselect--with-variables': availableVariables,
         }"
         :value="value"
         @input="updateValue"

--- a/ui/src/components/stepforms/widgets/MultiInputText.vue
+++ b/ui/src/components/stepforms/widgets/MultiInputText.vue
@@ -12,7 +12,10 @@
     >
       <multiselect
         class="widget-multiinputtext__multiselect"
-        :class="{ 'widget-multiinputtext__multiselect--big': isMultiselectBig }"
+        :class="{ 
+          'widget-multiinputtext__multiselect--big': isMultiselectBig, 
+          'multiselect--with-variables': availableVariables 
+        }"
         :value="value"
         @input="updateValue"
         :options="options"
@@ -185,6 +188,11 @@ export default class MultiInputTextWidget extends Vue {
   line-height: 20px;
   padding-left: 5px;
 }
+
+.multiselect--with-variables .multiselect__single {
+  padding-right: 28px;
+}
+
 .multiselect__single {
   background-color: transparent;
   color: $base-color-light;

--- a/ui/src/components/stepforms/widgets/VariableInput.vue
+++ b/ui/src/components/stepforms/widgets/VariableInput.vue
@@ -13,6 +13,7 @@
       </div>
     </div>
     <VariableInputBase
+      :isVariable="isVariable"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :trusted-variable-delimiters="trustedVariableDelimiters"

--- a/ui/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
+++ b/ui/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
@@ -12,6 +12,7 @@
         class="widget-variable__toggle"
         :class="{
           'widget-variable__toggle--choosing': isChoosingVariable,
+          'widget-variable__toggle--hidden': isVariable,
           'widget-variable__toggle--parent-arrow': hasArrow,
         }"
         @click.stop="startChoosingVariable"
@@ -80,6 +81,9 @@ export default class VariableInputBase extends Vue {
 
   @Prop({ default: false })
   hasArrow!: boolean;
+
+  @Prop({ default: false })
+  isVariable!: boolean;
 
   isChoosingVariable = false;
 
@@ -208,8 +212,6 @@ export default class VariableInputBase extends Vue {
 }
 
 .widget-variable__toggle {
-  opacity: 0;
-  visibility: hidden;
   display: block;
   position: absolute;
   top: 0;
@@ -229,10 +231,12 @@ export default class VariableInputBase extends Vue {
 
   &:hover,
   &.widget-variable__toggle--choosing {
-    opacity: 1;
-    visibility: visible;
     background: $active-color;
     color: #eaeff5;
+  }
+
+  &.widget-variable__toggle--hidden {
+    display: none;
   }
 
   &.widget-variable__toggle--parent-arrow {


### PR DESCRIPTION
We modify the variable button display to always make it visible.
We also add a padding to components that use it (Input/Autocomplete) in order to display labels correctly as there is an extra element in it.

Before:
![before1](https://github.com/user-attachments/assets/a7915976-6c23-4cbe-8bb8-9189308c3a93)
![before2](https://github.com/user-attachments/assets/d5440d99-b54e-4c3a-aee6-6a1acfd9a161)

After:
![after1](https://github.com/user-attachments/assets/1a8c76ed-1e84-4ba1-b33e-e40d57e49fa2)
![after2](https://github.com/user-attachments/assets/66f64c65-8255-4a51-aef2-bea6639d9e3c)
