### PR TITLE
Revert "build(deps): bump the prod-deps group across 1 directory with 4 updates (#2371)"

### DIFF
--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1469,7 +1469,7 @@ wheels = [
 
 [[package]]
 name = "psycopg"
-version = "3.2.6"
+version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -1569,7 +1569,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.6"
+version = "2.10.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -1645,7 +1645,7 @@ wheels = [
 
 [[package]]
 name = "pymongo"
-version = "4.11.3"
+version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dnspython" },
@@ -1953,7 +1953,7 @@ wheels = [
 
 [[package]]
 name = "quart-cors"
-version = "0.8.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "quart" },


### PR DESCRIPTION
Issue with dependabot : https://github.com/astral-sh/uv/issues/12254

This reverts commit 97fcf7482cbf759018335d6ea9f520fe02e87a34.