### PR TITLE
refactor!(server/pipeline): raise UndefinedVariableError when variables are missing during rendering [TCTC-10013]

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+-  Missing variables during rendering now raises `UndefinedVariableError` instead of validation errors.
+
 ## [0.51.2] - 2025-02-20
 
 ### Fixed

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Changed
--  Missing variables during rendering now raises `UndefinedVariableError` instead of validation errors.
+- Missing variables during rendering now cause a `UndefinedVariableError`  to be raised instead of a `ValidationError`.
 
 ## [0.51.2] - 2025-02-20
 

--- a/server/src/weaverbird/utils/toucan_connectors.py
+++ b/server/src/weaverbird/utils/toucan_connectors.py
@@ -1,0 +1,11 @@
+from toucan_connectors.common import nosql_apply_parameters_to_query
+
+
+def nosql_apply_parameters_to_query_with_errors(
+    query: dict | list[dict] | tuple | str, parameters: dict | None, **kwargs
+):
+    """
+    When a variable is missing, it may lead to undefined values and therefore pydantic validation errors.
+    Instead, we want UndefinedVariableError so we force `handle_errors=True` which does exactly this.
+    """
+    return nosql_apply_parameters_to_query(query, parameters, handle_errors=True, **kwargs)

--- a/server/tests/backends/mongo_translator/test_mongo_translator_steps.py
+++ b/server/tests/backends/mongo_translator/test_mongo_translator_steps.py
@@ -8,11 +8,11 @@ import pandas as pd
 import pytest
 from pandas.api.types import is_bool_dtype, is_datetime64_any_dtype, is_numeric_dtype
 from pymongo import MongoClient
-from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import assert_dataframes_content_equals, get_spec_from_json_fixture, retrieve_case
 from weaverbird.backends.mongo_translator.mongo_pipeline_translator import translate_pipeline
 from weaverbird.pipeline import PipelineWithVariables
+from weaverbird.utils.toucan_connectors import nosql_apply_parameters_to_query_with_errors
 
 exec_type = "mongo"
 test_cases = retrieve_case("mongo_translator", exec_type)
@@ -96,7 +96,9 @@ def test_mongo_translator_pipeline(mongo_database, case_id, case_spec_file_path,
 
     # create query
     steps = spec["step"]["pipeline"]
-    pipeline = PipelineWithVariables(steps=steps).render(available_variables, nosql_apply_parameters_to_query)
+    pipeline = PipelineWithVariables(steps=steps).render(
+        available_variables, nosql_apply_parameters_to_query_with_errors
+    )
     query = translate_pipeline(pipeline)
     # execute query
     result = list(mongo_database[collection_uid].aggregate(query))

--- a/server/tests/backends/pandas_executor/test_pandas_executor_steps.py
+++ b/server/tests/backends/pandas_executor/test_pandas_executor_steps.py
@@ -4,11 +4,11 @@ from io import StringIO
 import geopandas as gpd
 import pandas as pd
 import pytest
-from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import assert_dataframes_equals, get_spec_from_json_fixture, retrieve_case
 from weaverbird.backends.pandas_executor import execute_pipeline
 from weaverbird.pipeline import PipelineWithVariables
+from weaverbird.utils.toucan_connectors import nosql_apply_parameters_to_query_with_errors
 
 test_cases = retrieve_case("pandas_executor", "pandas")
 
@@ -30,7 +30,9 @@ def test_pandas_execute_pipeline(case_id, case_spec_file_path, available_variabl
 
     steps = spec["step"]["pipeline"]
     steps.insert(0, {"name": "domain", "domain": "in"})
-    pipeline = PipelineWithVariables(steps=steps).render(available_variables, nosql_apply_parameters_to_query)
+    pipeline = PipelineWithVariables(steps=steps).render(
+        available_variables, nosql_apply_parameters_to_query_with_errors
+    )
 
     domains = {"in": df_in, **dfs_in_others}
     result = execute_pipeline(pipeline, domain_retriever=lambda x: domains[x])[0]

--- a/server/tests/backends/sql_translator_integration_tests/test_sql_athena_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_athena_translator_steps.py
@@ -7,12 +7,12 @@ import awswrangler as wr
 import pandas as pd
 import pytest
 from boto3 import Session
-from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import assert_dataframes_equals, get_spec_from_json_fixture, retrieve_case
 from weaverbird.backends.pypika_translator.dialects import SQLDialect
 from weaverbird.backends.pypika_translator.translate import translate_pipeline
 from weaverbird.pipeline import PipelineWithVariables
+from weaverbird.utils.toucan_connectors import nosql_apply_parameters_to_query_with_errors
 
 _REGION = environ["ATHENA_REGION"]
 _DB = environ["ATHENA_DATABASE"]
@@ -57,7 +57,9 @@ def test_athena_translator_pipeline(
     pipeline_spec = get_spec_from_json_fixture(case_id, case_spec_file)
 
     steps = [{"name": "domain", "domain": "beers_tiny"}] + pipeline_spec["step"]["pipeline"]
-    pipeline = PipelineWithVariables(steps=steps).render(available_variables, nosql_apply_parameters_to_query)
+    pipeline = PipelineWithVariables(steps=steps).render(
+        available_variables, nosql_apply_parameters_to_query_with_errors
+    )
 
     query = translate_pipeline(
         sql_dialect=SQLDialect.ATHENA,

--- a/server/tests/backends/sql_translator_integration_tests/test_sql_bigquery_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_bigquery_translator_steps.py
@@ -7,7 +7,6 @@ import pytest
 from google.cloud.bigquery import Client
 from google.oauth2 import service_account
 from pandas.api.types import is_datetime64_any_dtype
-from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import (
     _BEERS_TABLE_COLUMNS,
@@ -18,6 +17,7 @@ from tests.utils import (
 from weaverbird.backends.pypika_translator.dialects import SQLDialect
 from weaverbird.backends.pypika_translator.translate import translate_pipeline
 from weaverbird.pipeline import PipelineWithVariables
+from weaverbird.utils.toucan_connectors import nosql_apply_parameters_to_query_with_errors
 
 credentials = service_account.Credentials.from_service_account_info(
     info=json.loads(environ["GOOGLE_BIG_QUERY_CREDENTIALS"])
@@ -51,7 +51,9 @@ def test_bigquery_translator_pipeline(
         steps = [{"name": "domain", "domain": "beers_tiny"}] + pipeline_spec["step"]["pipeline"]
         table_columns = _BEERS_TABLE_COLUMNS
 
-    pipeline = PipelineWithVariables(steps=steps).render(available_variables, nosql_apply_parameters_to_query)
+    pipeline = PipelineWithVariables(steps=steps).render(
+        available_variables, nosql_apply_parameters_to_query_with_errors
+    )
 
     query = translate_pipeline(
         sql_dialect=SQLDialect.GOOGLEBIGQUERY,

--- a/server/tests/backends/sql_translator_integration_tests/test_sql_mysql_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_mysql_translator_steps.py
@@ -9,7 +9,6 @@ import pymysql
 import pytest
 from docker.types import Ulimit
 from sqlalchemy import create_engine, text
-from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import (
     _BEERS_TABLE_COLUMNS,
@@ -21,6 +20,7 @@ from tests.utils import (
 from weaverbird.backends.pypika_translator.dialects import SQLDialect
 from weaverbird.backends.pypika_translator.translate import translate_pipeline
 from weaverbird.pipeline import PipelineWithVariables
+from weaverbird.utils.toucan_connectors import nosql_apply_parameters_to_query_with_errors
 
 _CON_PARAMS = {
     "host": "127.0.0.1",
@@ -79,7 +79,9 @@ def test_sql_translator_pipeline(case_id: str, case_spec_file_path: str, engine:
 
     steps = spec["step"]["pipeline"]
     steps.insert(0, {"name": "domain", "domain": "beers_tiny"})
-    pipeline = PipelineWithVariables(steps=steps).render(available_variables, nosql_apply_parameters_to_query)
+    pipeline = PipelineWithVariables(steps=steps).render(
+        available_variables, nosql_apply_parameters_to_query_with_errors
+    )
 
     # Convert Pipeline object to Postgres Query
     query = translate_pipeline(

--- a/server/tests/backends/sql_translator_integration_tests/test_sql_postgres_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_postgres_translator_steps.py
@@ -9,7 +9,6 @@ import psycopg2
 import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine.base import OptionEngine
-from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import (
     _BEERS_TABLE_COLUMNS,
@@ -21,6 +20,7 @@ from tests.utils import (
 from weaverbird.backends.pypika_translator.dialects import SQLDialect
 from weaverbird.backends.pypika_translator.translate import translate_pipeline
 from weaverbird.pipeline import PipelineWithVariables
+from weaverbird.utils.toucan_connectors import nosql_apply_parameters_to_query_with_errors
 
 con_params = {
     "host": "127.0.0.1",
@@ -75,7 +75,9 @@ def test_sql_translator_pipeline(
 
     steps = spec["step"]["pipeline"]
     steps.insert(0, {"name": "domain", "domain": "beers_tiny"})
-    pipeline = PipelineWithVariables(steps=steps).render(available_variables, nosql_apply_parameters_to_query)
+    pipeline = PipelineWithVariables(steps=steps).render(
+        available_variables, nosql_apply_parameters_to_query_with_errors
+    )
 
     # Convert Pipeline object to Postgres Query
     query = translate_pipeline(

--- a/server/tests/backends/sql_translator_integration_tests/test_sql_redshift_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_redshift_translator_steps.py
@@ -7,12 +7,12 @@ import pandas as pd
 import pytest
 import redshift_connector
 from tenacity import retry, stop_after_attempt, wait_fixed
-from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import assert_dataframes_equals, get_spec_from_json_fixture, retrieve_case
 from weaverbird.backends.pypika_translator.dialects import SQLDialect
 from weaverbird.backends.pypika_translator.translate import translate_pipeline
 from weaverbird.pipeline import PipelineWithVariables
+from weaverbird.utils.toucan_connectors import nosql_apply_parameters_to_query_with_errors
 
 _HOST = environ["REDSHIFT_HOST"]
 _USER = environ["REDSHIFT_USER"]
@@ -51,7 +51,9 @@ def test_redshift_translator_pipeline(
     pipeline_spec = get_spec_from_json_fixture(case_id, case_spec_file)
 
     steps = [{"name": "domain", "domain": "beers_tiny"}] + pipeline_spec["step"]["pipeline"]
-    pipeline = PipelineWithVariables(steps=steps).render(available_variables, nosql_apply_parameters_to_query)
+    pipeline = PipelineWithVariables(steps=steps).render(
+        available_variables, nosql_apply_parameters_to_query_with_errors
+    )
 
     query = translate_pipeline(
         sql_dialect=SQLDialect.REDSHIFT,

--- a/server/tests/backends/sql_translator_integration_tests/test_sql_snowflake_translator_steps.py
+++ b/server/tests/backends/sql_translator_integration_tests/test_sql_snowflake_translator_steps.py
@@ -7,12 +7,12 @@ import pandas as pd
 import pytest
 from snowflake.sqlalchemy import URL
 from sqlalchemy import create_engine, text
-from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import assert_dataframes_equals, get_spec_from_json_fixture, retrieve_case
 from weaverbird.backends.pypika_translator.dialects import SQLDialect
 from weaverbird.backends.pypika_translator.translate import translate_pipeline
 from weaverbird.pipeline import PipelineWithVariables
+from weaverbird.utils.toucan_connectors import nosql_apply_parameters_to_query_with_errors
 
 _ACCOUNT = "toucantocopartner.west-europe.azure"
 _USER = "toucan_test"
@@ -57,7 +57,9 @@ def test_snowflake_translator_pipeline(engine: Any, case_id: str, case_spec_file
     pipeline_spec = get_spec_from_json_fixture(case_id, case_spec_file)
 
     steps = [{"name": "domain", "domain": "beers_tiny"}] + pipeline_spec["step"]["pipeline"]
-    pipeline = PipelineWithVariables(steps=steps).render(available_variables, nosql_apply_parameters_to_query)
+    pipeline = PipelineWithVariables(steps=steps).render(
+        available_variables, nosql_apply_parameters_to_query_with_errors
+    )
 
     query = translate_pipeline(
         sql_dialect=SQLDialect.SNOWFLAKE,

--- a/server/tests/steps/test_filter.py
+++ b/server/tests/steps/test_filter.py
@@ -11,15 +11,11 @@ from pandas.testing import assert_frame_equal
 
 from tests.utils import assert_dataframes_equals
 from weaverbird.backends.pandas_executor.steps.filter import execute_filter
-from weaverbird.pipeline.conditions import (
-    ComparisonCondition,
-    ConditionComboAnd,
-    DateBoundCondition,
-    nosql_apply_parameters_to_query_with_errors,
-)
+from weaverbird.pipeline.conditions import ComparisonCondition, ConditionComboAnd, DateBoundCondition
 from weaverbird.pipeline.dates import RelativeDateWithVariables
 from weaverbird.pipeline.steps import FilterStep
 from weaverbird.pipeline.steps.filter import FilterStepWithVariables
+from weaverbird.utils.toucan_connectors import nosql_apply_parameters_to_query_with_errors
 
 
 @pytest.fixture

--- a/server/tests/steps/test_filter.py
+++ b/server/tests/steps/test_filter.py
@@ -8,7 +8,6 @@ from zoneinfo import ZoneInfo
 import pytest
 from pandas import DataFrame, read_json
 from pandas.testing import assert_frame_equal
-from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import assert_dataframes_equals
 from weaverbird.backends.pandas_executor.steps.filter import execute_filter
@@ -16,6 +15,7 @@ from weaverbird.pipeline.conditions import (
     ComparisonCondition,
     ConditionComboAnd,
     DateBoundCondition,
+    nosql_apply_parameters_to_query_with_errors,
 )
 from weaverbird.pipeline.dates import RelativeDateWithVariables
 from weaverbird.pipeline.steps import FilterStep
@@ -439,7 +439,7 @@ def test_render_filter_step_with_variables(available_variables: dict[str, Any]) 
             "operator": "from",
         }
     )
-    rendered = step.render(available_variables, nosql_apply_parameters_to_query)
+    rendered = step.render(available_variables, nosql_apply_parameters_to_query_with_errors)
     assert rendered.condition.value == available_variables["TODAY"]
 
     step = FilterStepWithVariables(
@@ -454,13 +454,13 @@ def test_render_filter_step_with_variables(available_variables: dict[str, Any]) 
             "operator": "from",
         }
     )
-    rendered = step.render(available_variables, nosql_apply_parameters_to_query)
+    rendered = step.render(available_variables, nosql_apply_parameters_to_query_with_errors)
     assert rendered.condition.value.date == available_variables["TODAY"]
 
     step = FilterStepWithVariables(condition={"or": [step.model_dump()["condition"]]})
-    rendered = step.render(available_variables, nosql_apply_parameters_to_query)
+    rendered = step.render(available_variables, nosql_apply_parameters_to_query_with_errors)
     assert rendered.condition.or_[0].value.date == available_variables["TODAY"]
 
     step = FilterStepWithVariables(condition={"column": "int_column", "operator": "in", "value": "{{ INTEGER_LIST }}"})
-    rendered = step.render(available_variables, nosql_apply_parameters_to_query)
+    rendered = step.render(available_variables, nosql_apply_parameters_to_query_with_errors)
     assert rendered.condition.value == available_variables["INTEGER_LIST"] == [1, 2, 3]

--- a/server/tests/steps/test_ifthenelse.py
+++ b/server/tests/steps/test_ifthenelse.py
@@ -2,11 +2,11 @@ from typing import Any
 
 import pytest
 from pandas import NA, DataFrame
-from toucan_connectors.common import nosql_apply_parameters_to_query
 
 from tests.utils import assert_dataframes_equals
 from weaverbird.backends.pandas_executor.steps.ifthenelse import execute_ifthenelse
 from weaverbird.pipeline.steps.ifthenelse import IfthenelseStep, IfThenElseStepWithVariables
+from weaverbird.utils.toucan_connectors import nosql_apply_parameters_to_query_with_errors
 
 
 @pytest.fixture
@@ -197,7 +197,7 @@ def test_render_ifthenelsestep_step_with_variables(available_variables: dict[str
             "new_column": "coucou",
         }
     )
-    rendered = step.render(available_variables, nosql_apply_parameters_to_query)
+    rendered = step.render(available_variables, nosql_apply_parameters_to_query_with_errors)
     assert rendered.condition.value == available_variables["TODAY"]
 
     step = IfThenElseStepWithVariables(
@@ -218,5 +218,5 @@ def test_render_ifthenelsestep_step_with_variables(available_variables: dict[str
         }
     )
 
-    rendered = step.render(available_variables, nosql_apply_parameters_to_query)
+    rendered = step.render(available_variables, nosql_apply_parameters_to_query_with_errors)
     assert rendered.condition.value.date == available_variables["TODAY"]

--- a/server/tests/test_pipeline.py
+++ b/server/tests/test_pipeline.py
@@ -660,7 +660,7 @@ def test_keep_condition_if_empty_list_from_filter_steps(
     assert remove_void_conditions_from_filter_steps([step]) == expected_steps
 
 
-def test_raise_error_when_variables_are_missing():
+def test_raises_error_when_variables_are_missing():
     with pytest.raises(UndefinedVariableError):
         PipelineWithVariables(
             steps=[


### PR DESCRIPTION
When there is a pipeline with a variable and a value is not provided, we get this error:
```
E       pydantic_core._pydantic_core.ValidationError: 3 validation errors for FilterStep
E       condition.ConditionComboAnd.and
E         Field required [type=missing, input_value={'column': 'price', 'operator': 'lt'}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.10/v/missing
E       condition.ConditionComboOr.or
E         Field required [type=missing, input_value={'column': 'price', 'operator': 'lt'}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.10/v/missing
E       condition.tagged-union[ComparisonCondition,ComparisonCondition,ComparisonCondition,ComparisonCondition,ComparisonCondition,ComparisonCondition,InclusionCondition,InclusionCondition,NullCondition,NullCondition,MatchCondition,MatchCondition,DateBoundCondition,DateBoundCondition].lt.value
E         Field required [type=missing, input_value={'column': 'price', 'operator': 'lt'}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.10/v/missing
```

This PR uses an already there param in `toucan-connectors::nosql_apply_parameters_to_query` to get `UndefinedVariableError` instead.

This PR adds `nosql_apply_parameters_to_query` in `weaverbird.utils.toucan_connectors` to use this param everywhere, and a test to match.