### PR TITLE
chore(release): update readme and `build` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,14 +153,6 @@ This library is published on npm under the name `weaverbird` automatically each 
 
     ex: `[0.20.0] - 2020-08-03`
 
-  - Add link to the `CHANGELOG.md` from this version to the previous one at the end of the `CHANGELOG.md`
-
-    ```
-    [X.Y.Z]: https://github.com/ToucanToco/weaverbird/compare/voldX.oldY.oldZ...vX.Y.Z
-    ```
-
-    ex: [0.20.0]: https://github.com/ToucanToco/weaverbird/compare/v0.19.2...v0.20.0
-
 - Commit changes with version number
 
   ex: `v0.20.0`

--- a/server/Makefile
+++ b/server/Makefile
@@ -45,7 +45,7 @@ build:
 
 .PHONY: upload
 upload:
-	uv publish --build
+	uv publish
 
 .PHONY: start_docker_playground
 start-docker-playground:


### PR DESCRIPTION
Remove deprecated step in release process.

Also `uv publish` does not take `--build` param:
```bash
error: unexpected argument '--build' found

  tip: to pass '--build' as a value, use '-- --build'

Usage: uv publish [OPTIONS] [FILES]...
```