### PR TITLE
fix(ui, dategranularity): `granularity` handle both enum values and variables

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Step `dategranularity` now works properly with values like `day`, `month` as well as templated variables.
+
 ## [0.117.0] - 2025-04-24
 
 ### Added

--- a/ui/src/components/stepforms/DateGranularityStepForm.vue
+++ b/ui/src/components/stepforms/DateGranularityStepForm.vue
@@ -18,6 +18,7 @@
       :selectedColumns="selectedColumns"
       @setSelectedColumns="setSelectedColumns"
     />
+    <!-- Uses `granularity` getter/setter to support both variables (string) and enum values (GranularityOption) -->
     <AutocompleteWidget
       class="dateInfoInput"
       v-model="granularity"

--- a/ui/src/components/stepforms/DateGranularityStepForm.vue
+++ b/ui/src/components/stepforms/DateGranularityStepForm.vue
@@ -20,13 +20,13 @@
     />
     <AutocompleteWidget
       class="dateInfoInput"
-      v-model="editedStep.granularity"
+      v-model="granularity"
       name="Date granularity to apply:"
       :options="granularities"
       :trackBy="`info`"
       :label="`label`"
       placeholder="Select one or several"
-      data-path=".dateInfo"
+      data-path=".granularity"
       :available-variables="availableVariables"
       :variable-delimiters="variableDelimiters"
       :trusted-variable-delimiters="trustedVariableDelimiters"
@@ -76,6 +76,7 @@ export default class DateGranularityStepForm extends BaseStepForm<DateGranularit
     default: () => ({
       name: 'dategranularity',
       column: '',
+      granularity: '',
     }),
   })
   declare initialStepValue: DateGranularityStep;
@@ -104,6 +105,15 @@ export default class DateGranularityStepForm extends BaseStepForm<DateGranularit
     } else {
       return null;
     }
+  }
+
+  get granularity(): GranularityOption {
+    const enumOption = this.granularities.filter((d) => d.info === this.editedStep.granularity)[0];
+    return enumOption ?? this.editedStep.granularity;
+  }
+
+  set granularity(input: GranularityOption | string | undefined) {
+    this.editedStep.granularity = typeof input == 'string' ? input : input?.info ?? '';
   }
 }
 </script>

--- a/ui/src/components/stepforms/schemas/dategranularity.ts
+++ b/ui/src/components/stepforms/schemas/dategranularity.ts
@@ -21,15 +21,16 @@ export default {
       minLength: 1,
       oneOf: [
         {
+          $comment: 'Listed first to display a legible validation message',
+          enum: ['year', 'quarter', 'month', 'isoWeek', 'week', 'day'],
+        },
+        {
           $comment: 'Front-end variable',
           pattern: '^<%=.+%>$',
         },
         {
           $comment: 'Back-end variable',
           pattern: '^\\{\\{.+\\}\\}$',
-        },
-        {
-          enum: ['year', 'quarter', 'month', 'isoWeek', 'week', 'day'],
         },
       ],
       title: 'Date granularity to apply',

--- a/ui/tests/unit/dategranularity-step-form.spec.ts
+++ b/ui/tests/unit/dategranularity-step-form.spec.ts
@@ -33,15 +33,15 @@ describe('DateGranularity Step Form', () => {
         },
         {
           dataPath: '.granularity',
-          keyword: 'pattern',
-        },
-        {
-          dataPath: '.granularity',
-          keyword: 'pattern',
-        },
-        {
-          dataPath: '.granularity',
           keyword: 'enum',
+        },
+        {
+          dataPath: '.granularity',
+          keyword: 'pattern',
+        },
+        {
+          dataPath: '.granularity',
+          keyword: 'pattern',
         },
         {
           dataPath: '.granularity',
@@ -68,15 +68,15 @@ describe('DateGranularity Step Form', () => {
       errors: [
         {
           dataPath: '.granularity',
-          keyword: 'pattern',
-        },
-        {
-          dataPath: '.granularity',
-          keyword: 'pattern',
-        },
-        {
-          dataPath: '.granularity',
           keyword: 'enum',
+        },
+        {
+          dataPath: '.granularity',
+          keyword: 'pattern',
+        },
+        {
+          dataPath: '.granularity',
+          keyword: 'pattern',
         },
         {
           dataPath: '.granularity',
@@ -139,7 +139,8 @@ describe('DateGranularity Step Form', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('AutocompleteWidget-stub').props('value')).toEqual('year');
+    const transferedValue = wrapper.find('AutocompleteWidget-stub').props('value');
+    expect(transferedValue?.info).toEqual('year');
   });
 
   it('should update editedStep when Autocomplete is updated', async () => {


### PR DESCRIPTION
Fixes two problems: 
- better validation message
- handle type differences between enum values and variable values