### PR TITLE
feat(ui, variables): send mixpanel event [TCTC-10072]

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Form: clicking on variables button `{}` sends `Variables button clicked` mixpanel event.
+
 ## [0.115.4] - 2024-01-24
 
 ### Changed

--- a/ui/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
+++ b/ui/src/components/stepforms/widgets/VariableInputs/VariableInputBase.vue
@@ -48,6 +48,7 @@ import type { VariableDelimiters, VariablesBucket } from '@/lib/variables';
 
 import AdvancedVariableModal from './AdvancedVariableModal.vue';
 import VariableChooser from './VariableChooser.vue';
+import { sendAnalytics } from '@/lib/send-analytics';
 
 /**
  * This component wraps an input of any type and allow modifing its value by one or multiple variables chosen from a list or an
@@ -128,6 +129,7 @@ export default class VariableInputBase extends Vue {
 
   startChoosingVariable() {
     this.isChoosingVariable = true;
+    sendAnalytics({ name: 'Variables button clicked' });
   }
 
   stopChoosingVariable() {

--- a/ui/tests/unit/variable-input-base.spec.ts
+++ b/ui/tests/unit/variable-input-base.spec.ts
@@ -1,13 +1,16 @@
 import type { Wrapper } from '@vue/test-utils';
 import { shallowMount } from '@vue/test-utils';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, SpyInstance, vi } from 'vitest';
 
 import VariableInputBase from '@/components/stepforms/widgets/VariableInputs/VariableInputBase.vue';
+import * as sendAnalyticsUtils from '@/lib/send-analytics';
 
 describe('Variable Input', () => {
   let wrapper: Wrapper<VariableInputBase>;
+  let sendAnalyticsSpy: SpyInstance;
 
   beforeEach(() => {
+    sendAnalyticsSpy = vi.spyOn(sendAnalyticsUtils, 'sendAnalytics');
     wrapper = shallowMount(VariableInputBase, {
       sync: false,
       propsData: {
@@ -142,6 +145,10 @@ describe('Variable Input', () => {
 
       it('should display the slot click handler', () => {
         expect(wrapper.find('.widget-variable__click-handler').exists()).toBe(true);
+      });
+
+      it('should send analytics event', () => {
+        expect(sendAnalyticsSpy).toHaveBeenCalledWith({ name: 'Variables button clicked' });
       });
 
       describe('when closing the popover', () => {


### PR DESCRIPTION
[TCTC-10072](https://toucantoco.atlassian.net/browse/TCTC-10072?atlOrigin=eyJpIjoiMTBiMDJlODVlZDMzNGEzMmI2NTQzZDU0MmRiNzg2MzIiLCJwIjoiaiJ9):
> As we want to be able to better track feature usage we want to add some Mixpanel events to the addition we’ve done on weaverbird: [fix(variable-input): always display variable input](https://github.com/ToucanToco/weaverbird/pull/2333)
> - Click on variable button

This PR adds the analytics event on the click, and the unit test to match.

[TCTC-10072]: https://toucantoco.atlassian.net/browse/TCTC-10072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ